### PR TITLE
feat: enactment logs

### DIFF
--- a/lib/coloured_flow/runner/storage/migrations/v0.ex
+++ b/lib/coloured_flow/runner/storage/migrations/v0.ex
@@ -52,7 +52,7 @@ defmodule ColouredFlow.Runner.Migrations.V0 do
       timestamps([{:updated_at, false} | @timestamps_opts])
     end
 
-    create index("enactment_logs", [:enactment_id], index_options)
+    create index("enactment_logs", [:enactment_id, :inserted_at], index_options)
 
     create table("workitems", table_options) do
       add :id, :binary_id, primary_key: true
@@ -66,7 +66,8 @@ defmodule ColouredFlow.Runner.Migrations.V0 do
       timestamps(@timestamps_opts)
     end
 
-    create index("workitems", [:enactment_id, :state], index_options)
+    create index("workitems", [:state], index_options)
+    create index("workitems", [:updated_at], index_options)
 
     create table("occurrences", table_options) do
       add :enactment_id, references("enactments", type: :binary_id, on_delete: :delete_all),
@@ -97,7 +98,7 @@ defmodule ColouredFlow.Runner.Migrations.V0 do
       timestamps(@timestamps_opts)
     end
 
-    create index("occurrences", [:enactment_id], index_options)
+    create index("snapshots", [:enactment_id], index_options)
 
     :ok
   end

--- a/lib/coloured_flow/runner/storage/migrations/v0.ex
+++ b/lib/coloured_flow/runner/storage/migrations/v0.ex
@@ -38,6 +38,22 @@ defmodule ColouredFlow.Runner.Migrations.V0 do
       timestamps(@timestamps_opts)
     end
 
+    create table("enactment_logs", table_options) do
+      add :id, :binary_id, primary_key: true
+
+      add :enactment_id, references("enactments", type: :binary_id, on_delete: :delete_all),
+        null: false
+
+      add :state, :string, null: false
+
+      add :termination, :jsonb
+      add :exception, :jsonb
+
+      timestamps([{:updated_at, false} | @timestamps_opts])
+    end
+
+    create index("enactment_logs", [:enactment_id], index_options)
+
     create table("workitems", table_options) do
       add :id, :binary_id, primary_key: true
 

--- a/lib/coloured_flow/runner/storage/schemas/enactment.ex
+++ b/lib/coloured_flow/runner/storage/schemas/enactment.ex
@@ -13,7 +13,12 @@ defmodule ColouredFlow.Runner.Storage.Schemas.Enactment do
     field :flow, Types.association(Flow.t())
     field :state, :running | :exception | :terminated, default: :running
     field :label, String.t(), enforce: false
-    field :data, %{initial_markings: [Marking.t()]}
+
+    field :data, %{
+      required(:initial_markings) => [Marking.t()],
+      optional(:final_markings) => [Marking.t()]
+    }
+
     field :steps, Types.association([Occurrence.t()])
 
     field :inserted_at, NaiveDateTime.t()

--- a/lib/coloured_flow/runner/storage/schemas/enactment.ex
+++ b/lib/coloured_flow/runner/storage/schemas/enactment.ex
@@ -7,11 +7,15 @@ defmodule ColouredFlow.Runner.Storage.Schemas.Enactment do
   alias ColouredFlow.Runner.Storage.Schemas.Flow
   alias ColouredFlow.Runner.Storage.Schemas.Occurrence
 
+  states = ~w[running  exception terminated]a
+
+  @type state() :: unquote(ColouredFlow.Types.make_sum_type(states))
+
   typed_structor define_struct: false, enforce: true do
     field :id, Types.id()
     field :flow_id, Types.id()
     field :flow, Types.association(Flow.t())
-    field :state, :running | :exception | :terminated, default: :running
+    field :state, state(), default: :running
     field :label, String.t(), enforce: false
 
     field :data, %{
@@ -42,6 +46,9 @@ defmodule ColouredFlow.Runner.Storage.Schemas.Enactment do
 
     timestamps()
   end
+
+  @spec __states__() :: [state()]
+  def __states__, do: unquote(states)
 
   @spec to_initial_markings(t()) :: [Marking.t()]
   def to_initial_markings(%__MODULE__{} = enactment) do

--- a/lib/coloured_flow/runner/storage/schemas/enactment_log.ex
+++ b/lib/coloured_flow/runner/storage/schemas/enactment_log.ex
@@ -1,0 +1,46 @@
+defmodule ColouredFlow.Runner.Storage.Schemas.EnactmentLog do
+  @moduledoc false
+
+  use ColouredFlow.Runner.Storage.Schemas.Schema
+
+  alias ColouredFlow.Runner.Storage.Schemas.Enactment
+
+  typed_structor define_struct: false, enforce: true do
+    field :id, Types.id()
+    field :enactment_id, Types.id()
+    field :enactment, Types.association(Enactment.t())
+
+    field :state, Enactment.state()
+
+    field :termination, %{type: ColouredFlow.Termination.type(), message: String.t() | nil},
+      enforce: false
+
+    field :exception, %{type: String.t(), message: String.t(), original: String.t()},
+      enforce: false
+
+    field :inserted_at, NaiveDateTime.t()
+  end
+
+  schema "enactment_logs" do
+    belongs_to :enactment, Enactment
+
+    field :state, Ecto.Enum, values: Enactment.__states__()
+
+    embeds_one :termination, Termination, primary_key: false, on_replace: :delete do
+      @moduledoc false
+
+      field :type, Ecto.Enum, values: ColouredFlow.Termination.__types__()
+      field :message, :string
+    end
+
+    embeds_one :exception, Exception, primary_key: false, on_replace: :delete do
+      @moduledoc false
+
+      field :type, :string
+      field :message, :string
+      field :original, :string
+    end
+
+    timestamps(updated_at: false)
+  end
+end

--- a/lib/coloured_flow/runner/storage/storage.ex
+++ b/lib/coloured_flow/runner/storage/storage.ex
@@ -122,7 +122,7 @@ defmodule ColouredFlow.Runner.Storage do
   @doc false
   @spec terminate_enactment(
           enactment_id(),
-          type :: :implicit | :explicit | :force,
+          type :: ColouredFlow.Termination.type(),
           final_markings :: [Marking.t()],
           options :: [message: String.t()]
         ) :: :ok

--- a/lib/coloured_flow/termination/termination.ex
+++ b/lib/coloured_flow/termination/termination.ex
@@ -49,4 +49,10 @@ defmodule ColouredFlow.Termination do
 
     __ENV__
   end
+
+  types = ~w[implicit explicit force]a
+  @type type() :: unquote(ColouredFlow.Types.make_sum_type(types))
+
+  @spec __types__() :: [type()]
+  def __types__, do: unquote(types)
 end

--- a/test/coloured_flow/runner/enactment/enactment_termination_test.exs
+++ b/test/coloured_flow/runner/enactment/enactment_termination_test.exs
@@ -74,6 +74,25 @@ defmodule ColouredFlow.Runner.Enactment.EnactmentTerminationTest do
       assert initial_markings === schema.data.final_markings
     end
 
+    @tag initial_markings: [%Marking{place: "output", tokens: ~MS[1]}]
+    test "inserts enactment log", %{enactment: enactment} do
+      [enactment_server: enactment_server] = start_enactment(%{enactment: enactment})
+      wait_enactment_to_stop!(enactment_server)
+
+      logs = Repo.all(Schemas.EnactmentLog, enactment_id: enactment.id)
+
+      assert match?(
+               [
+                 %Schemas.EnactmentLog{
+                   state: :terminated,
+                   termination: %Schemas.EnactmentLog.Termination{type: :implicit, message: nil},
+                   exception: nil
+                 }
+               ],
+               logs
+             )
+    end
+
     @tag initial_markings: [%Marking{place: "input", tokens: ~MS[2]}]
     test "terminates explicitly when no more enabled workitems after a workitem completed", %{
       enactment: enactment
@@ -132,6 +151,25 @@ defmodule ColouredFlow.Runner.Enactment.EnactmentTerminationTest do
       schema = Repo.get(Schemas.Enactment, enactment.id)
       assert :terminated === schema.state
       assert initial_markings === schema.data.final_markings
+    end
+
+    @tag initial_markings: [%Marking{place: "output", tokens: ~MS[2**1]}]
+    test "inserts enactment log", %{enactment: enactment} do
+      [enactment_server: enactment_server] = start_enactment(%{enactment: enactment})
+      wait_enactment_to_stop!(enactment_server)
+
+      logs = Repo.all(Schemas.EnactmentLog, enactment_id: enactment.id)
+
+      assert match?(
+               [
+                 %Schemas.EnactmentLog{
+                   state: :terminated,
+                   termination: %Schemas.EnactmentLog.Termination{type: :explicit, message: nil},
+                   exception: nil
+                 }
+               ],
+               logs
+             )
     end
 
     @tag initial_markings: [%Marking{place: "input", tokens: ~MS[2**1]}]


### PR DESCRIPTION
Add enactment logs to store transitions of the enactment

This pull request introduces significant changes to the `ColouredFlow` project, focusing on the termination process of enactments and the logging of these terminations. The changes include modifications to the `terminate_enactment` function, the addition of a new `EnactmentLog` schema, and updates to the database migrations and tests.

Key changes include:

### Termination Process Enhancements:
* Refactored `terminate_enactment` function to use `Ecto.Multi` for handling multiple database operations atomically, including updating the enactment state and inserting a new enactment log (`lib/coloured_flow/runner/storage/default.ex`).

### Database Schema Updates:
* Added a new `enactment_logs` table to store logs of enactment terminations, including fields for `enactment_id`, `state`, `termination`, and `exception` (`lib/coloured_flow/runner/storage/migrations/v0.ex`).
* Updated indexes for the `workitems` and `occurrences` tables to optimize queries (`lib/coloured_flow/runner/storage/migrations/v0.ex`). [[1]](diffhunk://#diff-8d7212cee65e7ed35e5a23bb32ecd582e06b5608eef6772ef325b7286214122eL53-R70) [[2]](diffhunk://#diff-8d7212cee65e7ed35e5a23bb32ecd582e06b5608eef6772ef325b7286214122eL84-R101)

### Schema and Type Definitions:
* Introduced a new `EnactmentLog` schema to log termination details and exceptions (`lib/coloured_flow/runner/storage/schemas/enactment_log.ex`).
* Defined new types for `Enactment` states and `Termination` types to ensure type safety and consistency across the codebase (`lib/coloured_flow/runner/storage/schemas/enactment.ex`, `lib/coloured_flow/termination/termination.ex`). [[1]](diffhunk://#diff-b6dc33daea6bb2786e4f44dbbf41d7365b6df319667babebbd066120a95fbb8bR10-R25) [[2]](diffhunk://#diff-42231a3bdbd82591ce046906533b7186425763908b99f943b0f4a66e26fac06dR52-R57)

### Test Enhancements:
* Added tests to verify the insertion of enactment logs upon termination, ensuring that the logs contain the correct state and termination details (`test/coloured_flow/runner/enactment/enactment_termination_test.exs`). [[1]](diffhunk://#diff-ae5585857dd18e5c34eb745982e9fdd206399ada0dadd4e54e2b71a2bf67e7eeR77-R95) [[2]](diffhunk://#diff-ae5585857dd18e5c34eb745982e9fdd206399ada0dadd4e54e2b71a2bf67e7eeR156-R174)