### PR TITLE
refactor: use ~MS instead of ~b

### DIFF
--- a/lib/coloured_flow/multi_set.ex
+++ b/lib/coloured_flow/multi_set.ex
@@ -462,7 +462,7 @@ defmodule ColouredFlow.MultiSet do
   end
 
   @doc """
-  Handles the sigil `~b`(short for `bag`, aka `multi_set`).
+  Handles the sigil `~MS`(that is `multi_set`).
 
   It returns a `multi_set` split by whitespace.
   Character interpolation happens for each pairs.
@@ -474,16 +474,15 @@ defmodule ColouredFlow.MultiSet do
   ## Examples
 
       iex> a = :a
-      iex> ~b[3**(1+1) 2**a 1**"a"]
+      iex> ~MS[3**(1+1) 2**a 1**"a"]
       ColouredFlow.MultiSet.from_pairs([{3, 2}, {2, :a}, {1, "a"}])
-      iex> ~b[a "a"]
+      iex> ~MS[a "a"]
       ColouredFlow.MultiSet.from_pairs([{1, :a}, {1, "a"}])
   """
   # credo:disable-for-next-line JetCredo.Checks.ExplicitAnyType
-  @spec sigil_b(term(), list(binary())) :: Macro.t()
-  defmacro sigil_b(term, modifiers)
-
-  defmacro sigil_b({:<<>>, _meta, [pairs]}, _modifiers) do
+  @spec sigil_MS(term(), list(binary())) :: Macro.t()
+  # credo:disable-for-next-line Credo.Check.Readability.FunctionNames
+  defmacro sigil_MS({:<<>>, _meta, [pairs]} = _term, _modifiers) do
     {list, is_literal?} =
       pairs
       |> String.split()
@@ -537,7 +536,7 @@ defmodule ColouredFlow.MultiSet do
 
           reraise(
             """
-            The sigils ~b only accepts pairs of the form `coefficient**value`,
+            The sigils ~MS only accepts pairs of the form `coefficient**value`,
             a literal `value`(the coefficient is 1),
             or a variable `value`(the coefficient is 1).
             """,

--- a/test/coloured_flow/enabled_binding_elements/computation_test.exs
+++ b/test/coloured_flow/enabled_binding_elements/computation_test.exs
@@ -59,17 +59,17 @@ defmodule ColouredFlow.EnabledBindingElements.ComputationTest do
                %BindingElement{
                  transition: "filter",
                  binding: [x: 1],
-                 to_consume: [%Marking{place: "integer", tokens: ~b[1]}]
+                 to_consume: [%Marking{place: "integer", tokens: ~MS[1]}]
                },
                %BindingElement{
                  transition: "filter",
                  binding: [x: 1],
-                 to_consume: [%Marking{place: "integer", tokens: ~b[1]}]
+                 to_consume: [%Marking{place: "integer", tokens: ~MS[1]}]
                },
                %BindingElement{
                  transition: "filter",
                  binding: [x: 2],
-                 to_consume: [%Marking{place: "integer", tokens: ~b[2]}]
+                 to_consume: [%Marking{place: "integer", tokens: ~MS[2]}]
                }
              ] === ebes
     end
@@ -134,32 +134,32 @@ defmodule ColouredFlow.EnabledBindingElements.ComputationTest do
                  transition: "merge",
                  binding: [],
                  to_consume: [
-                   %Marking{place: "a", tokens: ~b[2**{}]},
-                   %Marking{place: "b", tokens: ~b[{}]}
+                   %Marking{place: "a", tokens: ~MS[2**{}]},
+                   %Marking{place: "b", tokens: ~MS[{}]}
                  ]
                },
                %BindingElement{
                  transition: "merge",
                  binding: [],
                  to_consume: [
-                   %Marking{place: "a", tokens: ~b[2**{}]},
-                   %Marking{place: "b", tokens: ~b[{}]}
+                   %Marking{place: "a", tokens: ~MS[2**{}]},
+                   %Marking{place: "b", tokens: ~MS[{}]}
                  ]
                },
                %BindingElement{
                  transition: "merge",
                  binding: [],
                  to_consume: [
-                   %Marking{place: "a", tokens: ~b[2**{}]},
-                   %Marking{place: "b", tokens: ~b[{}]}
+                   %Marking{place: "a", tokens: ~MS[2**{}]},
+                   %Marking{place: "b", tokens: ~MS[{}]}
                  ]
                },
                %BindingElement{
                  transition: "merge",
                  binding: [],
                  to_consume: [
-                   %Marking{place: "a", tokens: ~b[2**{}]},
-                   %Marking{place: "b", tokens: ~b[{}]}
+                   %Marking{place: "a", tokens: ~MS[2**{}]},
+                   %Marking{place: "b", tokens: ~MS[{}]}
                  ]
                }
              ] === ebes
@@ -235,48 +235,48 @@ defmodule ColouredFlow.EnabledBindingElements.ComputationTest do
                  transition: "a + b",
                  binding: [a: 1, b: 4],
                  to_consume: [
-                   %Marking{place: "a", tokens: ~b[1]},
-                   %Marking{place: "b", tokens: ~b[4]}
+                   %Marking{place: "a", tokens: ~MS[1]},
+                   %Marking{place: "b", tokens: ~MS[4]}
                  ]
                },
                %BindingElement{
                  transition: "a + b",
                  binding: [a: 1, b: 5],
                  to_consume: [
-                   %Marking{place: "a", tokens: ~b[1]},
-                   %Marking{place: "b", tokens: ~b[5]}
+                   %Marking{place: "a", tokens: ~MS[1]},
+                   %Marking{place: "b", tokens: ~MS[5]}
                  ]
                },
                %BindingElement{
                  transition: "a + b",
                  binding: [a: 2, b: 4],
                  to_consume: [
-                   %Marking{place: "a", tokens: ~b[2]},
-                   %Marking{place: "b", tokens: ~b[4]}
+                   %Marking{place: "a", tokens: ~MS[2]},
+                   %Marking{place: "b", tokens: ~MS[4]}
                  ]
                },
                %BindingElement{
                  transition: "a + b",
                  binding: [a: 2, b: 5],
                  to_consume: [
-                   %Marking{place: "a", tokens: ~b[2]},
-                   %Marking{place: "b", tokens: ~b[5]}
+                   %Marking{place: "a", tokens: ~MS[2]},
+                   %Marking{place: "b", tokens: ~MS[5]}
                  ]
                },
                %BindingElement{
                  transition: "a + b",
                  binding: [a: 3, b: 4],
                  to_consume: [
-                   %Marking{place: "a", tokens: ~b[3]},
-                   %Marking{place: "b", tokens: ~b[4]}
+                   %Marking{place: "a", tokens: ~MS[3]},
+                   %Marking{place: "b", tokens: ~MS[4]}
                  ]
                },
                %BindingElement{
                  transition: "a + b",
                  binding: [a: 3, b: 5],
                  to_consume: [
-                   %Marking{place: "a", tokens: ~b[3]},
-                   %Marking{place: "b", tokens: ~b[5]}
+                   %Marking{place: "a", tokens: ~MS[3]},
+                   %Marking{place: "b", tokens: ~MS[5]}
                  ]
                }
              ] ===
@@ -351,48 +351,48 @@ defmodule ColouredFlow.EnabledBindingElements.ComputationTest do
                  transition: "a + b",
                  binding: [a: 0, b: -1],
                  to_consume: [
-                   %Marking{place: "a", tokens: ~b[0]},
-                   %Marking{place: "b", tokens: ~b[1**-1]}
+                   %Marking{place: "a", tokens: ~MS[0]},
+                   %Marking{place: "b", tokens: ~MS[1**-1]}
                  ]
                },
                %BindingElement{
                  transition: "a + b",
                  binding: [a: 0, b: 0],
                  to_consume: [
-                   %Marking{place: "a", tokens: ~b[0]},
-                   %Marking{place: "b", tokens: ~b[0]}
+                   %Marking{place: "a", tokens: ~MS[0]},
+                   %Marking{place: "b", tokens: ~MS[0]}
                  ]
                },
                %BindingElement{
                  transition: "a + b",
                  binding: [a: 0, b: 1],
                  to_consume: [
-                   %Marking{place: "a", tokens: ~b[0]},
-                   %Marking{place: "b", tokens: ~b[1]}
+                   %Marking{place: "a", tokens: ~MS[0]},
+                   %Marking{place: "b", tokens: ~MS[1]}
                  ]
                },
                %BindingElement{
                  transition: "a + b",
                  binding: [a: 1, b: -1],
                  to_consume: [
-                   %Marking{place: "a", tokens: ~b[0]},
-                   %Marking{place: "b", tokens: ~b[1**-1]}
+                   %Marking{place: "a", tokens: ~MS[0]},
+                   %Marking{place: "b", tokens: ~MS[1**-1]}
                  ]
                },
                %BindingElement{
                  transition: "a + b",
                  binding: [a: 1, b: 0],
                  to_consume: [
-                   %Marking{place: "a", tokens: ~b[0]},
-                   %Marking{place: "b", tokens: ~b[0]}
+                   %Marking{place: "a", tokens: ~MS[0]},
+                   %Marking{place: "b", tokens: ~MS[0]}
                  ]
                },
                %BindingElement{
                  transition: "a + b",
                  binding: [a: 1, b: 1],
                  to_consume: [
-                   %Marking{place: "a", tokens: ~b[1]},
-                   %Marking{place: "b", tokens: ~b[1]}
+                   %Marking{place: "a", tokens: ~MS[1]},
+                   %Marking{place: "b", tokens: ~MS[1]}
                  ]
                }
              ] === ebes
@@ -409,8 +409,8 @@ defmodule ColouredFlow.EnabledBindingElements.ComputationTest do
                  transition: "a + b",
                  binding: [a: 1, b: 1],
                  to_consume: [
-                   %Marking{place: "a", tokens: ~b[1]},
-                   %Marking{place: "b", tokens: ~b[1]}
+                   %Marking{place: "a", tokens: ~MS[1]},
+                   %Marking{place: "b", tokens: ~MS[1]}
                  ]
                }
              ] === ebes
@@ -477,64 +477,64 @@ defmodule ColouredFlow.EnabledBindingElements.ComputationTest do
                  transition: "merge",
                  binding: [n: 0, x: 1],
                  to_consume: [
-                   %Marking{place: "counter", tokens: ~b[0**{}]},
-                   %Marking{place: "numbers", tokens: ~b[0**1]}
+                   %Marking{place: "counter", tokens: ~MS[0**{}]},
+                   %Marking{place: "numbers", tokens: ~MS[0**1]}
                  ]
                },
                %BindingElement{
                  transition: "merge",
                  binding: [n: 0, x: 2],
                  to_consume: [
-                   %Marking{place: "counter", tokens: ~b[0**{}]},
-                   %Marking{place: "numbers", tokens: ~b[0**2]}
+                   %Marking{place: "counter", tokens: ~MS[0**{}]},
+                   %Marking{place: "numbers", tokens: ~MS[0**2]}
                  ]
                },
                %BindingElement{
                  transition: "merge",
                  binding: [n: 0, x: 3],
                  to_consume: [
-                   %Marking{place: "counter", tokens: ~b[0**{}]},
-                   %Marking{place: "numbers", tokens: ~b[0**3]}
+                   %Marking{place: "counter", tokens: ~MS[0**{}]},
+                   %Marking{place: "numbers", tokens: ~MS[0**3]}
                  ]
                },
                %BindingElement{
                  transition: "merge",
                  binding: [n: 1, x: 1],
                  to_consume: [
-                   %Marking{place: "counter", tokens: ~b[{}]},
-                   %Marking{place: "numbers", tokens: ~b[1]}
+                   %Marking{place: "counter", tokens: ~MS[{}]},
+                   %Marking{place: "numbers", tokens: ~MS[1]}
                  ]
                },
                %BindingElement{
                  transition: "merge",
                  binding: [n: 1, x: 2],
                  to_consume: [
-                   %Marking{place: "counter", tokens: ~b[{}]},
-                   %Marking{place: "numbers", tokens: ~b[2]}
+                   %Marking{place: "counter", tokens: ~MS[{}]},
+                   %Marking{place: "numbers", tokens: ~MS[2]}
                  ]
                },
                %BindingElement{
                  transition: "merge",
                  binding: [n: 1, x: 3],
                  to_consume: [
-                   %Marking{place: "counter", tokens: ~b[{}]},
-                   %Marking{place: "numbers", tokens: ~b[3]}
+                   %Marking{place: "counter", tokens: ~MS[{}]},
+                   %Marking{place: "numbers", tokens: ~MS[3]}
                  ]
                },
                %BindingElement{
                  transition: "merge",
                  binding: [n: 2, x: 1],
                  to_consume: [
-                   %Marking{place: "counter", tokens: ~b[2**{}]},
-                   %Marking{place: "numbers", tokens: ~b[2**1]}
+                   %Marking{place: "counter", tokens: ~MS[2**{}]},
+                   %Marking{place: "numbers", tokens: ~MS[2**1]}
                  ]
                },
                %BindingElement{
                  transition: "merge",
                  binding: [n: 2, x: 2],
                  to_consume: [
-                   %Marking{place: "counter", tokens: ~b[2**{}]},
-                   %Marking{place: "numbers", tokens: ~b[2**2]}
+                   %Marking{place: "counter", tokens: ~MS[2**{}]},
+                   %Marking{place: "numbers", tokens: ~MS[2**2]}
                  ]
                }
              ] === ebes
@@ -588,21 +588,21 @@ defmodule ColouredFlow.EnabledBindingElements.ComputationTest do
                  transition: "filter",
                  binding: [x: 1],
                  to_consume: [
-                   %Marking{place: "integer", tokens: ~b[1]}
+                   %Marking{place: "integer", tokens: ~MS[1]}
                  ]
                },
                %BindingElement{
                  transition: "filter",
                  binding: [x: 1],
                  to_consume: [
-                   %Marking{place: "integer", tokens: ~b[1]}
+                   %Marking{place: "integer", tokens: ~MS[1]}
                  ]
                },
                %BindingElement{
                  transition: "filter",
                  binding: [x: 2],
                  to_consume: [
-                   %Marking{place: "integer", tokens: ~b[2]}
+                   %Marking{place: "integer", tokens: ~MS[2]}
                  ]
                }
              ] === ebes
@@ -655,7 +655,7 @@ defmodule ColouredFlow.EnabledBindingElements.ComputationTest do
                %BindingElement{
                  transition: "filter",
                  binding: [x: 1],
-                 to_consume: [%Marking{place: "integer", tokens: ~b[2**1]}]
+                 to_consume: [%Marking{place: "integer", tokens: ~MS[2**1]}]
                }
              ] === ebes
     end
@@ -720,40 +720,40 @@ defmodule ColouredFlow.EnabledBindingElements.ComputationTest do
                  transition: "merge",
                  binding: [c: 2, x: 0],
                  to_consume: [
-                   %Marking{place: "counter", tokens: ~b[2]},
-                   %Marking{place: "numbers", tokens: ~b[0**2]}
+                   %Marking{place: "counter", tokens: ~MS[2]},
+                   %Marking{place: "numbers", tokens: ~MS[0**2]}
                  ]
                },
                %BindingElement{
                  transition: "merge",
                  binding: [c: 2, x: 1],
                  to_consume: [
-                   %Marking{place: "counter", tokens: ~b[2]},
-                   %Marking{place: "numbers", tokens: ~b[1**2]}
+                   %Marking{place: "counter", tokens: ~MS[2]},
+                   %Marking{place: "numbers", tokens: ~MS[1**2]}
                  ]
                },
                %BindingElement{
                  transition: "merge",
                  binding: [c: 2, x: 2],
                  to_consume: [
-                   %Marking{place: "counter", tokens: ~b[2]},
-                   %Marking{place: "numbers", tokens: ~b[2**2]}
+                   %Marking{place: "counter", tokens: ~MS[2]},
+                   %Marking{place: "numbers", tokens: ~MS[2**2]}
                  ]
                },
                %BindingElement{
                  transition: "merge",
                  binding: [c: 3, x: 0],
                  to_consume: [
-                   %Marking{place: "counter", tokens: ~b[3]},
-                   %Marking{place: "numbers", tokens: ~b[0**3]}
+                   %Marking{place: "counter", tokens: ~MS[3]},
+                   %Marking{place: "numbers", tokens: ~MS[0**3]}
                  ]
                },
                %BindingElement{
                  transition: "merge",
                  binding: [c: 3, x: 1],
                  to_consume: [
-                   %Marking{place: "counter", tokens: ~b[3]},
-                   %Marking{place: "numbers", tokens: ~b[1**3]}
+                   %Marking{place: "counter", tokens: ~MS[3]},
+                   %Marking{place: "numbers", tokens: ~MS[1**3]}
                  ]
                }
              ] === ebes
@@ -813,7 +813,7 @@ defmodule ColouredFlow.EnabledBindingElements.ComputationTest do
                %BindingElement{
                  transition: "filter",
                  binding: [x: 2],
-                 to_consume: [%Marking{place: "integer", tokens: ~b[2]}]
+                 to_consume: [%Marking{place: "integer", tokens: ~MS[2]}]
                }
              ] === ebes
     end

--- a/test/coloured_flow/enabled_binding_elements/occurrence_test.exs
+++ b/test/coloured_flow/enabled_binding_elements/occurrence_test.exs
@@ -52,7 +52,7 @@ defmodule ColouredFlow.EnabledBindingElements.OccurrenceTest do
       binding_element = %BindingElement{
         transition: "filter",
         binding: [x: 2],
-        to_consume: [%Marking{place: "integer", tokens: ~b[2]}]
+        to_consume: [%Marking{place: "integer", tokens: ~MS[2]}]
       }
 
       free_binding = []
@@ -60,7 +60,7 @@ defmodule ColouredFlow.EnabledBindingElements.OccurrenceTest do
       {:ok, occurrence} = Occurrence.occur(binding_element, free_binding, cpnet)
 
       assert [] === occurrence.free_binding
-      assert [%Marking{place: "even", tokens: ~b[1**2]}] === occurrence.to_produce
+      assert [%Marking{place: "even", tokens: ~MS[1**2]}] === occurrence.to_produce
     end
 
     test "the literal arc expression" do
@@ -113,8 +113,8 @@ defmodule ColouredFlow.EnabledBindingElements.OccurrenceTest do
           transition: "merge",
           binding: [],
           to_consume: [
-            %Marking{place: "a", tokens: ~b[2**{}]},
-            %Marking{place: "b", tokens: ~b[{}]}
+            %Marking{place: "a", tokens: ~MS[2**{}]},
+            %Marking{place: "b", tokens: ~MS[{}]}
           ]
         }
 
@@ -123,7 +123,7 @@ defmodule ColouredFlow.EnabledBindingElements.OccurrenceTest do
       {:ok, occurrence} = Occurrence.occur(binding_element, free_binding, cpnet)
 
       assert [] === occurrence.free_binding
-      assert [%Marking{place: "unit", tokens: ~b[1**{}]}] === occurrence.to_produce
+      assert [%Marking{place: "unit", tokens: ~MS[1**{}]}] === occurrence.to_produce
     end
 
     test "works with multiple output places" do
@@ -178,7 +178,7 @@ defmodule ColouredFlow.EnabledBindingElements.OccurrenceTest do
           transition: transition.name,
           binding: [x: 1],
           to_consume: [
-            %Marking{place: "number", tokens: ~b[1]}
+            %Marking{place: "number", tokens: ~MS[1]}
           ]
         }
 
@@ -189,8 +189,8 @@ defmodule ColouredFlow.EnabledBindingElements.OccurrenceTest do
       assert [] === occurrence.free_binding
 
       assert [
-               %Marking{place: "one", tokens: ~b[1]},
-               %Marking{place: "another", tokens: ~b[1]}
+               %Marking{place: "one", tokens: ~MS[1]},
+               %Marking{place: "another", tokens: ~MS[1]}
              ] ===
                occurrence.to_produce
     end
@@ -271,8 +271,8 @@ defmodule ColouredFlow.EnabledBindingElements.OccurrenceTest do
           transition: transition.name,
           binding: [dividend: 5, divisor: 2],
           to_consume: [
-            %Marking{place: "dividend", tokens: ~b[5]},
-            %Marking{place: "divisor", tokens: ~b[2]}
+            %Marking{place: "dividend", tokens: ~MS[5]},
+            %Marking{place: "divisor", tokens: ~MS[2]}
           ]
         }
 
@@ -283,8 +283,8 @@ defmodule ColouredFlow.EnabledBindingElements.OccurrenceTest do
       assert [modulo: 1, quotient: 2] === sort_binding(occurrence.free_binding)
 
       assert [
-               %Marking{place: "modulo", tokens: ~b[1]},
-               %Marking{place: "quotient", tokens: ~b[2]}
+               %Marking{place: "modulo", tokens: ~MS[1]},
+               %Marking{place: "quotient", tokens: ~MS[2]}
              ] === sort_markings(occurrence.to_produce)
     end
 
@@ -333,7 +333,7 @@ defmodule ColouredFlow.EnabledBindingElements.OccurrenceTest do
       binding_element = %BindingElement{
         transition: "filter",
         binding: [x: 2],
-        to_consume: [%Marking{place: "integer", tokens: ~b[2]}]
+        to_consume: [%Marking{place: "integer", tokens: ~MS[2]}]
       }
 
       free_binding = []
@@ -385,7 +385,7 @@ defmodule ColouredFlow.EnabledBindingElements.OccurrenceTest do
       binding_element = %BindingElement{
         transition: "filter",
         binding: [x: 2],
-        to_consume: [%Marking{place: "integer", tokens: ~b[2]}]
+        to_consume: [%Marking{place: "integer", tokens: ~MS[2]}]
       }
 
       free_binding = []

--- a/test/coloured_flow/enactment/binding_element_test.exs
+++ b/test/coloured_flow/enactment/binding_element_test.exs
@@ -15,8 +15,8 @@ defmodule ColouredFlow.Enactment.BindingElementTest do
           transition,
           [x: 1, y: 2, z: 3],
           [
-            %Marking{place: "input", tokens: ~b[3**1]},
-            %Marking{place: "output", tokens: ~b[2**2]}
+            %Marking{place: "input", tokens: ~MS[3**1]},
+            %Marking{place: "output", tokens: ~MS[2**2]}
           ]
         )
 
@@ -25,8 +25,8 @@ defmodule ColouredFlow.Enactment.BindingElementTest do
           transition,
           [y: 2, x: 1, z: 3],
           [
-            %Marking{place: "output", tokens: ~b[2**2]},
-            %Marking{place: "input", tokens: ~b[3**1]}
+            %Marking{place: "output", tokens: ~MS[2**2]},
+            %Marking{place: "input", tokens: ~MS[3**1]}
           ]
         )
 

--- a/test/coloured_flow/multi_set_test.exs
+++ b/test/coloured_flow/multi_set_test.exs
@@ -53,21 +53,22 @@ defmodule ColouredFlow.MultiSetTest do
     test "works" do
       a = :a
 
-      assert MultiSet.from_pairs([{3, 2}, {2, :a}, {1, "a"}]) === ~b[3**(1+1) 2**a 1**"a"]
-      assert MultiSet.from_pairs([{1, :a}, {1, "a"}]) === ~b(a "a")
-      assert MultiSet.from_pairs([]) === ~b()
+      assert MultiSet.from_pairs([{3, 2}, {2, :a}, {1, "a"}]) === ~MS[3**(1+1) 2**a 1**"a"]
+      assert MultiSet.from_pairs([{1, :a}, {1, "a"}]) === ~MS(a "a")
+      assert MultiSet.from_pairs([]) === ~MS()
 
-      assert_raise RuntimeError, ~r/The sigils ~b only accepts pairs/, fn ->
-        Code.eval_quoted(quote(do: ~b[URI.parse("/")]))
+      assert_raise RuntimeError, ~r/The sigils ~MS only accepts pairs/, fn ->
+        Code.eval_quoted(quote(do: ~MS[URI.parse("/")]))
       end
     end
 
     test "works with tuple" do
-      assert MultiSet.from_pairs([{2, {}}]) === ~b(2**{})
-      assert MultiSet.from_pairs([{1, {}}]) === ~b({})
+      assert MultiSet.from_pairs([{2, {}}]) === ~MS(2**{})
+      assert MultiSet.from_pairs([{1, {}}]) === ~MS({})
 
-      assert MultiSet.from_pairs([{1, {:{}, [], []}}]) === ~b({:{},[],[]})
-      assert MultiSet.from_pairs([{2, {:{}, [], []}}]) === ~b(2**{:{},[],[]})
+      item = {:{}, [], []}
+      assert MultiSet.from_pairs([{1, {:{}, [], []}}]) === ~MS(item)
+      assert MultiSet.from_pairs([{2, {:{}, [], []}}]) === ~MS(2**item)
     end
   end
 end

--- a/test/coloured_flow/runner/enactment/catchuping_test.exs
+++ b/test/coloured_flow/runner/enactment/catchuping_test.exs
@@ -18,7 +18,7 @@ defmodule ColouredFlow.Runner.Enactment.CatchupingTest do
 
     test "works with consumed and produced tokens" do
       current_markings = [
-        %Marking{place: "a", tokens: ~b[3**:a 4**:b]}
+        %Marking{place: "a", tokens: ~MS[3**:a 4**:b]}
       ]
 
       occurrence1 = %Occurrence{
@@ -26,18 +26,18 @@ defmodule ColouredFlow.Runner.Enactment.CatchupingTest do
           transition: "t",
           binding: [x: "a"],
           to_consume: [
-            %Marking{place: "a", tokens: ~b[2**:a]}
+            %Marking{place: "a", tokens: ~MS[2**:a]}
           ]
         },
         free_binding: [],
-        to_produce: [%Marking{place: "b", tokens: ~b[2**:b 1**:c]}]
+        to_produce: [%Marking{place: "b", tokens: ~MS[2**:b 1**:c]}]
       }
 
       assert {
                1,
                [
-                 %Marking{place: "a", tokens: ~b[1**:a 4**:b]},
-                 %Marking{place: "b", tokens: ~b[2**:b 1**:c]}
+                 %Marking{place: "a", tokens: ~MS[1**:a 4**:b]},
+                 %Marking{place: "b", tokens: ~MS[2**:b 1**:c]}
                ]
              } ===
                order(Catchuping.apply(current_markings, [occurrence1]))
@@ -47,17 +47,17 @@ defmodule ColouredFlow.Runner.Enactment.CatchupingTest do
           transition: "t",
           binding: [x: "a"],
           to_consume: [
-            %Marking{place: "a", tokens: ~b[1**:a 4**:b]},
-            %Marking{place: "b", tokens: ~b[2**:b 1**:c]}
+            %Marking{place: "a", tokens: ~MS[1**:a 4**:b]},
+            %Marking{place: "b", tokens: ~MS[2**:b 1**:c]}
           ]
         },
         free_binding: [],
-        to_produce: [%Marking{place: "c", tokens: ~b[1**:c]}]
+        to_produce: [%Marking{place: "c", tokens: ~MS[1**:c]}]
       }
 
       assert {
                2,
-               [%Marking{place: "c", tokens: ~b[1**:c]}]
+               [%Marking{place: "c", tokens: ~MS[1**:c]}]
              } ===
                order(Catchuping.apply(current_markings, [occurrence1, occurrence2]))
     end

--- a/test/coloured_flow/runner/enactment/enactment_test.exs
+++ b/test/coloured_flow/runner/enactment/enactment_test.exs
@@ -8,7 +8,7 @@ defmodule ColouredFlow.Runner.EnactmentTest do
   import Ecto.Query
 
   @moduletag cpnet: :simple_sequence
-  @moduletag initial_markings: [%Marking{place: "input", tokens: ~b[2**1]}]
+  @moduletag initial_markings: [%Marking{place: "input", tokens: ~MS[2**1]}]
 
   setup :setup_flow
   setup :setup_enactment
@@ -28,7 +28,7 @@ defmodule ColouredFlow.Runner.EnactmentTest do
                version: 0
              } = get_enactment_state(enactment_server)
 
-      assert [%Marking{place: "input", tokens: ~b[2**1]}] ===
+      assert [%Marking{place: "input", tokens: ~MS[2**1]}] ===
                get_enactment_markings(enactment_server)
 
       assert match?(
@@ -39,7 +39,7 @@ defmodule ColouredFlow.Runner.EnactmentTest do
                    binding_element: %BindingElement{
                      transition: "pass_through",
                      binding: [x: 1],
-                     to_consume: [%Marking{place: "input", tokens: ~b[1]}]
+                     to_consume: [%Marking{place: "input", tokens: ~MS[1]}]
                    }
                  },
                  %Enactment.Workitem{
@@ -48,7 +48,7 @@ defmodule ColouredFlow.Runner.EnactmentTest do
                    binding_element: %BindingElement{
                      transition: "pass_through",
                      binding: [x: 1],
-                     to_consume: [%Marking{place: "input", tokens: ~b[1]}]
+                     to_consume: [%Marking{place: "input", tokens: ~MS[1]}]
                    }
                  }
                ]
@@ -66,8 +66,8 @@ defmodule ColouredFlow.Runner.EnactmentTest do
 
     test "with snapshot", %{enactment: enactment} do
       markings = [
-        %Marking{place: "input", tokens: ~b[1]},
-        %Marking{place: "output", tokens: ~b[1]}
+        %Marking{place: "input", tokens: ~MS[1]},
+        %Marking{place: "output", tokens: ~MS[1]}
       ]
 
       :snapshot
@@ -78,8 +78,8 @@ defmodule ColouredFlow.Runner.EnactmentTest do
       [enactment_server: enactment_server] = start_enactment(%{enactment: enactment})
 
       assert [
-               %Marking{place: "input", tokens: ~b[1]},
-               %Marking{place: "output", tokens: ~b[1]}
+               %Marking{place: "input", tokens: ~MS[1]},
+               %Marking{place: "output", tokens: ~MS[1]}
              ] === get_enactment_markings(enactment_server)
 
       assert [
@@ -90,7 +90,7 @@ defmodule ColouredFlow.Runner.EnactmentTest do
                    transition: "pass_through",
                    binding: [x: 1],
                    to_consume: [
-                     %Marking{place: "input", tokens: ~b[1]}
+                     %Marking{place: "input", tokens: ~MS[1]}
                    ]
                  }
                }
@@ -108,18 +108,18 @@ defmodule ColouredFlow.Runner.EnactmentTest do
           BindingElement.new(
             "pass_through",
             [x: 1],
-            [%Marking{place: "input", tokens: ~b[1]}]
+            [%Marking{place: "input", tokens: ~MS[1]}]
           ),
         free_binding: [],
-        to_produce: [%Marking{place: "output", tokens: ~b[1]}]
+        to_produce: [%Marking{place: "output", tokens: ~MS[1]}]
       })
       |> insert()
 
       [enactment_server: enactment_server] = start_enactment(%{enactment: enactment})
 
       assert [
-               %Marking{place: "input", tokens: ~b[1]},
-               %Marking{place: "output", tokens: ~b[1]}
+               %Marking{place: "input", tokens: ~MS[1]},
+               %Marking{place: "output", tokens: ~MS[1]}
              ] === get_enactment_markings(enactment_server)
 
       assert [
@@ -129,7 +129,7 @@ defmodule ColouredFlow.Runner.EnactmentTest do
                  binding_element: %BindingElement{
                    transition: "pass_through",
                    binding: [x: 1],
-                   to_consume: [%Marking{place: "input", tokens: ~b[1]}]
+                   to_consume: [%Marking{place: "input", tokens: ~MS[1]}]
                  }
                }
              ] = get_enactment_workitems(enactment_server)
@@ -150,7 +150,7 @@ defmodule ColouredFlow.Runner.EnactmentTest do
             "pass_through",
             [x: 2],
             # there isn't a token `2` in the input place
-            [%Marking{place: "input", tokens: ~b[2]}]
+            [%Marking{place: "input", tokens: ~MS[2]}]
           )
         )
         |> insert()
@@ -162,7 +162,7 @@ defmodule ColouredFlow.Runner.EnactmentTest do
           BindingElement.new(
             "pass_through",
             [x: 1],
-            [%Marking{place: "input", tokens: ~b[1]}]
+            [%Marking{place: "input", tokens: ~MS[1]}]
           )
         )
         |> insert()
@@ -175,7 +175,7 @@ defmodule ColouredFlow.Runner.EnactmentTest do
             "pass_through",
             [x: 2],
             # there isn't a token `2` in the input place
-            [%Marking{place: "input", tokens: ~b[2]}]
+            [%Marking{place: "input", tokens: ~MS[2]}]
           )
         )
         |> insert()
@@ -187,7 +187,7 @@ defmodule ColouredFlow.Runner.EnactmentTest do
           BindingElement.new(
             "pass_through",
             [x: 1],
-            [%Marking{place: "input", tokens: ~b[1]}]
+            [%Marking{place: "input", tokens: ~MS[1]}]
           )
         )
         |> insert()
@@ -199,7 +199,7 @@ defmodule ColouredFlow.Runner.EnactmentTest do
           BindingElement.new(
             "pass_through",
             [x: 1],
-            [%Marking{place: "input", tokens: ~b[1]}]
+            [%Marking{place: "input", tokens: ~MS[1]}]
           )
         )
         |> insert()
@@ -213,7 +213,7 @@ defmodule ColouredFlow.Runner.EnactmentTest do
       assert %Enactment{
                enactment_id: ^enactment_id,
                version: 0,
-               markings: %{"input" => %Marking{place: "input", tokens: ~b[2**1]}}
+               markings: %{"input" => %Marking{place: "input", tokens: ~MS[2**1]}}
              } = get_enactment_state(enactment_server)
 
       # withdrawn for the binding_element is not satisfied
@@ -233,7 +233,7 @@ defmodule ColouredFlow.Runner.EnactmentTest do
                  binding_element: %BindingElement{
                    transition: "pass_through",
                    binding: [x: 1],
-                   to_consume: [%Marking{place: "input", tokens: ~b[1]}]
+                   to_consume: [%Marking{place: "input", tokens: ~MS[1]}]
                  }
                },
                %Enactment.Workitem{
@@ -242,7 +242,7 @@ defmodule ColouredFlow.Runner.EnactmentTest do
                  binding_element: %BindingElement{
                    transition: "pass_through",
                    binding: [x: 1],
-                   to_consume: [%Marking{place: "input", tokens: ~b[1]}]
+                   to_consume: [%Marking{place: "input", tokens: ~MS[1]}]
                  }
                }
              ] = get_enactment_workitems(enactment_server)

--- a/test/coloured_flow/runner/enactment/transitions/allocate_test.exs
+++ b/test/coloured_flow/runner/enactment/transitions/allocate_test.exs
@@ -6,7 +6,7 @@ defmodule ColouredFlow.Runner.Enactment.Transitions.AllocateTest do
 
   describe "returns the allocated workitem" do
     @describetag cpnet: :simple_sequence
-    @describetag initial_markings: [%Marking{place: "input", tokens: ~b[1]}]
+    @describetag initial_markings: [%Marking{place: "input", tokens: ~MS[1]}]
 
     setup :setup_flow
     setup :setup_enactment
@@ -59,7 +59,7 @@ defmodule ColouredFlow.Runner.Enactment.Transitions.AllocateTest do
     end
 
     @tag cpnet: :deferred_choice
-    @tag initial_markings: [%Marking{place: "place", tokens: ~b[1]}]
+    @tag initial_markings: [%Marking{place: "place", tokens: ~MS[1]}]
     test "returns UnsufficientTokensToConsume exception", %{
       enactment_server: enactment_server,
       enactment: enactment
@@ -75,11 +75,11 @@ defmodule ColouredFlow.Runner.Enactment.Transitions.AllocateTest do
       assert %Exceptions.UnsufficientTokensToConsume{
                enactment_id: enactment.id,
                place: "place",
-               tokens: ~b[1]
+               tokens: ~MS[1]
              } === exception
     end
 
-    @tag initial_markings: [%Marking{place: "input", tokens: ~b[2**1]}]
+    @tag initial_markings: [%Marking{place: "input", tokens: ~MS[2**1]}]
     test "allocates multiple workitems", %{enactment_server: enactment_server} do
       [workitem_1, workitem_2] = get_enactment_workitems(enactment_server)
 
@@ -100,7 +100,7 @@ defmodule ColouredFlow.Runner.Enactment.Transitions.AllocateTest do
     setup :start_enactment
 
     @tag cpnet: :deferred_choice
-    @tag initial_markings: [%Marking{place: "place", tokens: ~b[1]}]
+    @tag initial_markings: [%Marking{place: "place", tokens: ~MS[1]}]
     test "works", %{enactment_server: enactment_server} do
       state = get_enactment_state(enactment_server)
 

--- a/test/coloured_flow/runner/enactment/transitions/complete_test.exs
+++ b/test/coloured_flow/runner/enactment/transitions/complete_test.exs
@@ -13,7 +13,7 @@ defmodule ColouredFlow.Runner.Enactment.Transitions.CompleteTest do
     setup :start_enactment
 
     @describetag cpnet: :simple_sequence
-    @describetag initial_markings: [%Marking{place: "input", tokens: ~b[3**1]}]
+    @describetag initial_markings: [%Marking{place: "input", tokens: ~MS[3**1]}]
 
     setup %{enactment_server: enactment_server} do
       [
@@ -76,10 +76,10 @@ defmodule ColouredFlow.Runner.Enactment.Transitions.CompleteTest do
                  binding_element: %BindingElement{
                    transition: "pass_through",
                    binding: [x: 1],
-                   to_consume: [%Marking{place: "input", tokens: ~b[1]}]
+                   to_consume: [%Marking{place: "input", tokens: ~MS[1]}]
                  },
                  free_binding: [],
-                 to_produce: [%Marking{place: "output", tokens: ~b[1]}]
+                 to_produce: [%Marking{place: "output", tokens: ~MS[1]}]
                }
              ] ===
                Schemas.Occurrence
@@ -129,8 +129,8 @@ defmodule ColouredFlow.Runner.Enactment.Transitions.CompleteTest do
 
     @tag cpnet: :deferred_choice
     @tag initial_markings: [
-           %Marking{place: "input", tokens: ~b[1]},
-           %Marking{place: "place", tokens: ~b[1]}
+           %Marking{place: "input", tokens: ~MS[1]},
+           %Marking{place: "place", tokens: ~MS[1]}
          ]
     test "works", %{enactment_server: enactment_server} do
       [
@@ -178,7 +178,7 @@ defmodule ColouredFlow.Runner.Enactment.Transitions.CompleteTest do
 
     @tag cpnet: :simple_sequence
     @tag out_arc_expression: ~S[{2, x}]
-    @tag initial_markings: [%Marking{place: "input", tokens: ~b[1]}]
+    @tag initial_markings: [%Marking{place: "input", tokens: ~MS[1]}]
     test "consumes and produces tokens", %{enactment_server: enactment_server} do
       previous_markings = get_enactment_markings(enactment_server)
 
@@ -192,8 +192,8 @@ defmodule ColouredFlow.Runner.Enactment.Transitions.CompleteTest do
 
       markings = get_enactment_markings(enactment_server)
 
-      assert [%Marking{place: "input", tokens: ~b[1]}] === previous_markings
-      assert [%Marking{place: "output", tokens: ~b[2**1]}] === markings
+      assert [%Marking{place: "input", tokens: ~MS[1]}] === previous_markings
+      assert [%Marking{place: "output", tokens: ~MS[2**1]}] === markings
     end
   end
 
@@ -207,7 +207,7 @@ defmodule ColouredFlow.Runner.Enactment.Transitions.CompleteTest do
     @describetag cpnet: :simple_sequence
 
     @tag out_arc_expression: ~S[raise ArgumentError, "Bad out arc"]
-    @tag initial_markings: [%Marking{place: "input", tokens: ~b[1]}]
+    @tag initial_markings: [%Marking{place: "input", tokens: ~MS[1]}]
     test "returns user raised exception", %{enactment_server: enactment_server} do
       [workitem] = get_enactment_workitems(enactment_server)
       workitem = start_workitem(workitem, enactment_server)
@@ -219,7 +219,7 @@ defmodule ColouredFlow.Runner.Enactment.Transitions.CompleteTest do
     end
 
     @tag out_arc_expression: ~S[{1, a + b}]
-    @tag initial_markings: [%Marking{place: "input", tokens: ~b[1]}]
+    @tag initial_markings: [%Marking{place: "input", tokens: ~MS[1]}]
     test "returns EvalDiagnostic", %{enactment_server: enactment_server} do
       [workitem] = get_enactment_workitems(enactment_server)
       workitem = start_workitem(workitem, enactment_server)
@@ -233,7 +233,7 @@ defmodule ColouredFlow.Runner.Enactment.Transitions.CompleteTest do
     end
 
     @tag out_arc_expression: ~S[{x, "hello"}]
-    @tag initial_markings: [%Marking{place: "input", tokens: ~b[1]}]
+    @tag initial_markings: [%Marking{place: "input", tokens: ~MS[1]}]
     test "returns ColourSetMismatch", %{enactment_server: enactment_server} do
       [workitem] = get_enactment_workitems(enactment_server)
       workitem = start_workitem(workitem, enactment_server)
@@ -302,7 +302,7 @@ defmodule ColouredFlow.Runner.Enactment.Transitions.CompleteTest do
     setup :setup_enactment
     setup :start_enactment
 
-    @tag initial_markings: [%Marking{place: "input", tokens: ~b[1]}]
+    @tag initial_markings: [%Marking{place: "input", tokens: ~MS[1]}]
     test "works", %{enactment_server: enactment_server} do
       [workitem] = get_enactment_workitems(enactment_server)
       workitem = start_workitem(workitem, enactment_server)
@@ -318,21 +318,21 @@ defmodule ColouredFlow.Runner.Enactment.Transitions.CompleteTest do
                  binding_element: %BindingElement{
                    transition: "pass_through",
                    binding: [x: 1],
-                   to_consume: [%Marking{place: "input", tokens: ~b[1]}]
+                   to_consume: [%Marking{place: "input", tokens: ~MS[1]}]
                  },
                  free_binding: [y: 2],
-                 to_produce: [%Marking{place: "output", tokens: ~b[2**1]}]
+                 to_produce: [%Marking{place: "output", tokens: ~MS[2**1]}]
                }
              ] ===
                Schemas.Occurrence
                |> Repo.all()
                |> Enum.map(&Schemas.Occurrence.to_occurrence/1)
 
-      assert [%Marking{place: "output", tokens: ~b[2**1]}] ===
+      assert [%Marking{place: "output", tokens: ~MS[2**1]}] ===
                get_enactment_markings(enactment_server)
     end
 
-    @tag initial_markings: [%Marking{place: "input", tokens: ~b[1]}]
+    @tag initial_markings: [%Marking{place: "input", tokens: ~MS[1]}]
     test "returns UnboundActionOutput", %{enactment_server: enactment_server} do
       [workitem] = get_enactment_workitems(enactment_server)
       workitem = start_workitem(workitem, enactment_server)
@@ -347,7 +347,7 @@ defmodule ColouredFlow.Runner.Enactment.Transitions.CompleteTest do
              } = exception
     end
 
-    @tag initial_markings: [%Marking{place: "input", tokens: ~b[1]}]
+    @tag initial_markings: [%Marking{place: "input", tokens: ~MS[1]}]
     test "returns ColourSetMismatch", %{enactment_server: enactment_server} do
       alias ColouredFlow.Definition.ColourSet
 
@@ -383,8 +383,8 @@ defmodule ColouredFlow.Runner.Enactment.Transitions.CompleteTest do
     setup :start_enactment
 
     @tag initial_markings: [
-           %Marking{place: "input", tokens: ~b[1]},
-           %Marking{place: "place", tokens: ~b[1]}
+           %Marking{place: "input", tokens: ~MS[1]},
+           %Marking{place: "place", tokens: ~MS[1]}
          ]
     test "produces new workitems", %{enactment_server: enactment_server} do
       [
@@ -424,8 +424,8 @@ defmodule ColouredFlow.Runner.Enactment.Transitions.CompleteTest do
     end
 
     @tag initial_markings: [
-           %Marking{place: "input", tokens: ~b[1]},
-           %Marking{place: "place", tokens: ~b[1]}
+           %Marking{place: "input", tokens: ~MS[1]},
+           %Marking{place: "place", tokens: ~MS[1]}
          ]
     test "produces new workitems when there is non-enabled workitems", %{
       enactment_server: enactment_server

--- a/test/coloured_flow/runner/enactment/transitions/start_test.exs
+++ b/test/coloured_flow/runner/enactment/transitions/start_test.exs
@@ -6,7 +6,7 @@ defmodule ColouredFlow.Runner.Enactment.Transitions.StartTest do
 
   describe "start workitems" do
     @describetag cpnet: :simple_sequence
-    @describetag initial_markings: [%Marking{place: "input", tokens: ~b[1]}]
+    @describetag initial_markings: [%Marking{place: "input", tokens: ~MS[1]}]
 
     setup :setup_flow
     setup :setup_enactment

--- a/test/coloured_flow/runner/enactment/workitem_calibration_test.exs
+++ b/test/coloured_flow/runner/enactment/workitem_calibration_test.exs
@@ -21,7 +21,7 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
 
       assert state === calibration.state
       assert [] === calibration.to_withdraw
-      assert ~b[] === calibration.to_produce
+      assert ~MS[] === calibration.to_produce
     end
 
     test "produces binding_elements" do
@@ -29,7 +29,7 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
 
       state = %Enactment{
         enactment_id: Ecto.UUID.generate(),
-        markings: to_map([%Marking{place: "input", tokens: ~b[2**1]}])
+        markings: to_map([%Marking{place: "input", tokens: ~MS[2**1]}])
       }
 
       calibration = WorkitemCalibration.initial_calibrate(state, cpnet)
@@ -40,10 +40,10 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
       binding_elemnt = %BindingElement{
         transition: "pass_through",
         binding: [x: 1],
-        to_consume: [%Marking{place: "input", tokens: ~b[1]}]
+        to_consume: [%Marking{place: "input", tokens: ~MS[1]}]
       }
 
-      assert ~b[2**binding_elemnt] === calibration.to_produce
+      assert ~MS[2**binding_elemnt] === calibration.to_produce
     end
 
     test "produces missing binding_elements" do
@@ -51,7 +51,7 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
 
       state = %Enactment{
         enactment_id: Ecto.UUID.generate(),
-        markings: to_map([%Marking{place: "input", tokens: ~b[2**1]}]),
+        markings: to_map([%Marking{place: "input", tokens: ~MS[2**1]}]),
         workitems:
           to_map([
             %Enactment.Workitem{
@@ -60,7 +60,7 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
               binding_element: %BindingElement{
                 transition: "pass_through",
                 binding: [x: 1],
-                to_consume: [%Marking{place: "input", tokens: ~b[1]}]
+                to_consume: [%Marking{place: "input", tokens: ~MS[1]}]
               }
             }
           ])
@@ -74,10 +74,10 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
       binding_elemnt = %BindingElement{
         transition: "pass_through",
         binding: [x: 1],
-        to_consume: [%Marking{place: "input", tokens: ~b[1]}]
+        to_consume: [%Marking{place: "input", tokens: ~MS[1]}]
       }
 
-      assert ~b[binding_elemnt] === calibration.to_produce
+      assert ~MS[binding_elemnt] === calibration.to_produce
     end
 
     test "withdraws some workitems" do
@@ -89,13 +89,13 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
         binding_element: %BindingElement{
           transition: "pass_through",
           binding: [x: 1],
-          to_consume: [%Marking{place: "input", tokens: ~b[1]}]
+          to_consume: [%Marking{place: "input", tokens: ~MS[1]}]
         }
       }
 
       state = %Enactment{
         enactment_id: Ecto.UUID.generate(),
-        markings: to_map([%Marking{place: "input", tokens: ~b[]}]),
+        markings: to_map([%Marking{place: "input", tokens: ~MS[]}]),
         workitems: to_map([workitem])
       }
 
@@ -104,7 +104,7 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
       assert %{state | workitems: %{}} === calibration.state
       assert [workitem] === calibration.to_withdraw
 
-      assert ~b[] === calibration.to_produce
+      assert ~MS[] === calibration.to_produce
     end
 
     test "produces some binding_elements and withdraws some workitems" do
@@ -116,13 +116,13 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
         binding_element: %BindingElement{
           transition: "pass_through",
           binding: [x: 2],
-          to_consume: [%Marking{place: "input", tokens: ~b[2]}]
+          to_consume: [%Marking{place: "input", tokens: ~MS[2]}]
         }
       }
 
       state = %Enactment{
         enactment_id: Ecto.UUID.generate(),
-        markings: to_map([%Marking{place: "input", tokens: ~b[1]}]),
+        markings: to_map([%Marking{place: "input", tokens: ~MS[1]}]),
         workitems: to_map([workitem])
       }
 
@@ -134,10 +134,10 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
       binding_elemnt = %BindingElement{
         transition: "pass_through",
         binding: [x: 1],
-        to_consume: [%Marking{place: "input", tokens: ~b[1]}]
+        to_consume: [%Marking{place: "input", tokens: ~MS[1]}]
       }
 
-      assert ~b[binding_elemnt] === calibration.to_produce
+      assert ~MS[binding_elemnt] === calibration.to_produce
     end
 
     test "works with mulitple input places transition" do
@@ -150,9 +150,9 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
           transition: "and_join",
           binding: [x: 1],
           to_consume: [
-            %Marking{place: "input1", tokens: ~b[1]},
-            %Marking{place: "input2", tokens: ~b[1]},
-            %Marking{place: "input3", tokens: ~b[1]}
+            %Marking{place: "input1", tokens: ~MS[1]},
+            %Marking{place: "input2", tokens: ~MS[1]},
+            %Marking{place: "input3", tokens: ~MS[1]}
           ]
         }
       }
@@ -161,8 +161,8 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
         enactment_id: Ecto.UUID.generate(),
         markings:
           to_map([
-            %Marking{place: "input1", tokens: ~b[1]},
-            %Marking{place: "input2", tokens: ~b[1]}
+            %Marking{place: "input1", tokens: ~MS[1]},
+            %Marking{place: "input2", tokens: ~MS[1]}
           ]),
         workitems: to_map([workitem])
       }
@@ -171,7 +171,7 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
 
       assert %{state | workitems: %{}} === calibration.state
       assert [workitem] === calibration.to_withdraw
-      assert ~b[] === calibration.to_produce
+      assert ~MS[] === calibration.to_produce
     end
   end
 
@@ -179,7 +179,7 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
     # ```mermaid
     # flowchart LR
     #   %% colset int() :: integer()
-    #   %% ~b[3**1]
+    #   %% ~MS[3**1]
     #   i((input))
     #   o((output))
     #   pt1[pass_through_1]
@@ -197,7 +197,7 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
         binding_element: %BindingElement{
           transition: "pass_through_1",
           binding: [x: 1],
-          to_consume: [%Marking{place: "input", tokens: ~b[1]}]
+          to_consume: [%Marking{place: "input", tokens: ~MS[1]}]
         }
       }
 
@@ -207,7 +207,7 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
         binding_element: %BindingElement{
           transition: "pass_through_1",
           binding: [x: 1],
-          to_consume: [%Marking{place: "input", tokens: ~b[1]}]
+          to_consume: [%Marking{place: "input", tokens: ~MS[1]}]
         }
       }
 
@@ -217,7 +217,7 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
         binding_element: %BindingElement{
           transition: "pass_through_1",
           binding: [x: 1],
-          to_consume: [%Marking{place: "input", tokens: ~b[1]}]
+          to_consume: [%Marking{place: "input", tokens: ~MS[1]}]
         }
       }
 
@@ -227,14 +227,14 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
         binding_element: %BindingElement{
           transition: "pass_through_2",
           binding: [x: 1],
-          to_consume: [%Marking{place: "input", tokens: ~b[2**1]}]
+          to_consume: [%Marking{place: "input", tokens: ~MS[2**1]}]
         }
       }
 
       state = %Enactment{
         enactment_id: enactment_id,
         version: 0,
-        markings: to_map([%Marking{place: "input", tokens: ~b[3**1]}]),
+        markings: to_map([%Marking{place: "input", tokens: ~MS[3**1]}]),
         workitems:
           to_map([
             %Enactment.Workitem{
@@ -270,7 +270,7 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
     # ```mermaid
     # flowchart LR
     #   %% colset int() :: integer()
-    #   %% ~b[2**1]
+    #   %% ~MS[2**1]
     #   i((input))
     #   o((output))
     #   pt1[pass_through_1]
@@ -288,7 +288,7 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
         binding_element: %BindingElement{
           transition: "pass_through_1",
           binding: [x: 1],
-          to_consume: [%Marking{place: "input", tokens: ~b[1]}]
+          to_consume: [%Marking{place: "input", tokens: ~MS[1]}]
         }
       }
 
@@ -298,7 +298,7 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
         binding_element: %BindingElement{
           transition: "pass_through_1",
           binding: [x: 1],
-          to_consume: [%Marking{place: "input", tokens: ~b[1]}]
+          to_consume: [%Marking{place: "input", tokens: ~MS[1]}]
         }
       }
 
@@ -308,14 +308,14 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
         binding_element: %BindingElement{
           transition: "pass_through_2",
           binding: [x: 1],
-          to_consume: [%Marking{place: "input", tokens: ~b[2**1]}]
+          to_consume: [%Marking{place: "input", tokens: ~MS[2**1]}]
         }
       }
 
       state = %Enactment{
         enactment_id: enactment_id,
         version: 0,
-        markings: to_map([%Marking{place: "input", tokens: ~b[2**1]}]),
+        markings: to_map([%Marking{place: "input", tokens: ~MS[2**1]}]),
         workitems:
           to_map([
             %Enactment.Workitem{
@@ -348,11 +348,11 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
     # ```mermaid
     # flowchart TB
     #   %% colset int() :: integer()
-    #   %% ~b[2**1]
+    #   %% ~MS[2**1]
     #   i1((input1))
-    #   %% ~b[1]
+    #   %% ~MS[1]
     #   i2((input2))
-    #   %% ~b[1]
+    #   %% ~MS[1]
     #   i3((input3))
     #   o((output))
     #   join[And Join]
@@ -368,9 +368,9 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
           transition: "and_join",
           binding: [x: 1],
           to_consume: [
-            %Marking{place: "input1", tokens: ~b[1]},
-            %Marking{place: "input2", tokens: ~b[1]},
-            %Marking{place: "input3", tokens: ~b[1]}
+            %Marking{place: "input1", tokens: ~MS[1]},
+            %Marking{place: "input2", tokens: ~MS[1]},
+            %Marking{place: "input3", tokens: ~MS[1]}
           ]
         }
       }
@@ -382,9 +382,9 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
           transition: "and_join",
           binding: [x: 1],
           to_consume: [
-            %Marking{place: "input1", tokens: ~b[1]},
-            %Marking{place: "input2", tokens: ~b[1]},
-            %Marking{place: "input3", tokens: ~b[1]}
+            %Marking{place: "input1", tokens: ~MS[1]},
+            %Marking{place: "input2", tokens: ~MS[1]},
+            %Marking{place: "input3", tokens: ~MS[1]}
           ]
         }
       }
@@ -394,9 +394,9 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
         version: 0,
         markings:
           to_map([
-            %Marking{place: "input1", tokens: ~b[2**1]},
-            %Marking{place: "input2", tokens: ~b[1]},
-            %Marking{place: "input3", tokens: ~b[1]}
+            %Marking{place: "input1", tokens: ~MS[2**1]},
+            %Marking{place: "input2", tokens: ~MS[1]},
+            %Marking{place: "input3", tokens: ~MS[1]}
           ]),
         workitems:
           to_map([
@@ -440,27 +440,27 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
         binding_element: %BindingElement{
           transition: "branch_2",
           binding: [x: 1],
-          to_consume: [%Marking{place: "input", tokens: ~b[2**1]}]
+          to_consume: [%Marking{place: "input", tokens: ~MS[2**1]}]
         }
       }
 
       state = %Enactment{
         enactment_id: Ecto.UUID.generate(),
         version: 0,
-        markings: to_map([%Marking{place: "input", tokens: ~b[2**1]}]),
+        markings: to_map([%Marking{place: "input", tokens: ~MS[2**1]}]),
         workitems: to_map([])
       }
 
       occurrence = %Occurrence{
         binding_element: b2_workitem.binding_element,
         free_binding: [],
-        to_produce: [%Marking{place: "merge", tokens: ~b[1]}]
+        to_produce: [%Marking{place: "merge", tokens: ~MS[1]}]
       }
 
       expected_state = %Enactment{
         state
         | version: 1,
-          markings: to_map([%Marking{place: "merge", tokens: ~b[1]}])
+          markings: to_map([%Marking{place: "merge", tokens: ~MS[1]}])
       }
 
       calibration =
@@ -488,7 +488,7 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
         binding_element: %BindingElement{
           transition: "pass_through",
           binding: [],
-          to_consume: [%Marking{place: "input", tokens: ~b[1]}]
+          to_consume: [%Marking{place: "input", tokens: ~MS[1]}]
         }
       }
 
@@ -498,7 +498,7 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
         binding_element: %BindingElement{
           transition: "deferred_choice_1",
           binding: [x: 1],
-          to_consume: [%Marking{place: "place", tokens: ~b[1]}]
+          to_consume: [%Marking{place: "place", tokens: ~MS[1]}]
         }
       }
 
@@ -507,8 +507,8 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
         version: 0,
         markings:
           to_map([
-            %Marking{place: "input", tokens: ~b[1]},
-            %Marking{place: "place", tokens: ~b[1]}
+            %Marking{place: "input", tokens: ~MS[1]},
+            %Marking{place: "place", tokens: ~MS[1]}
           ]),
         workitems: to_map([dc1_workitem])
       }
@@ -516,13 +516,13 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
       occurrence = %Occurrence{
         binding_element: pt_workitem.binding_element,
         free_binding: [],
-        to_produce: [%Marking{place: "place", tokens: ~b[1]}]
+        to_produce: [%Marking{place: "place", tokens: ~MS[1]}]
       }
 
       expected_state = %Enactment{
         state
         | version: 1,
-          markings: to_map([%Marking{place: "place", tokens: ~b[2**1]}])
+          markings: to_map([%Marking{place: "place", tokens: ~MS[2**1]}])
       }
 
       calibration =
@@ -537,7 +537,7 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
                %BindingElement{
                  transition: "deferred_choice_1",
                  binding: [x: 1],
-                 to_consume: [%Marking{place: "place", tokens: ~b[1]}]
+                 to_consume: [%Marking{place: "place", tokens: ~MS[1]}]
                }
              ] === calibration.to_produce
     end
@@ -551,7 +551,7 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
         binding_element: %BindingElement{
           transition: "branch_1",
           binding: [x: 1],
-          to_consume: [%Marking{place: "input", tokens: ~b[1]}]
+          to_consume: [%Marking{place: "input", tokens: ~MS[1]}]
         }
       }
 
@@ -561,7 +561,7 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
         binding_element: %BindingElement{
           transition: "thread_merge",
           binding: [],
-          to_consume: [%Marking{place: "merge", tokens: ~b[2**1]}]
+          to_consume: [%Marking{place: "merge", tokens: ~MS[2**1]}]
         }
       }
 
@@ -570,8 +570,8 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
         version: 0,
         markings:
           to_map([
-            %Marking{place: "input", tokens: ~b[1]},
-            %Marking{place: "merge", tokens: ~b[2**1]}
+            %Marking{place: "input", tokens: ~MS[1]},
+            %Marking{place: "merge", tokens: ~MS[2**1]}
           ]),
         workitems: to_map([tm_workitem])
       }
@@ -579,13 +579,13 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
       occurrence = %Occurrence{
         binding_element: b1_workitem.binding_element,
         free_binding: [],
-        to_produce: [%Marking{place: "merge", tokens: ~b[1]}]
+        to_produce: [%Marking{place: "merge", tokens: ~MS[1]}]
       }
 
       expected_state = %Enactment{
         state
         | version: 1,
-          markings: to_map([%Marking{place: "merge", tokens: ~b[3**1]}])
+          markings: to_map([%Marking{place: "merge", tokens: ~MS[3**1]}])
       }
 
       calibration =
@@ -607,7 +607,7 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
         binding_element: %BindingElement{
           transition: "branch_1",
           binding: [x: 1],
-          to_consume: [%Marking{place: "input", tokens: ~b[1]}]
+          to_consume: [%Marking{place: "input", tokens: ~MS[1]}]
         }
       }
 
@@ -617,33 +617,33 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
         binding_element: %BindingElement{
           transition: "branch_1",
           binding: [x: 1],
-          to_consume: [%Marking{place: "input", tokens: ~b[1]}]
+          to_consume: [%Marking{place: "input", tokens: ~MS[1]}]
         }
       }
 
       state = %Enactment{
         enactment_id: Ecto.UUID.generate(),
         version: 0,
-        markings: to_map([%Marking{place: "input", tokens: ~b[2**1]}]),
+        markings: to_map([%Marking{place: "input", tokens: ~MS[2**1]}]),
         workitems: to_map([])
       }
 
       b1_occurrence_1 = %Occurrence{
         binding_element: b1_workitem_1.binding_element,
         free_binding: [],
-        to_produce: [%Marking{place: "merge", tokens: ~b[1]}]
+        to_produce: [%Marking{place: "merge", tokens: ~MS[1]}]
       }
 
       b1_occurrence_2 = %Occurrence{
         binding_element: b1_workitem_2.binding_element,
         free_binding: [],
-        to_produce: [%Marking{place: "merge", tokens: ~b[1]}]
+        to_produce: [%Marking{place: "merge", tokens: ~MS[1]}]
       }
 
       expected_state = %Enactment{
         state
         | version: 2,
-          markings: to_map([%Marking{place: "merge", tokens: ~b[2**1]}])
+          markings: to_map([%Marking{place: "merge", tokens: ~MS[2**1]}])
       }
 
       calibration =
@@ -661,7 +661,7 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
                %BindingElement{
                  transition: "thread_merge",
                  binding: [],
-                 to_consume: [%Marking{place: "merge", tokens: ~b[2**1]}]
+                 to_consume: [%Marking{place: "merge", tokens: ~MS[2**1]}]
                }
              ] === calibration.to_produce
     end
@@ -675,7 +675,7 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
         binding_element: %BindingElement{
           transition: "branch_1",
           binding: [x: 1],
-          to_consume: [%Marking{place: "input", tokens: ~b[1]}]
+          to_consume: [%Marking{place: "input", tokens: ~MS[1]}]
         }
       }
 
@@ -684,8 +684,8 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
         version: 0,
         markings:
           to_map([
-            %Marking{place: "input", tokens: ~b[1]},
-            %Marking{place: "merge", tokens: ~b[1]}
+            %Marking{place: "input", tokens: ~MS[1]},
+            %Marking{place: "merge", tokens: ~MS[1]}
           ]),
         workitems: to_map([])
       }
@@ -693,13 +693,13 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
       b1_occurrence = %Occurrence{
         binding_element: b1_workitem.binding_element,
         free_binding: [],
-        to_produce: [%Marking{place: "merge", tokens: ~b[1]}]
+        to_produce: [%Marking{place: "merge", tokens: ~MS[1]}]
       }
 
       expected_state = %Enactment{
         state
         | version: 1,
-          markings: to_map([%Marking{place: "merge", tokens: ~b[2**1]}])
+          markings: to_map([%Marking{place: "merge", tokens: ~MS[2**1]}])
       }
 
       calibration =
@@ -714,7 +714,7 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
                %BindingElement{
                  transition: "thread_merge",
                  binding: [],
-                 to_consume: [%Marking{place: "merge", tokens: ~b[2**1]}]
+                 to_consume: [%Marking{place: "merge", tokens: ~MS[2**1]}]
                }
              ] === calibration.to_produce
     end
@@ -728,27 +728,27 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
         binding_element: %BindingElement{
           transition: "pass_through",
           binding: [x: 1],
-          to_consume: [%Marking{place: "input", tokens: ~b[1]}]
+          to_consume: [%Marking{place: "input", tokens: ~MS[1]}]
         }
       }
 
       state = %Enactment{
         enactment_id: Ecto.UUID.generate(),
         version: 0,
-        markings: to_map([%Marking{place: "input", tokens: ~b[1]}]),
+        markings: to_map([%Marking{place: "input", tokens: ~MS[1]}]),
         workitems: to_map([])
       }
 
       pt_occurrence = %Occurrence{
         binding_element: pt_workitem.binding_element,
         free_binding: [],
-        to_produce: [%Marking{place: "place", tokens: ~b[1]}]
+        to_produce: [%Marking{place: "place", tokens: ~MS[1]}]
       }
 
       expected_state = %Enactment{
         state
         | version: 1,
-          markings: to_map([%Marking{place: "place", tokens: ~b[1]}])
+          markings: to_map([%Marking{place: "place", tokens: ~MS[1]}])
       }
 
       calibration =
@@ -763,12 +763,12 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
                %BindingElement{
                  transition: "deferred_choice_1",
                  binding: [x: 1],
-                 to_consume: [%Marking{place: "place", tokens: ~b[1]}]
+                 to_consume: [%Marking{place: "place", tokens: ~MS[1]}]
                },
                %BindingElement{
                  transition: "deferred_choice_2",
                  binding: [x: 1],
-                 to_consume: [%Marking{place: "place", tokens: ~b[1]}]
+                 to_consume: [%Marking{place: "place", tokens: ~MS[1]}]
                }
              ] === calibration.to_produce
     end
@@ -782,14 +782,14 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
         binding_element: %BindingElement{
           transition: "parallel_split",
           binding: [x: 1],
-          to_consume: [%Marking{place: "input", tokens: ~b[1]}]
+          to_consume: [%Marking{place: "input", tokens: ~MS[1]}]
         }
       }
 
       state = %Enactment{
         enactment_id: Ecto.UUID.generate(),
         version: 0,
-        markings: to_map([%Marking{place: "input", tokens: ~b[1]}]),
+        markings: to_map([%Marking{place: "input", tokens: ~MS[1]}]),
         workitems: to_map([])
       }
 
@@ -797,8 +797,8 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
         binding_element: ps_workitem.binding_element,
         free_binding: [],
         to_produce: [
-          %Marking{place: "place_1", tokens: ~b[1]},
-          %Marking{place: "place_2", tokens: ~b[1]}
+          %Marking{place: "place_1", tokens: ~MS[1]},
+          %Marking{place: "place_2", tokens: ~MS[1]}
         ]
       }
 
@@ -807,8 +807,8 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
         | version: 1,
           markings:
             to_map([
-              %Marking{place: "place_1", tokens: ~b[1]},
-              %Marking{place: "place_2", tokens: ~b[1]}
+              %Marking{place: "place_1", tokens: ~MS[1]},
+              %Marking{place: "place_2", tokens: ~MS[1]}
             ])
       }
 
@@ -824,12 +824,12 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
                %BindingElement{
                  transition: "pass_through_1",
                  binding: [x: 1],
-                 to_consume: [%Marking{place: "place_1", tokens: ~b[1]}]
+                 to_consume: [%Marking{place: "place_1", tokens: ~MS[1]}]
                },
                %BindingElement{
                  transition: "pass_through_2",
                  binding: [x: 1],
-                 to_consume: [%Marking{place: "place_2", tokens: ~b[1]}]
+                 to_consume: [%Marking{place: "place_2", tokens: ~MS[1]}]
                }
              ] === calibration.to_produce
     end

--- a/test/coloured_flow/runner/enactment/workitem_completion_test.exs
+++ b/test/coloured_flow/runner/enactment/workitem_completion_test.exs
@@ -42,7 +42,7 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCompletionTest do
                   %Occurrence{
                     binding_element: workitem.binding_element,
                     free_binding: [],
-                    to_produce: [%Marking{place: "output", tokens: ~b[1]}]
+                    to_produce: [%Marking{place: "output", tokens: ~MS[1]}]
                   }
                 }
               ]} === WorkitemCompletion.complete(workitem_and_outputs, cpnet)
@@ -72,7 +72,7 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCompletionTest do
                   %Occurrence{
                     binding_element: workitem_1.binding_element,
                     free_binding: [],
-                    to_produce: [%Marking{place: "output", tokens: ~b[1]}]
+                    to_produce: [%Marking{place: "output", tokens: ~MS[1]}]
                   }
                 },
                 {
@@ -80,7 +80,7 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCompletionTest do
                   %Occurrence{
                     binding_element: workitem_2.binding_element,
                     free_binding: [],
-                    to_produce: [%Marking{place: "output", tokens: ~b[1]}]
+                    to_produce: [%Marking{place: "output", tokens: ~MS[1]}]
                   }
                 }
               ]} === WorkitemCompletion.complete(workitem_and_outputs, cpnet)
@@ -153,7 +153,7 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCompletionTest do
                   %Occurrence{
                     binding_element: workitem.binding_element,
                     free_binding: [y: 1],
-                    to_produce: [%Marking{place: "output", tokens: ~b[1]}]
+                    to_produce: [%Marking{place: "output", tokens: ~MS[1]}]
                   }
                 }
               ]} === WorkitemCompletion.complete(workitem_and_outputs, cpnet)
@@ -183,7 +183,7 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCompletionTest do
                   %Occurrence{
                     binding_element: workitem_1.binding_element,
                     free_binding: [y: 2],
-                    to_produce: [%Marking{place: "output", tokens: ~b[2]}]
+                    to_produce: [%Marking{place: "output", tokens: ~MS[2]}]
                   }
                 },
                 {
@@ -191,7 +191,7 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCompletionTest do
                   %Occurrence{
                     binding_element: workitem_2.binding_element,
                     free_binding: [y: 3],
-                    to_produce: [%Marking{place: "output", tokens: ~b[3]}]
+                    to_produce: [%Marking{place: "output", tokens: ~MS[3]}]
                   }
                 }
               ]} === WorkitemCompletion.complete(workitem_and_outputs, cpnet)

--- a/test/coloured_flow/runner/enactment/workitem_consumption_test.exs
+++ b/test/coloured_flow/runner/enactment/workitem_consumption_test.exs
@@ -17,7 +17,7 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemConsumptionTest do
           transition: "pass_through",
           binding: [x: 1],
           to_consume: [
-            %Marking{place: "input", tokens: ~b[1]}
+            %Marking{place: "input", tokens: ~MS[1]}
           ]
         }
       }
@@ -29,7 +29,7 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemConsumptionTest do
           transition: "pass_through",
           binding: [x: 1],
           to_consume: [
-            %Marking{place: "input", tokens: ~b[1]}
+            %Marking{place: "input", tokens: ~MS[1]}
           ]
         }
       }
@@ -76,17 +76,17 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemConsumptionTest do
   describe "consume_tokens" do
     test "works" do
       place_markings = [
-        %Marking{place: "a", tokens: ~b[1]},
-        %Marking{place: "b", tokens: ~b[1]},
-        %Marking{place: "c", tokens: ~b[1]}
+        %Marking{place: "a", tokens: ~MS[1]},
+        %Marking{place: "b", tokens: ~MS[1]},
+        %Marking{place: "c", tokens: ~MS[1]}
       ]
 
       binding_element_1 = %BindingElement{
         transition: "t",
         binding: [],
         to_consume: [
-          %Marking{place: "a", tokens: ~b[1]},
-          %Marking{place: "b", tokens: ~b[1]}
+          %Marking{place: "a", tokens: ~MS[1]},
+          %Marking{place: "b", tokens: ~MS[1]}
         ]
       }
 
@@ -94,7 +94,7 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemConsumptionTest do
         transition: "t",
         binding: [],
         to_consume: [
-          %Marking{place: "c", tokens: ~b[1]}
+          %Marking{place: "c", tokens: ~MS[1]}
         ]
       }
 
@@ -104,7 +104,7 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemConsumptionTest do
                  binding_element_2
                ])
 
-      assert {:ok, %{"c" => %Marking{place: "c", tokens: ~b[1]}}} ===
+      assert {:ok, %{"c" => %Marking{place: "c", tokens: ~MS[1]}}} ===
                WorkitemConsumption.consume_tokens(to_map(place_markings), [
                  binding_element_1
                ])
@@ -112,32 +112,32 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemConsumptionTest do
 
     test "tokens are consumed partially" do
       place_markings = [
-        %Marking{place: "a", tokens: ~b[2**1]}
+        %Marking{place: "a", tokens: ~MS[2**1]}
       ]
 
       binding_element = %BindingElement{
         transition: "t",
         binding: [],
         to_consume: [
-          %Marking{place: "a", tokens: ~b[1]}
+          %Marking{place: "a", tokens: ~MS[1]}
         ]
       }
 
-      assert {:ok, %{"a" => %Marking{place: "a", tokens: ~b[1]}}} ===
+      assert {:ok, %{"a" => %Marking{place: "a", tokens: ~MS[1]}}} ===
                WorkitemConsumption.consume_tokens(to_map(place_markings), [binding_element])
     end
 
     test "empty markings or binding_elements" do
       place_markings =
         to_map([
-          %Marking{place: "a", tokens: ~b[1]},
-          %Marking{place: "b", tokens: ~b[1]},
-          %Marking{place: "c", tokens: ~b[1]}
+          %Marking{place: "a", tokens: ~MS[1]},
+          %Marking{place: "b", tokens: ~MS[1]},
+          %Marking{place: "c", tokens: ~MS[1]}
         ])
 
       to_consume = [
-        %Marking{place: "a", tokens: ~b[1]},
-        %Marking{place: "b", tokens: ~b[1]}
+        %Marking{place: "a", tokens: ~MS[1]},
+        %Marking{place: "b", tokens: ~MS[1]}
       ]
 
       binding_element = %BindingElement{
@@ -154,9 +154,9 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemConsumptionTest do
 
     test "returns unsufficient_tokens error" do
       place_markings = [
-        %Marking{place: "a", tokens: ~b[1]},
-        %Marking{place: "b", tokens: ~b[1]},
-        %Marking{place: "c", tokens: ~b[1]}
+        %Marking{place: "a", tokens: ~MS[1]},
+        %Marking{place: "b", tokens: ~MS[1]},
+        %Marking{place: "c", tokens: ~MS[1]}
       ]
 
       binding_elements = [
@@ -164,15 +164,15 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemConsumptionTest do
           transition: "t",
           binding: [],
           to_consume: [
-            %Marking{place: "a", tokens: ~b[1]},
-            %Marking{place: "b", tokens: ~b[1]}
+            %Marking{place: "a", tokens: ~MS[1]},
+            %Marking{place: "b", tokens: ~MS[1]}
           ]
         },
         %BindingElement{
           transition: "t",
           binding: [],
           to_consume: [
-            %Marking{place: "c", tokens: ~b[2]}
+            %Marking{place: "c", tokens: ~MS[2]}
           ]
         }
       ]
@@ -181,16 +181,16 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemConsumptionTest do
                :error,
                {
                  :unsufficient_tokens,
-                 %Marking{place: "c", tokens: ~b[1]}
+                 %Marking{place: "c", tokens: ~MS[1]}
                }
              } === WorkitemConsumption.consume_tokens(to_map(place_markings), binding_elements)
     end
 
     test "raises error when place marking is absent" do
       place_markings = [
-        %Marking{place: "a", tokens: ~b[1]},
-        %Marking{place: "b", tokens: ~b[1]},
-        %Marking{place: "c", tokens: ~b[1]}
+        %Marking{place: "a", tokens: ~MS[1]},
+        %Marking{place: "b", tokens: ~MS[1]},
+        %Marking{place: "c", tokens: ~MS[1]}
       ]
 
       binding_elements = [
@@ -198,7 +198,7 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemConsumptionTest do
           transition: "t",
           binding: [],
           to_consume: [
-            %Marking{place: "d", tokens: ~b[2]}
+            %Marking{place: "d", tokens: ~MS[2]}
           ]
         }
       ]

--- a/test/coloured_flow/runner/storage/schemas/json_instance/codec/binding_element_test.exs
+++ b/test/coloured_flow/runner/storage/schemas/json_instance/codec/binding_element_test.exs
@@ -12,12 +12,12 @@ defmodule ColouredFlow.Runner.Storage.Schemas.JsonInstance.Codec.BindingElementT
         %BindingElement{
           transition: "t1",
           binding: [x: 1],
-          to_consume: [%Marking{place: "p1", tokens: ~b[1]}]
+          to_consume: [%Marking{place: "p1", tokens: ~MS[1]}]
         },
         %BindingElement{
           transition: "t1",
           binding: [x: 1, y: 2],
-          to_consume: [%Marking{place: "p1", tokens: ~b[1**2 2**3]}]
+          to_consume: [%Marking{place: "p1", tokens: ~MS[1**2 2**3]}]
         }
       ]
 

--- a/test/coloured_flow/runner/storage/schemas/json_instance/codec/marking_test.exs
+++ b/test/coloured_flow/runner/storage/schemas/json_instance/codec/marking_test.exs
@@ -8,8 +8,8 @@ defmodule ColouredFlow.Runner.Storage.Schemas.JsonInstance.Codec.MarkingTest do
   describe "codec" do
     test "works" do
       list = [
-        %Marking{place: "p1", tokens: ~b[1]},
-        %Marking{place: "p1", tokens: ~b[1**2 2**3]}
+        %Marking{place: "p1", tokens: ~MS[1]},
+        %Marking{place: "p1", tokens: ~MS[1**2 2**3]}
       ]
 
       assert_codec(list)

--- a/test/coloured_flow/runner/storage/schemas/json_instance/codec/occurrence_test.exs
+++ b/test/coloured_flow/runner/storage/schemas/json_instance/codec/occurrence_test.exs
@@ -14,11 +14,11 @@ defmodule ColouredFlow.Runner.Storage.Schemas.JsonInstance.Codec.OccurrenceTest 
           binding_element: %BindingElement{
             transition: "t1",
             binding: [x: 1],
-            to_consume: [%Marking{place: "p1", tokens: ~b[1]}]
+            to_consume: [%Marking{place: "p1", tokens: ~MS[1]}]
           },
           free_binding: [x: 1],
           to_produce: [
-            %Marking{place: "p2", tokens: ~b[2**1]}
+            %Marking{place: "p2", tokens: ~MS[2**1]}
           ]
         }
       ]

--- a/test/coloured_flow/runner/storage/schemas/schema_test.exs
+++ b/test/coloured_flow/runner/storage/schemas/schema_test.exs
@@ -24,7 +24,7 @@ defmodule ColouredFlow.Runner.Storage.Schemas.SchemaTest do
   end
 
   test "persists enactment with initial_markings" do
-    markings = [%Marking{place: "p1", tokens: ~b[1]}]
+    markings = [%Marking{place: "p1", tokens: ~MS[1]}]
     built_enactment = :enactment |> build() |> enactment_with_initial_markings(markings)
     inserted = insert(built_enactment)
     enactment = Schemas.Enactment |> Repo.get(inserted.id) |> Repo.preload([:flow])
@@ -49,11 +49,11 @@ defmodule ColouredFlow.Runner.Storage.Schemas.SchemaTest do
       binding_element: %BindingElement{
         transition: "t1",
         binding: [x: 1],
-        to_consume: [%Marking{place: "p1", tokens: ~b[1]}]
+        to_consume: [%Marking{place: "p1", tokens: ~MS[1]}]
       },
       free_binding: [x: 1],
       to_produce: [
-        %Marking{place: "p2", tokens: ~b[2**1]}
+        %Marking{place: "p2", tokens: ~MS[2**1]}
       ]
     }
 
@@ -80,7 +80,7 @@ defmodule ColouredFlow.Runner.Storage.Schemas.SchemaTest do
     binding_element = %BindingElement{
       transition: "t1",
       binding: [x: 1],
-      to_consume: [%Marking{place: "p1", tokens: ~b[1]}]
+      to_consume: [%Marking{place: "p1", tokens: ~MS[1]}]
     }
 
     built_workitem = :workitem |> build() |> workitem_with_binding_element(binding_element)
@@ -101,7 +101,7 @@ defmodule ColouredFlow.Runner.Storage.Schemas.SchemaTest do
   end
 
   test "persists snapshot with markings" do
-    marking = %Marking{place: "p1", tokens: ~b[1]}
+    marking = %Marking{place: "p1", tokens: ~MS[1]}
     built_snapshot = :snapshot |> build() |> snapshot_with_markings([marking])
     inserted = insert(built_snapshot)
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -11,7 +11,7 @@ defmodule ColouredFlow.Factory do
 
   use ExMachina.Ecto, repo: Repo
 
-  import ColouredFlow.MultiSet, only: [sigil_b: 2]
+  import ColouredFlow.MultiSet, only: :sigils
 
   def flow_factory do
     %Schemas.Flow{
@@ -54,10 +54,10 @@ defmodule ColouredFlow.Factory do
               BindingElement.new(
                 "pass_through",
                 [x: 1],
-                [%Marking{place: "integer", tokens: ~b[1]}]
+                [%Marking{place: "integer", tokens: ~MS[1]}]
               ),
             free_binding: [],
-            to_produce: [%Marking{place: "output", tokens: ~b[1**2]}]
+            to_produce: [%Marking{place: "output", tokens: ~MS[1**2]}]
           }
         }
       end
@@ -79,7 +79,7 @@ defmodule ColouredFlow.Factory do
             BindingElement.new(
               "pass_through",
               [x: 1],
-              [%Marking{place: "integer", tokens: ~b[1]}]
+              [%Marking{place: "integer", tokens: ~MS[1]}]
             )
         }
       end


### PR DESCRIPTION
leave the single lower-case letter to Elixir sigils
