### PR TITLE
feat: workitem log

### DIFF
--- a/lib/coloured_flow/runner/storage/migrations/v1.ex
+++ b/lib/coloured_flow/runner/storage/migrations/v1.ex
@@ -1,0 +1,44 @@
+defmodule ColouredFlow.Runner.Migrations.V1 do
+  @moduledoc false
+
+  use Ecto.Migration
+
+  @prefix "coloured_flow"
+
+  @table_options [
+    primary_key: false
+  ]
+
+  @timestamps_opts [type: :utc_datetime_usec]
+
+  @spec change(prefix: String.t()) :: :ok
+  def change(opts \\ []) do
+    prefix = Keyword.get(opts, :prefix, @prefix)
+    table_options = Keyword.put(@table_options, :prefix, prefix)
+    index_options = [prefix: prefix]
+
+    create table("workitem_logs", table_options) do
+      add :id, :binary_id, primary_key: true
+
+      add :workitem_id, references("workitems", type: :binary_id, on_delete: :delete_all),
+        null: false
+
+      add :enactment_id, references("enactments", type: :binary_id, on_delete: :delete_all),
+        null: false
+
+      add :from_state, :string, null: false
+      add :to_state, :string, null: false
+      add :action, :string, null: false
+
+      timestamps([{:updated_at, false} | @timestamps_opts])
+    end
+
+    # Index for querying logs by workitem_id, ordered by insertion time
+    create index("workitem_logs", [:workitem_id, :inserted_at], index_options)
+
+    # Index for querying logs by enactment_id, ordered by insertion time
+    create index("workitem_logs", [:enactment_id, :inserted_at], index_options)
+
+    :ok
+  end
+end

--- a/lib/coloured_flow/runner/storage/migrations/v1.ex
+++ b/lib/coloured_flow/runner/storage/migrations/v1.ex
@@ -33,9 +33,6 @@ defmodule ColouredFlow.Runner.Migrations.V1 do
       timestamps([{:updated_at, false} | @timestamps_opts])
     end
 
-    # Index for querying logs by workitem_id, ordered by insertion time
-    create index("workitem_logs", [:workitem_id, :inserted_at], index_options)
-
     # Index for querying logs by enactment_id, ordered by insertion time
     create index("workitem_logs", [:enactment_id, :inserted_at], index_options)
 

--- a/lib/coloured_flow/runner/storage/schemas/workitem_log.ex
+++ b/lib/coloured_flow/runner/storage/schemas/workitem_log.ex
@@ -15,9 +15,9 @@ defmodule ColouredFlow.Runner.Storage.Schemas.WorkitemLog do
     field :workitem, Types.association(Workitem.t())
     field :enactment_id, Types.id()
     field :enactment, Types.association(Enactment.t())
-    field :from_state, ColouredWorkitem.state()
+    field :from_state, :initial | ColouredWorkitem.state()
     field :to_state, ColouredWorkitem.state()
-    field :action, ColouredWorkitem.transition_action()
+    field :action, :produce | ColouredWorkitem.transition_action()
 
     field :inserted_at, DateTime.t()
   end
@@ -26,11 +26,13 @@ defmodule ColouredFlow.Runner.Storage.Schemas.WorkitemLog do
     belongs_to :workitem, Workitem
     belongs_to :enactment, Enactment
 
-    field :from_state, Ecto.Enum, values: ColouredWorkitem.__states__()
+    field :from_state, Ecto.Enum, values: [:initial | ColouredWorkitem.__states__()]
     field :to_state, Ecto.Enum, values: ColouredWorkitem.__states__()
 
     field :action, Ecto.Enum,
-      values: ColouredWorkitem.__transitions__() |> Enum.map(&elem(&1, 1)) |> Enum.uniq()
+      values: [
+        :produce | ColouredWorkitem.__transitions__() |> Enum.map(&elem(&1, 1)) |> Enum.uniq()
+      ]
 
     timestamps(updated_at: false)
   end

--- a/lib/coloured_flow/runner/storage/schemas/workitem_log.ex
+++ b/lib/coloured_flow/runner/storage/schemas/workitem_log.ex
@@ -1,0 +1,37 @@
+defmodule ColouredFlow.Runner.Storage.Schemas.WorkitemLog do
+  @moduledoc """
+  The schema for the workitem log in the coloured_flow runner.
+  """
+
+  use ColouredFlow.Runner.Storage.Schemas.Schema
+
+  alias ColouredFlow.Runner.Enactment.Workitem, as: ColouredWorkitem
+  alias ColouredFlow.Runner.Storage.Schemas.Enactment
+  alias ColouredFlow.Runner.Storage.Schemas.Workitem
+
+  typed_structor define_struct: false, enforce: true do
+    field :id, Types.id()
+    field :workitem_id, Types.id()
+    field :workitem, Types.association(Workitem.t())
+    field :enactment_id, Types.id()
+    field :enactment, Types.association(Enactment.t())
+    field :from_state, ColouredWorkitem.state()
+    field :to_state, ColouredWorkitem.state()
+    field :action, ColouredWorkitem.transition_action()
+
+    field :inserted_at, DateTime.t()
+  end
+
+  schema "workitem_logs" do
+    belongs_to :workitem, Workitem
+    belongs_to :enactment, Enactment
+
+    field :from_state, Ecto.Enum, values: ColouredWorkitem.__states__()
+    field :to_state, Ecto.Enum, values: ColouredWorkitem.__states__()
+
+    field :action, Ecto.Enum,
+      values: ColouredWorkitem.__transitions__() |> Enum.map(&elem(&1, 1)) |> Enum.uniq()
+
+    timestamps(updated_at: false)
+  end
+end

--- a/test/coloured_flow/runner/storage/schemas/workitem_log_test.exs
+++ b/test/coloured_flow/runner/storage/schemas/workitem_log_test.exs
@@ -1,0 +1,79 @@
+defmodule ColouredFlow.Runner.Storage.Schemas.WorkitemLogTest do
+  use ColouredFlow.RepoCase
+
+  import Ecto.Query
+
+  alias ColouredFlow.Runner.Enactment.Workitem, as: ColouredWorkitem
+  alias ColouredFlow.Runner.Storage.Default
+  alias ColouredFlow.Runner.Storage.Repo
+  alias ColouredFlow.Runner.Storage.Schemas.Workitem
+
+  test "workitem transition creates log entry" do
+    {[workitem], [coloured_workitem]} = insert_workitems({:enabled, :started}, 1)
+
+    :ok = Default.transition_workitem(coloured_workitem, action: :start)
+
+    log =
+      Schemas.WorkitemLog
+      |> where([l], l.workitem_id == ^coloured_workitem.id)
+      |> Repo.one!()
+
+    assert log.workitem_id == workitem.id
+    assert log.enactment_id == workitem.enactment_id
+    assert log.from_state == :enabled
+    assert log.to_state == :started
+    assert log.action == :start
+  end
+
+  test "batch workitem transition creates log entries" do
+    {workitems, coloured_workitems} = insert_workitems({:enabled, :started}, 3)
+
+    :ok = Default.transition_workitems(coloured_workitems, action: :start)
+
+    logs =
+      Schemas.WorkitemLog
+      |> where([l], l.workitem_id in ^Enum.map(coloured_workitems, & &1.id))
+      |> Repo.all()
+
+    assert length(logs) == length(workitems)
+
+    Enum.each(logs, fn log ->
+      assert log.from_state == :enabled
+      assert log.to_state == :started
+      assert log.action == :start
+    end)
+  end
+
+  for {from_state, action, to_state} <- ColouredWorkitem.__transitions__() do
+    test "#{inspect({from_state, action, to_state})} creates log entries" do
+      {workitems, coloured_workitems} =
+        insert_workitems({unquote(from_state), unquote(to_state)}, 3)
+
+      :ok = Default.transition_workitems(coloured_workitems, action: unquote(action))
+
+      logs =
+        Schemas.WorkitemLog
+        |> where([l], l.workitem_id in ^Enum.map(coloured_workitems, & &1.id))
+        |> Repo.all()
+
+      assert length(logs) == length(workitems)
+
+      Enum.each(logs, fn log ->
+        assert log.from_state == unquote(from_state)
+        assert log.to_state == unquote(to_state)
+        assert log.action == unquote(action)
+      end)
+    end
+  end
+
+  defp insert_workitems({from_state, to_state}, count) do
+    workitems = Enum.map(1..count, fn _index -> insert(:workitem, state: from_state) end)
+
+    coloured_workitems =
+      Enum.map(workitems, fn workitem ->
+        workitem |> Workitem.to_workitem() |> Map.put(:state, to_state)
+      end)
+
+    {workitems, coloured_workitems}
+  end
+end

--- a/test/support/repo.ex
+++ b/test/support/repo.ex
@@ -7,7 +7,10 @@ defmodule ColouredFlow.TestRepo do
   def migrate do
     Ecto.Migrator.run(
       __MODULE__,
-      [{0, ColouredFlow.Runner.Migrations.V0}],
+      [
+        {0, ColouredFlow.Runner.Migrations.V0},
+        {1, ColouredFlow.Runner.Migrations.V1}
+      ],
       :up,
       all: true
     )


### PR DESCRIPTION
This pull request introduces a logging mechanism for workitem state transitions in the `ColouredFlow` system. It includes schema changes, migration scripts, updates to the storage logic, and corresponding tests to ensure the logging functionality works as expected.

### Logging Mechanism for Workitem Transitions

* **Added `workitem_logs` schema**: Introduced the `Schemas.WorkitemLog` module to represent a log entry for workitem state transitions. It tracks fields such as `from_state`, `to_state`, `action`, and timestamps. (`lib/coloured_flow/runner/storage/schemas/workitem_log.ex`)

* **Created migration for `workitem_logs` table**: Added a migration script to define the `workitem_logs` table with necessary fields, foreign key constraints, and indexes for efficient querying. (`lib/coloured_flow/runner/storage/migrations/v1.ex`)

### Updates to Storage Logic

* **Modified `produce_workitems` function**: Updated the function to log the creation of workitems by inserting entries into the `workitem_logs` table as part of a database transaction. (`lib/coloured_flow/runner/storage/default.ex`) [[1]](diffhunk://#diff-735c4b914a79b457f2a1e9cdefe527b4f9c3fe2feead5f9582be17b73588be1eL148-R155) [[2]](diffhunk://#diff-735c4b914a79b457f2a1e9cdefe527b4f9c3fe2feead5f9582be17b73588be1eL158-R199)

* **Enhanced `transition_workitems` function**: Extended the function to log state transitions of workitems, ensuring logs are created for batch transitions as well. (`lib/coloured_flow/runner/storage/default.ex`)

### Test Coverage for Logging

* **Added tests for `workitem_logs`**: Implemented tests to verify that log entries are correctly created during workitem production and state transitions, including batch transitions. (`test/coloured_flow/runner/storage/schemas/workitem_log_test.exs`)

### Miscellaneous Updates

* **Updated test repository migrations**: Included the new migration (`V1`) for `workitem_logs` in the test repository setup. (`test/support/repo.ex`)