### PR TITLE
feat: add arc validator

### DIFF
--- a/lib/coloured_flow/definition/arc.ex
+++ b/lib/coloured_flow/definition/arc.ex
@@ -1,6 +1,11 @@
 defmodule ColouredFlow.Definition.Arc do
   @moduledoc """
   An arc is a directed connection between a transition and a place.
+
+  > #### TIP {: .tip}
+  > Note that the terms `incoming` and `outgoing` are relevant to the transition.
+  > If the arc is linked from a place such that the orientation is `:p_to_t`,
+  > it is considered an incoming arc; otherwise, it is considered an outgoing arc.
   """
 
   use TypedStructor

--- a/lib/coloured_flow/validators/definition/arc_validator.ex
+++ b/lib/coloured_flow/validators/definition/arc_validator.ex
@@ -1,0 +1,109 @@
+defmodule ColouredFlow.Validators.Definition.ArcValidator do
+  @moduledoc """
+  This validator is used to validate arcs of the transition.
+
+  A valid arc must satisfy the following properties:
+  1. vars at incoming arcs must be either variables or constants.
+  2. vars at outgoing arcs must be either variables or constants.
+  If they are variables, they must be among those bound at the
+  incoming arcs or be the outputs of the transition action.
+  """
+
+  alias ColouredFlow.Definition.Arc
+  alias ColouredFlow.Definition.ColouredPetriNet
+  alias ColouredFlow.Validators.Exceptions.InvalidArcError
+
+  @spec validate(ColouredPetriNet.t()) ::
+          {:ok, ColouredPetriNet.t()} | {:error, InvalidArcError.t()}
+  def validate(%ColouredPetriNet{} = cpnet) do
+    vars_and_consts = build_vars_and_consts(cpnet)
+
+    cpnet.arcs
+    |> Enum.find_value(fn %Arc{} = arc ->
+      case validate_arc(arc, vars_and_consts, cpnet) do
+        :ok -> nil
+        {:error, reason} -> reason
+      end
+    end)
+    |> case do
+      nil -> {:ok, cpnet}
+      exception -> {:error, exception}
+    end
+  end
+
+  defp validate_arc(%Arc{orientation: :p_to_t} = arc, {vars, consts}, %ColouredPetriNet{}) do
+    arc.expression.vars
+    |> MapSet.new()
+    |> MapSet.difference(vars)
+    |> MapSet.difference(consts)
+    |> MapSet.to_list()
+    |> case do
+      [] ->
+        :ok
+
+      diff ->
+        label = if arc.label, do: "(#{arc.label})"
+
+        {
+          :error,
+          InvalidArcError.exception(
+            reason: :incoming_unbound_vars,
+            message: """
+            Found unbound variables at the incoming arc #{label}: #{inspect(diff)}.
+            variables: #{inspect(MapSet.to_list(vars))}
+            constants: #{inspect(MapSet.to_list(consts))}
+            arc: #{inspect(arc)}
+            """
+          )
+        }
+    end
+  end
+
+  defp validate_arc(
+         %Arc{orientation: :t_to_p} = arc,
+         {_vars, consts},
+         %ColouredPetriNet{} = cpnet
+       ) do
+    bound_vars =
+      cpnet.arcs
+      |> Enum.flat_map(fn
+        %Arc{orientation: :p_to_t} = arc -> arc.expression.vars
+        %Arc{} -> []
+      end)
+      |> MapSet.new()
+
+    vars_and_consts = MapSet.union(bound_vars, consts)
+
+    arc.expression.vars
+    |> MapSet.new()
+    |> MapSet.difference(vars_and_consts)
+    |> MapSet.to_list()
+    |> case do
+      [] ->
+        :ok
+
+      diff ->
+        label = if arc.label, do: "(#{arc.label})"
+
+        {
+          :error,
+          InvalidArcError.exception(
+            reason: :outgoing_unbound_vars,
+            message: """
+            Found unbound variables at the outgoing arc #{label}: #{inspect(diff)}.
+            variables from incoming-arcs : #{inspect(MapSet.to_list(bound_vars))}
+            constants: #{inspect(MapSet.to_list(consts))}
+            arc: #{inspect(arc)}
+            """
+          )
+        }
+    end
+  end
+
+  defp build_vars_and_consts(%ColouredPetriNet{} = cpnet) do
+    {
+      MapSet.new(cpnet.variables, & &1.name),
+      MapSet.new(cpnet.constants, & &1.name)
+    }
+  end
+end

--- a/lib/coloured_flow/validators/definition/guard_validator.ex
+++ b/lib/coloured_flow/validators/definition/guard_validator.ex
@@ -45,22 +45,26 @@ defmodule ColouredFlow.Validators.Definition.GuardValidator do
 
     vars_and_consts = MapSet.union(bound_vars, constants)
 
-    diff = MapSet.difference(MapSet.new(guard.vars), vars_and_consts)
+    guard.vars
+    |> MapSet.new()
+    |> MapSet.difference(vars_and_consts)
+    |> MapSet.to_list()
+    |> case do
+      [] ->
+        :ok
 
-    if diff === MapSet.new() do
-      :ok
-    else
-      {
-        :error,
-        InvalidGuardError.exception(
-          reason: :unbound_vars,
-          message: """
-          Found unbound variables: #{inspect(MapSet.to_list(diff))},
-          variables from incoming-arcs are #{inspect(MapSet.to_list(bound_vars))},
-          constants are #{inspect(MapSet.to_list(constants))}.
-          """
-        )
-      }
+      vars ->
+        {
+          :error,
+          InvalidGuardError.exception(
+            reason: :unbound_vars,
+            message: """
+            Found unbound variables: #{inspect(vars)},
+            variables from incoming-arcs are #{inspect(MapSet.to_list(bound_vars))},
+            constants are #{inspect(MapSet.to_list(constants))}.
+            """
+          )
+        }
     end
   end
 end

--- a/lib/coloured_flow/validators/exceptions/invalid_arc_error.ex
+++ b/lib/coloured_flow/validators/exceptions/invalid_arc_error.ex
@@ -1,0 +1,28 @@
+defmodule ColouredFlow.Validators.Exceptions.InvalidArcError do
+  @moduledoc """
+  This exception is raised when an arc is invalid:
+  1. 
+  """
+
+  use TypedStructor
+
+  @type reason() :: :incoming_unbound_vars | :outgoing_unbound_vars
+
+  typed_structor definer: :defexception, enforce: true do
+    field :reason, reason()
+    field :message, String.t()
+  end
+
+  @impl Exception
+  def exception(arguments) do
+    struct!(__MODULE__, arguments)
+  end
+
+  @impl Exception
+  def message(%__MODULE__{} = exception) do
+    """
+    The Arc is invalid, due to #{inspect(exception.reason)}.
+    #{exception.message}
+    """
+  end
+end

--- a/lib/coloured_flow/validators/validators.ex
+++ b/lib/coloured_flow/validators/validators.ex
@@ -5,6 +5,7 @@ defmodule ColouredFlow.Validators do
 
   alias ColouredFlow.Definition.ColouredPetriNet
 
+  alias ColouredFlow.Validators.Definition.ArcValidator
   alias ColouredFlow.Validators.Definition.ColourSetValidator
   alias ColouredFlow.Validators.Definition.ConstantsValidator
   alias ColouredFlow.Validators.Definition.GuardValidator
@@ -14,16 +15,19 @@ defmodule ColouredFlow.Validators do
 
   @spec run(ColouredPetriNet.t()) :: {:ok, ColouredPetriNet.t()} | {:error, Exception.t()}
   def run(%ColouredPetriNet{} = cpnet) do
+    # credo:disable-for-next-line Credo.Check.Refactor.RedundantWithClauseResult
     with(
       {:ok, cpnet} <- StructureValidator.validate(cpnet),
       {:ok, cpnet} <- UniqueNameValidator.validate(cpnet),
       {:ok, cpnet} <- ColourSetValidator.validate(cpnet),
       {:ok, constants} <- ConstantsValidator.validate(cpnet.constants, cpnet),
       cpnet = %ColouredPetriNet{cpnet | constants: constants},
-      {:ok, variables} <- VariablesValidator.validate(cpnet.variables, cpnet)
+      {:ok, variables} <- VariablesValidator.validate(cpnet.variables, cpnet),
+      cpnet = %ColouredPetriNet{cpnet | variables: variables},
+      {:ok, cpnet} <- ArcValidator.validate(cpnet),
+      {:ok, cpnet} <- GuardValidator.validate(cpnet)
     ) do
-      cpnet = %ColouredPetriNet{cpnet | variables: variables}
-      GuardValidator.validate(cpnet)
+      {:ok, cpnet}
     end
   end
 end

--- a/test/coloured_flow/validators/definition/arc_validator_test.exs
+++ b/test/coloured_flow/validators/definition/arc_validator_test.exs
@@ -1,0 +1,92 @@
+defmodule ColouredFlow.Validators.Definition.ArcValidatorTest do
+  use ExUnit.Case, async: true
+
+  use ColouredFlow.DefinitionHelpers
+  import ColouredFlow.Notation
+
+  alias ColouredFlow.Validators.Definition.ArcValidator
+  alias ColouredFlow.Validators.Exceptions.InvalidArcError
+
+  setup do
+    cpnet = %ColouredPetriNet{
+      colour_sets: [
+        colset(int() :: integer())
+      ],
+      places: [
+        %Place{name: "input", colour_set: :int},
+        %Place{name: "output", colour_set: :int}
+      ],
+      transitions: [
+        build_transition!(name: "pass_through", guard: "true")
+      ],
+      arcs: [
+        build_arc!(
+          label: "incoming-arc",
+          place: "input",
+          transition: "pass_through",
+          orientation: :p_to_t,
+          expression: "bind {n, x}"
+        ),
+        build_arc!(
+          place: "output",
+          transition: "pass_through",
+          orientation: :t_to_p,
+          expression: "{1, x}"
+        )
+      ],
+      variables: [
+        %Variable{name: :x, colour_set: :int}
+      ],
+      constants: [
+        val(n :: int() = 2)
+      ]
+    }
+
+    [cpnet: cpnet]
+  end
+
+  test "works", %{cpnet: cpnet} do
+    assert {:ok, _cpnet} = ArcValidator.validate(cpnet)
+  end
+
+  test "incoming_unbound_vars error", %{cpnet: cpnet} do
+    %{arcs: [_incoming_arc, outgoing_arc]} = cpnet
+
+    cpnet = %ColouredPetriNet{
+      cpnet
+      | arcs: [
+          build_arc!(
+            label: "incoming-arc",
+            place: "input",
+            transition: "pass_through",
+            orientation: :p_to_t,
+            expression: "bind {m, x}"
+          ),
+          outgoing_arc
+        ]
+    }
+
+    assert {:error, %InvalidArcError{reason: :incoming_unbound_vars}} =
+             ArcValidator.validate(cpnet)
+  end
+
+  test "outgoing_unbound_vars error", %{cpnet: cpnet} do
+    %{arcs: [incoming_arc, _outgoing_arc]} = cpnet
+
+    cpnet = %ColouredPetriNet{
+      cpnet
+      | arcs: [
+          incoming_arc,
+          build_arc!(
+            place: "output",
+            transition: "pass_through",
+            orientation: :t_to_p,
+            expression: "{m, x}"
+          )
+        ]
+    }
+
+    assert {:error, %InvalidArcError{reason: :outgoing_unbound_vars}} =
+             ArcValidator.validate(cpnet)
+  end
+end

--- a/test/coloured_flow/validators/exceptions_test.exs
+++ b/test/coloured_flow/validators/exceptions_test.exs
@@ -56,4 +56,14 @@ defmodule ColouredFlow.Validators.ExceptionsTest do
 
     assert Exception.message(exception) =~ ~r/unbound_vars/
   end
+
+  test "InvalidArcError" do
+    exception =
+      Exceptions.InvalidArcError.exception(
+        reason: :incoming_unbound_vars,
+        message: "invalid"
+      )
+
+    assert Exception.message(exception) =~ ~r/incoming_unbound_vars/
+  end
 end


### PR DESCRIPTION
This pull request introduces significant changes to the `ColouredFlow` project, primarily focusing on the validation of arcs within the system. The most important changes include the addition of a new `ArcValidator` module, updates to the `GuardValidator`, and the introduction of a new exception for invalid arcs.

### Validation Enhancements:

* **New Arc Validator**:
  - Added `ColouredFlow.Validators.Definition.ArcValidator` to validate arcs of the transition, ensuring variables at incoming and outgoing arcs are either variables or constants.
  - Introduced tests for the new `ArcValidator` to verify its functionality and error handling.

* **Guard Validator Update**:
  - Refactored the `GuardValidator` to use a more functional approach for checking unbound variables, improving readability and maintainability.

### Exception Handling:

* **New Invalid Arc Error**:
  - Created `ColouredFlow.Validators.Exceptions.InvalidArcError` to handle validation errors specific to arcs, with detailed error messages for incoming and outgoing unbound variables.
  - Added tests to ensure the new `InvalidArcError` exception works correctly.

### Documentation and Miscellaneous:

* **Arc Module Documentation**:
  - Enhanced the documentation in `ColouredFlow.Definition.Arc` with tips on the relevance of `incoming` and `outgoing` terms related to transitions.

* **Validator Integration**:
  - Updated the main `ColouredFlow.Validators` module to include the new `ArcValidator` in the validation pipeline. [[1]](diffhunk://#diff-0ff6c7a5058362d600640321d99e7ece6448aeb9752c051f476df279fed536d7R8) [[2]](diffhunk://#diff-0ff6c7a5058362d600640321d99e7ece6448aeb9752c051f476df279fed536d7R18-R30)