### PR TITLE
feat: terminate the enactment forcibly

### DIFF
--- a/lib/coloured_flow/runner/enactment/enactment.ex
+++ b/lib/coloured_flow/runner/enactment/enactment.ex
@@ -234,6 +234,21 @@ defmodule ColouredFlow.Runner.Enactment do
   end
 
   @impl GenServer
+  def handle_call({:terminate, options}, _from, %__MODULE__{} = state) when is_list(options) do
+    :ok =
+      Storage.terminate_enactment(
+        state.enactment_id,
+        :force,
+        to_list(state.markings),
+        options
+      )
+
+    message = Keyword.get(options, :message)
+    emit_event(:terminate, state, %{termination_type: :force, termination_message: message})
+
+    {:stop, :normal, :ok, state}
+  end
+
   def handle_call({:allocate_workitems, workitem_ids}, _from, %__MODULE__{} = state)
       when is_list(workitem_ids) do
     :allocate_workitems

--- a/lib/coloured_flow/runner/enactment/supervisor.ex
+++ b/lib/coloured_flow/runner/enactment/supervisor.ex
@@ -6,7 +6,10 @@ defmodule ColouredFlow.Runner.Enactment.Supervisor do
   use DynamicSupervisor
 
   alias ColouredFlow.Runner.Enactment
+  alias ColouredFlow.Runner.Enactment.Registry
   alias ColouredFlow.Runner.Storage
+
+  @typep enactment_id() :: Storage.enactment_id()
 
   # credo:disable-for-next-line JetCredo.Checks.ExplicitAnyType
   @spec start_link(term()) :: Supervisor.on_start()
@@ -19,17 +22,24 @@ defmodule ColouredFlow.Runner.Enactment.Supervisor do
     DynamicSupervisor.init(strategy: :one_for_one)
   end
 
-  @spec start_enactment(enactment_id :: Storage.enactment_id()) ::
-          DynamicSupervisor.on_start_child()
+  @spec start_enactment(enactment_id()) :: DynamicSupervisor.on_start_child()
   def start_enactment(enactment_id) do
     enactment_spec = {Enactment, enactment_id: enactment_id}
-
-    # TODO: handle enactment not found
 
     case DynamicSupervisor.start_child(__MODULE__, enactment_spec) do
       {:ok, _pid} = ok -> ok
       {:error, {:already_started, pid}} -> {:ok, pid}
       otherwise -> otherwise
     end
+  end
+
+  @doc """
+  Terminate an enactment forcibly.
+  """
+  @spec terminate_enactment(enactment_id(), options :: [message: String.t()]) :: :ok
+  def terminate_enactment(enactment_id, options \\ []) do
+    enactment = Registry.via_name({:enactment, enactment_id})
+
+    GenServer.call(enactment, {:terminate, options})
   end
 end

--- a/lib/coloured_flow/runner/runner.ex
+++ b/lib/coloured_flow/runner/runner.ex
@@ -7,6 +7,7 @@ defmodule ColouredFlow.Runner do
   alias ColouredFlow.Runner.Enactment.WorkitemTransition
 
   defdelegate start_enactment(enactment_id), to: EnactmentSupervisor
+  defdelegate terminate_enactment(enactment_id, options \\ []), to: EnactmentSupervisor
 
   defdelegate allocate_workitem(enactment_id, workitem_id), to: WorkitemTransition
   defdelegate allocate_workitems(enactment_id, workitem_ids), to: WorkitemTransition

--- a/lib/coloured_flow/runner/storage/default.ex
+++ b/lib/coloured_flow/runner/storage/default.ex
@@ -117,8 +117,7 @@ defmodule ColouredFlow.Runner.Storage.Default do
       |> Ecto.Changeset.put_embed(:data, data)
     end)
     |> Ecto.Multi.insert(:insert_enactment_log, fn %{enactment: enactment} ->
-      message = Keyword.get(options, :message)
-      Schemas.EnactmentLog.build_termination(enactment, type, message)
+      Schemas.EnactmentLog.build_termination(enactment, type, options)
     end)
     |> Repo.transaction()
     |> case do

--- a/lib/coloured_flow/runner/storage/schemas/enactment_log.ex
+++ b/lib/coloured_flow/runner/storage/schemas/enactment_log.ex
@@ -48,14 +48,17 @@ defmodule ColouredFlow.Runner.Storage.Schemas.EnactmentLog do
     timestamps(updated_at: false)
   end
 
-  @spec build_termination(Enactment.t(), ColouredFlow.Runner.Termination.type(), String.t() | nil) ::
-          Ecto.Changeset.t(t())
-  def build_termination(enactment, type, message) do
+  @spec build_termination(
+          Enactment.t(),
+          ColouredFlow.Runner.Termination.type(),
+          options :: [message: String.t()]
+        ) :: Ecto.Changeset.t(t())
+  def build_termination(enactment, type, options) do
     %__MODULE__{enactment_id: enactment.id}
     |> Ecto.Changeset.change(state: :terminated)
     |> Ecto.Changeset.put_embed(:termination, %__MODULE__.Termination{
       type: type,
-      message: message
+      message: Keyword.get(options, :message)
     })
   end
 

--- a/lib/coloured_flow/runner/telemetry.ex
+++ b/lib/coloured_flow/runner/telemetry.ex
@@ -12,11 +12,10 @@ defmodule ColouredFlow.Runner.Telemetry do
 
   All enactment events share the same measurements and metadata, but their metadata are different.
 
-  | event        | measurements                      | metadata                                                               |
-  | ------------ | --------------------------------- | ---------------------------------------------------------------------- |
-  | `:start`     | `:system_time`, `:monotonic_time` | `:enactment_id`, `:enactment_state`                                    |
-  | `:terminate` | `:system_time`, `:monotonic_time` | `:enactment_id`, `:enactment_state`, `termination_type`                |
-  | `:exception` | `:system_time`, `:monotonic_time` | `:enactment_id`, `:enactment_state`, `:exception_reason`, `:exception` |
+  | ------------ | --------------------------------- | ------------------------------------------------------------------------------- |
+  | `:start`     | `:system_time`, `:monotonic_time` | `:enactment_id`, `:enactment_state`                                             |
+  | `:terminate` | `:system_time`, `:monotonic_time` | `:enactment_id`, `:enactment_state`, `termination_type`, `:termination_message` |
+  | `:exception` | `:system_time`, `:monotonic_time` | `:enactment_id`, `:enactment_state`, `:exception_reason`, `:exception`          |
 
   #### Metadata
 
@@ -24,6 +23,7 @@ defmodule ColouredFlow.Runner.Telemetry do
   - `:enactment_state` — The current state of the enactment
   (`t:ColouredFlow.Runner.Enactment.state/0`).
   - `:termination_type` — The type of termination (`:explicit`, `:implicit` or `:force`).
+  - `:termination_message` — The termination message.
   - `:exception_reason` — The reason for the exception. (`t:ColouredFlow.Runner.Exception.reason/0`).
   - `:exception` — The exception that was raised.
 

--- a/lib/coloured_flow/runner/telemetry/default_logger.ex
+++ b/lib/coloured_flow/runner/telemetry/default_logger.ex
@@ -25,7 +25,8 @@ defmodule ColouredFlow.Runner.Telemetry.DefaultLogger do
             %{
               event: "enactment:terminate",
               system_time: convert_system_time(measurements.system_time),
-              termination_type: metadata.termination_type
+              termination_type: metadata.termination_type,
+              termination_message: Map.get(metadata, :termination_message)
             }
 
           :exception ->
@@ -167,6 +168,7 @@ defmodule ColouredFlow.Runner.Telemetry.DefaultLogger do
         enactment_workitems: {:list, workitem_spec()},
         system_time: system_time_spec(),
         termination_type: :atom,
+        termination_message: :string,
         exception_reason: :atom,
         error: :string
       ]

--- a/test/support/runner_helpers.ex
+++ b/test/support/runner_helpers.ex
@@ -213,6 +213,8 @@ defmodule ColouredFlow.RunnerHelpers do
 
     receive do
       {:DOWN, ^ref, :process, ^enactment_server, ^reason} -> :ok
+      # when the enactment server was stopped early
+      {:DOWN, ^ref, :process, ^enactment_server, :noproc} -> :ok
     after
       500 ->
         ExUnit.Assertions.flunk("Enactment server is expected to stop, but it's still running")


### PR DESCRIPTION
This pull request introduces a new feature to forcibly terminate enactments and includes various related changes across multiple files. The most important changes include adding the new termination functionality, updating the storage and logging mechanisms to handle termination messages, and enhancing the telemetry and tests to support this new feature.

### New Termination Functionality:

* [`lib/coloured_flow/runner/enactment/enactment.ex`](diffhunk://#diff-c6c6445a6acc9c6e986f451f5fa98010b02c3c8facd7585657dec65b8679e9edR237-R251): Added a `handle_call` function to handle the `:terminate` message and forcefully terminate enactments.
* [`lib/coloured_flow/runner/enactment/supervisor.ex`](diffhunk://#diff-f4943dd7020675622b3b83a926fff38af499078f28448b0cb5b97d05b51c4336L22-R44): Added a `terminate_enactment` function to the supervisor, which sends a termination message to the enactment process. [[1]](diffhunk://#diff-f4943dd7020675622b3b83a926fff38af499078f28448b0cb5b97d05b51c4336L22-R44) [[2]](diffhunk://#diff-f4943dd7020675622b3b83a926fff38af499078f28448b0cb5b97d05b51c4336R9-R13)
* [`lib/coloured_flow/runner/runner.ex`](diffhunk://#diff-4829dd6ad245a04d1fa975e5bc9cf2325174928f5a9d1553a58ba4423ecf6d47R10): Added a `terminate_enactment` function to delegate termination calls to the enactment supervisor.

### Storage and Logging Updates:

* [`lib/coloured_flow/runner/storage/default.ex`](diffhunk://#diff-735c4b914a79b457f2a1e9cdefe527b4f9c3fe2feead5f9582be17b73588be1eL120-R120): Updated the `insert_enactment_log` function to handle termination options.
* [`lib/coloured_flow/runner/storage/schemas/enactment_log.ex`](diffhunk://#diff-4c8fb09509d699480d9755a1453fba518ead8dabf297198e023d7867189bfc83L51-R61): Modified the `build_termination` function to accept a list of options instead of a single message.

### Telemetry Enhancements:

* [`lib/coloured_flow/runner/telemetry.ex`](diffhunk://#diff-869cea2dde1ea770ac179d79ada953cb21aded8e8c4bb66d8400cfae50afd40eL15-R17): Updated the telemetry metadata to include `:termination_message` for termination events. [[1]](diffhunk://#diff-869cea2dde1ea770ac179d79ada953cb21aded8e8c4bb66d8400cfae50afd40eL15-R17) [[2]](diffhunk://#diff-869cea2dde1ea770ac179d79ada953cb21aded8e8c4bb66d8400cfae50afd40eR26)
* [`lib/coloured_flow/runner/telemetry/default_logger.ex`](diffhunk://#diff-2db2c01ceac3e5f83e3b46c68715a43752979b2fc837ef4f04ec2da6ebd42641L28-R29): Modified the logger to include `termination_message` in the termination event logs. [[1]](diffhunk://#diff-2db2c01ceac3e5f83e3b46c68715a43752979b2fc837ef4f04ec2da6ebd42641L28-R29) [[2]](diffhunk://#diff-2db2c01ceac3e5f83e3b46c68715a43752979b2fc837ef4f04ec2da6ebd42641R171)

### Tests:

* [`test/coloured_flow/runner/enactment/enactment_termination_and_exception_test.exs`](diffhunk://#diff-8b5ce24dea9e87e08ca36a8ddfb4a87568fba20e2170446bef9cfbff237d0038R202-R231): Added tests to verify the new forced termination functionality.
* [`test/support/runner_helpers.ex`](diffhunk://#diff-fc099f1c41600a6c263f472de03ab5fe9f3208230d75572c8efe515a5d728082R216-R217): Updated helper functions to handle early termination of enactment servers.