### PR TITLE
feat: handle exception_occurs for an enactment

### DIFF
--- a/lib/coloured_flow/exception/exception.ex
+++ b/lib/coloured_flow/exception/exception.ex
@@ -1,0 +1,17 @@
+defmodule ColouredFlow.Exception do
+  @moduledoc """
+  The enactment may be stopped due to an exception.
+
+  ## Reasons:
+
+  ### `termination_criteria_evaluation`
+
+  The termination criteria evaluation failed due to an invalid expression or evaluation result.
+  """
+
+  reason = ~w[termination_criteria_evaluation]a
+  @type reason() :: unquote(ColouredFlow.Types.make_sum_type(reason))
+
+  @spec __reasons__() :: [reason()]
+  def __reasons__, do: unquote(reason)
+end

--- a/lib/coloured_flow/runner/enactment/enactment.ex
+++ b/lib/coloured_flow/runner/enactment/enactment.ex
@@ -193,7 +193,8 @@ defmodule ColouredFlow.Runner.Enactment do
   end
 
   # `:explicit` takes priority over `:implicit`
-  @spec check_termination(state(), ColouredPetriNet.t()) :: {:stop, :explicit | :implicit} | :cont
+  @spec check_termination(state(), ColouredPetriNet.t()) ::
+          {:stop, :explicit | :implicit | :exception} | :cont
   defp check_termination(%__MODULE__{} = state, cpnet) do
     import EnactmentTermination
 
@@ -210,9 +211,15 @@ defmodule ColouredFlow.Runner.Enactment do
 
         {:stop, type}
 
-      {:error, _exceptions} ->
-        # TODO: handle exceptions
-        :cont
+      {:error, exception} ->
+        :ok =
+          Storage.exception_occurs(
+            state.enactment_id,
+            :termination_criteria_evaluation,
+            exception
+          )
+
+        {:stop, :exception}
     end
   end
 

--- a/lib/coloured_flow/runner/enactment/enactment_termination.ex
+++ b/lib/coloured_flow/runner/enactment/enactment_termination.ex
@@ -14,7 +14,7 @@ defmodule ColouredFlow.Runner.Enactment.EnactmentTermination do
   @spec check_explicit_termination(
           termination_criteria :: TerminationCriteria.t() | nil,
           markings :: [Marking.t()]
-        ) :: {:stop, :explicit} | :cont | {:error, [Exception.t()]}
+        ) :: {:stop, :explicit} | :cont | {:error, Exception.t()}
   def check_explicit_termination(termination_criteria, markings)
   def check_explicit_termination(nil, markings) when is_list(markings), do: :cont
 
@@ -27,9 +27,15 @@ defmodule ColouredFlow.Runner.Enactment.EnactmentTermination do
     markings = Map.new(markings, &{&1.place, &1.tokens})
 
     case ColouredFlow.Termination.should_terminate(markings_criteria, markings) do
-      {:ok, true} -> {:stop, :explicit}
-      {:ok, false} -> :cont
-      {:error, exceptions} -> {:error, exceptions}
+      {:ok, true} ->
+        {:stop, :explicit}
+
+      {:ok, false} ->
+        :cont
+
+      {:error, [exception | _rest]} ->
+        # only pop the closest exception
+        {:error, exception}
     end
   end
 

--- a/lib/coloured_flow/runner/enactment/enactment_termination.ex
+++ b/lib/coloured_flow/runner/enactment/enactment_termination.ex
@@ -26,7 +26,7 @@ defmodule ColouredFlow.Runner.Enactment.EnactmentTermination do
       when is_list(markings) do
     markings = Map.new(markings, &{&1.place, &1.tokens})
 
-    case ColouredFlow.Termination.should_terminate(markings_criteria, markings) do
+    case ColouredFlow.Runner.Termination.should_terminate(markings_criteria, markings) do
       {:ok, true} ->
         {:stop, :explicit}
 

--- a/lib/coloured_flow/runner/exception/exception.ex
+++ b/lib/coloured_flow/runner/exception/exception.ex
@@ -1,4 +1,4 @@
-defmodule ColouredFlow.Exception do
+defmodule ColouredFlow.Runner.Exception do
   @moduledoc """
   The enactment may be stopped due to an exception.
 

--- a/lib/coloured_flow/runner/storage/default.ex
+++ b/lib/coloured_flow/runner/storage/default.ex
@@ -70,7 +70,7 @@ defmodule ColouredFlow.Runner.Storage.Default do
     |> Stream.map(&Schemas.Occurrence.to_occurrence/1)
   end
 
-  exception_reasons = ColouredFlow.Exception.__reasons__()
+  exception_reasons = ColouredFlow.Runner.Exception.__reasons__()
 
   @impl ColouredFlow.Runner.Storage
   def exception_occurs(enactment_id, reason, exception)
@@ -101,7 +101,7 @@ defmodule ColouredFlow.Runner.Storage.Default do
     end
   end
 
-  termination_types = ColouredFlow.Termination.__types__()
+  termination_types = ColouredFlow.Runner.Termination.__types__()
   @impl ColouredFlow.Runner.Storage
   def terminate_enactment(enactment_id, type, final_markings, options)
       when type in unquote(termination_types) do

--- a/lib/coloured_flow/runner/storage/schemas/enactment_log.ex
+++ b/lib/coloured_flow/runner/storage/schemas/enactment_log.ex
@@ -43,4 +43,15 @@ defmodule ColouredFlow.Runner.Storage.Schemas.EnactmentLog do
 
     timestamps(updated_at: false)
   end
+
+  @spec build_termination(Enactment.t(), ColouredFlow.Termination.type(), String.t() | nil) ::
+          Ecto.Changeset.t(t())
+  def build_termination(enactment, type, message) do
+    %__MODULE__{enactment_id: enactment.id}
+    |> Ecto.Changeset.change(state: :terminated)
+    |> Ecto.Changeset.put_embed(:termination, %__MODULE__.Termination{
+      type: type,
+      message: message
+    })
+  end
 end

--- a/lib/coloured_flow/runner/storage/schemas/enactment_log.ex
+++ b/lib/coloured_flow/runner/storage/schemas/enactment_log.ex
@@ -12,8 +12,9 @@ defmodule ColouredFlow.Runner.Storage.Schemas.EnactmentLog do
 
     field :state, Enactment.state()
 
-    field :termination, %{type: ColouredFlow.Termination.type(), message: String.t() | nil},
-      enforce: false
+    field :termination,
+          %{type: ColouredFlow.Runner.Termination.type(), message: String.t() | nil},
+          enforce: false
 
     field :exception, %{type: String.t(), message: String.t(), original: String.t()},
       enforce: false
@@ -29,14 +30,14 @@ defmodule ColouredFlow.Runner.Storage.Schemas.EnactmentLog do
     embeds_one :termination, Termination, primary_key: false, on_replace: :delete do
       @moduledoc false
 
-      field :type, Ecto.Enum, values: ColouredFlow.Termination.__types__()
+      field :type, Ecto.Enum, values: ColouredFlow.Runner.Termination.__types__()
       field :message, :string
     end
 
     embeds_one :exception, Exception, primary_key: false, on_replace: :delete do
       @moduledoc false
 
-      field :reason, Ecto.Enum, values: ColouredFlow.Exception.__reasons__()
+      field :reason, Ecto.Enum, values: ColouredFlow.Runner.Exception.__reasons__()
       field :type, :string
       field :message, :string
       field :original, :string
@@ -45,7 +46,7 @@ defmodule ColouredFlow.Runner.Storage.Schemas.EnactmentLog do
     timestamps(updated_at: false)
   end
 
-  @spec build_termination(Enactment.t(), ColouredFlow.Termination.type(), String.t() | nil) ::
+  @spec build_termination(Enactment.t(), ColouredFlow.Runner.Termination.type(), String.t() | nil) ::
           Ecto.Changeset.t(t())
   def build_termination(enactment, type, message) do
     %__MODULE__{enactment_id: enactment.id}
@@ -56,7 +57,7 @@ defmodule ColouredFlow.Runner.Storage.Schemas.EnactmentLog do
     })
   end
 
-  @spec build_exception(Enactment.t(), ColouredFlow.Exception.reason(), Exception.t()) ::
+  @spec build_exception(Enactment.t(), ColouredFlow.Runner.Exception.reason(), Exception.t()) ::
           Ecto.Changeset.t(t())
   def build_exception(enactment, reason, exception) do
     %__MODULE__{enactment_id: enactment.id}

--- a/lib/coloured_flow/runner/storage/schemas/enactment_log.ex
+++ b/lib/coloured_flow/runner/storage/schemas/enactment_log.ex
@@ -36,6 +36,7 @@ defmodule ColouredFlow.Runner.Storage.Schemas.EnactmentLog do
     embeds_one :exception, Exception, primary_key: false, on_replace: :delete do
       @moduledoc false
 
+      field :reason, Ecto.Enum, values: ColouredFlow.Exception.__reasons__()
       field :type, :string
       field :message, :string
       field :original, :string
@@ -52,6 +53,19 @@ defmodule ColouredFlow.Runner.Storage.Schemas.EnactmentLog do
     |> Ecto.Changeset.put_embed(:termination, %__MODULE__.Termination{
       type: type,
       message: message
+    })
+  end
+
+  @spec build_exception(Enactment.t(), ColouredFlow.Exception.reason(), Exception.t()) ::
+          Ecto.Changeset.t(t())
+  def build_exception(enactment, reason, exception) do
+    %__MODULE__{enactment_id: enactment.id}
+    |> Ecto.Changeset.change(state: :exception)
+    |> Ecto.Changeset.put_embed(:exception, %__MODULE__.Exception{
+      reason: reason,
+      type: inspect(exception.__struct__),
+      message: Exception.message(exception),
+      original: inspect(exception)
     })
   end
 end

--- a/lib/coloured_flow/runner/storage/storage.ex
+++ b/lib/coloured_flow/runner/storage/storage.ex
@@ -47,7 +47,7 @@ defmodule ColouredFlow.Runner.Storage do
   @doc group: :enactment
   @callback exception_occurs(
               enactment_id(),
-              reason :: ColouredFlow.Exception.reason(),
+              reason :: ColouredFlow.Runner.Exception.reason(),
               exception :: Exception.t()
             ) :: :ok
 
@@ -130,7 +130,8 @@ defmodule ColouredFlow.Runner.Storage do
   end
 
   @doc false
-  @spec exception_occurs(enactment_id(), ColouredFlow.Exception.reason(), Exception.t()) :: :ok
+  @spec exception_occurs(enactment_id(), ColouredFlow.Runner.Exception.reason(), Exception.t()) ::
+          :ok
   def exception_occurs(enactment_id, reason, exception) do
     __storage__().exception_occurs(enactment_id, reason, exception)
   end
@@ -138,7 +139,7 @@ defmodule ColouredFlow.Runner.Storage do
   @doc false
   @spec terminate_enactment(
           enactment_id(),
-          type :: ColouredFlow.Termination.type(),
+          type :: ColouredFlow.Runner.Termination.type(),
           final_markings :: [Marking.t()],
           options :: [message: String.t()]
         ) :: :ok

--- a/lib/coloured_flow/runner/storage/storage.ex
+++ b/lib/coloured_flow/runner/storage/storage.ex
@@ -45,7 +45,11 @@ defmodule ColouredFlow.Runner.Storage do
   An exception occurred during the enactment, and the corresponding enactment will be stopped.
   """
   @doc group: :enactment
-  @callback exception_occurs(enactment_id(), Exception.t()) :: :ok
+  @callback exception_occurs(
+              enactment_id(),
+              reason :: ColouredFlow.Exception.reason(),
+              exception :: Exception.t()
+            ) :: :ok
 
   @doc """
   The enactment is terminated, and the corresponding enactment will be stopped.
@@ -123,6 +127,12 @@ defmodule ColouredFlow.Runner.Storage do
           Enumerable.t(Occurrence.t())
   def occurrences_stream(enactment_id, from) do
     __storage__().occurrences_stream(enactment_id, from)
+  end
+
+  @doc false
+  @spec exception_occurs(enactment_id(), ColouredFlow.Exception.reason(), Exception.t()) :: :ok
+  def exception_occurs(enactment_id, reason, exception) do
+    __storage__().exception_occurs(enactment_id, reason, exception)
   end
 
   @doc false

--- a/lib/coloured_flow/runner/storage/storage.ex
+++ b/lib/coloured_flow/runner/storage/storage.ex
@@ -42,6 +42,12 @@ defmodule ColouredFlow.Runner.Storage do
               Enumerable.t(Occurrence.t())
 
   @doc """
+  An exception occurred during the enactment, and the corresponding enactment will be stopped.
+  """
+  @doc group: :enactment
+  @callback exception_occurs(enactment_id(), Exception.t()) :: :ok
+
+  @doc """
   The enactment is terminated, and the corresponding enactment will be stopped.
   There are three types of termination:
 

--- a/lib/coloured_flow/runner/termination/termination.ex
+++ b/lib/coloured_flow/runner/termination/termination.ex
@@ -1,4 +1,4 @@
-defmodule ColouredFlow.Termination do
+defmodule ColouredFlow.Runner.Termination do
   @moduledoc """
   Termination criteria evaluation for the enactment.
   """

--- a/test/coloured_flow/termination/termination_test.exs
+++ b/test/coloured_flow/termination/termination_test.exs
@@ -1,4 +1,4 @@
-defmodule ColouredFlow.TerminationTest do
+defmodule ColouredFlow.Runner.TerminationTest do
   use ExUnit.Case, async: true
 
   import ColouredFlow.MultiSet, only: :sigils
@@ -7,7 +7,7 @@ defmodule ColouredFlow.TerminationTest do
   alias ColouredFlow.Definition.TerminationCriteria.Markings
   alias ColouredFlow.Expression.InvalidResult
 
-  alias ColouredFlow.Termination
+  alias ColouredFlow.Runner.Termination
 
   describe "should_terminate/2" do
     test "works" do


### PR DESCRIPTION
This pull request introduces a new feature to handle exceptions during enactment and updates related modules to support this functionality. The most significant changes include modifying the termination check to account for exceptions, implementing a new method to log exceptions, and adding tests to ensure the new functionality works as expected.

### Exception Handling Improvements:

* [`lib/coloured_flow/runner/enactment/enactment.ex`](diffhunk://#diff-c6c6445a6acc9c6e986f451f5fa98010b02c3c8facd7585657dec65b8679e9edL196-R197): Updated the `check_termination` function to include an `:exception` type and handle exceptions by logging them and stopping the enactment. [[1]](diffhunk://#diff-c6c6445a6acc9c6e986f451f5fa98010b02c3c8facd7585657dec65b8679e9edL196-R197) [[2]](diffhunk://#diff-c6c6445a6acc9c6e986f451f5fa98010b02c3c8facd7585657dec65b8679e9edL213-R219)
* [`lib/coloured_flow/runner/storage/default.ex`](diffhunk://#diff-735c4b914a79b457f2a1e9cdefe527b4f9c3fe2feead5f9582be17b73588be1eR73-R105): Implemented the `exception_occurs` function to log exceptions and update the enactment state to `:exception`. [[1]](diffhunk://#diff-735c4b914a79b457f2a1e9cdefe527b4f9c3fe2feead5f9582be17b73588be1eR73-R105) [[2]](diffhunk://#diff-735c4b914a79b457f2a1e9cdefe527b4f9c3fe2feead5f9582be17b73588be1eL88-R116) [[3]](diffhunk://#diff-735c4b914a79b457f2a1e9cdefe527b4f9c3fe2feead5f9582be17b73588be1eL103-R125)
* [`lib/coloured_flow/runner/storage/schemas/enactment_log.ex`](diffhunk://#diff-4c8fb09509d699480d9755a1453fba518ead8dabf297198e023d7867189bfc83R46-R67): Added `build_termination` and `build_exception` functions to create logs for termination and exceptions.
* [`lib/coloured_flow/runner/storage/storage.ex`](diffhunk://#diff-48526facacb001647f6bd3bda7e37431094df5f2b1d7950a49c7eb444b0a9322R44-R49): Added a new callback and function for `exception_occurs` to the storage module. [[1]](diffhunk://#diff-48526facacb001647f6bd3bda7e37431094df5f2b1d7950a49c7eb444b0a9322R44-R49) [[2]](diffhunk://#diff-48526facacb001647f6bd3bda7e37431094df5f2b1d7950a49c7eb444b0a9322R128-R133)

### Testing Enhancements:

* [`test/coloured_flow/runner/enactment/enactment_termination_test.exs`](diffhunk://#diff-ae5585857dd18e5c34eb745982e9fdd206399ada0dadd4e54e2b71a2bf67e7eeR202-R312): Added tests to verify that exceptions are correctly logged and the enactment is stopped when exceptions occur at different stages.