### PR TITLE
feat: add module support for hierarchical CPN composition

### DIFF
--- a/docs/module_resolver_behaviour.md
+++ b/docs/module_resolver_behaviour.md
@@ -1,0 +1,455 @@
+# Module Resolver Design (Behaviour-Based)
+
+## Architecture Overview
+
+```
+┌─────────────────────────────────────────┐
+│  ColouredPetriNet with module_ref       │
+│  - transitions with {:module_ref, ...}   │
+└──────────────┬──────────────────────────┘
+               │
+               ▼
+┌─────────────────────────────────────────┐
+│  resolve_modules(cpnet, resolver)        │
+│  - Finds all module_ref                  │
+│  - Calls resolver.resolve() for each     │
+└──────────────┬──────────────────────────┘
+               │
+               ▼
+┌─────────────────────────────────────────┐
+│  ModuleResolver (Behaviour)              │
+│  @callback resolve(ref, ctx) -> module   │
+└──────────────┬──────────────────────────┘
+               │
+         ┌─────┴─────┐
+         ▼           ▼
+┌──────────────┐  ┌──────────────────┐
+│ Default      │  │ User Custom      │
+│ (from DB)    │  │ (from anywhere)  │
+└──────────────┘  └──────────────────┘
+```
+
+## Core Components
+
+### 1. ModuleReference (Type Definition)
+
+```elixir
+# lib/coloured_flow/runtime/module_reference.ex
+
+defmodule ColouredFlow.Runtime.ModuleReference do
+  @moduledoc """
+  Type definition for module references.
+
+  A module reference allows dynamic loading of modules at runtime.
+  """
+
+  alias ColouredFlow.Builder.FlowConverter
+
+  @type port_spec() :: {String.t(), :input | :output | :io}
+
+  @type t() ::
+    {:module_ref, flow_id: pos_integer(), port_specs: [port_spec()]}
+    | {:module_ref, flow_id: pos_integer(), module_name: String.t()}
+    | {:module_ref, flow_name: String.t(), port_specs: [port_spec()]}
+    | {:module_ref, flow_name: String.t(), module_name: String.t()}
+    | {:module_ref, custom: term()}  # For user-defined references
+end
+```
+
+### 2. ModuleResolver (Behaviour)
+
+```elixir
+# lib/coloured_flow/runtime/module_resolver.ex
+
+defmodule ColouredFlow.Runtime.ModuleResolver do
+  @moduledoc """
+  Behaviour for module resolution.
+
+  Implement this behaviour to provide custom module loading strategies.
+  """
+
+  alias ColouredFlow.Definition.Module
+  alias ColouredFlow.Runtime.ModuleReference
+
+  @type context() :: map()
+  @type module_ref() :: ModuleReference.t()
+
+  @doc """
+  Resolves a module reference to a concrete Module.
+
+  ## Parameters
+  - `module_ref`: The module reference to resolve
+  - `context`: Additional context (e.g., repo, cache, options)
+
+  ## Returns
+  - `{:ok, module}`: Successfully resolved module
+  - `{:error, reason}`: Failed to resolve
+  """
+  @callback resolve(module_ref(), context()) ::
+    {:ok, Module.t()} | {:error, term()}
+end
+```
+
+### 3. Default Resolver Implementation
+
+```elixir
+# lib/coloured_flow/runtime/module_resolver/default.ex
+
+defmodule ColouredFlow.Runtime.ModuleResolver.Default do
+  @moduledoc """
+  Default module resolver implementation.
+
+  Loads modules from the database using FlowConverter.
+  """
+
+  @behaviour ColouredFlow.Runtime.ModuleResolver
+
+  alias ColouredFlow.Builder.FlowConverter
+  alias ColouredFlow.Definition.ColouredPetriNet
+  alias ColouredFlow.Definition.Module
+  alias ColouredFlow.Runner.Storage.Schemas
+
+  @doc """
+  Creates a new default resolver with options.
+
+  ## Options
+  - `:repo` (required) - Ecto repo for loading flows
+  - `:cache` (optional) - Enable caching (default: false)
+  - `:cache_ttl` (optional) - Cache TTL in milliseconds
+
+  ## Examples
+
+      resolver = Default.new(repo: MyApp.Repo)
+      resolver = Default.new(repo: MyApp.Repo, cache: true)
+  """
+  @spec new(Keyword.t()) :: context()
+  def new(opts) do
+    repo = Keyword.fetch!(opts, :repo)
+
+    %{
+      repo: repo,
+      cache: Keyword.get(opts, :cache, false),
+      cache_ttl: Keyword.get(opts, :cache_ttl, 60_000),
+      cache_store: %{}  # Simple in-memory cache
+    }
+  end
+
+  @impl true
+  def resolve(module_ref, context)
+
+  # Resolve by flow_id with port_specs
+  def resolve({:module_ref, opts}, context) when is_list(opts) do
+    cond do
+      Keyword.has_key?(opts, :flow_id) and Keyword.has_key?(opts, :port_specs) ->
+        flow_id = Keyword.fetch!(opts, :flow_id)
+        port_specs = Keyword.fetch!(opts, :port_specs)
+        module_name = "flow_#{flow_id}_module"
+
+        load_from_flow_id(flow_id, module_name, port_specs, context)
+
+      Keyword.has_key?(opts, :flow_id) and Keyword.has_key?(opts, :module_name) ->
+        flow_id = Keyword.fetch!(opts, :flow_id)
+        module_name = Keyword.fetch!(opts, :module_name)
+
+        load_from_flow_id_auto(flow_id, module_name, context)
+
+      Keyword.has_key?(opts, :flow_name) and Keyword.has_key?(opts, :port_specs) ->
+        flow_name = Keyword.fetch!(opts, :flow_name)
+        port_specs = Keyword.fetch!(opts, :port_specs)
+        module_name = "#{flow_name}_module"
+
+        load_from_flow_name(flow_name, module_name, port_specs, context)
+
+      Keyword.has_key?(opts, :flow_name) and Keyword.has_key?(opts, :module_name) ->
+        flow_name = Keyword.fetch!(opts, :flow_name)
+        module_name = Keyword.fetch!(opts, :module_name)
+
+        load_from_flow_name_auto(flow_name, module_name, context)
+
+      true ->
+        {:error, {:invalid_module_ref, "Unknown module reference format"}}
+    end
+  end
+
+  defp load_from_flow_id(flow_id, module_name, port_specs, context) do
+    with {:ok, flow} <- fetch_flow_by_id(flow_id, context),
+         {:ok, module} <- convert_flow_to_module(flow, module_name, port_specs) do
+      {:ok, module}
+    end
+  end
+
+  defp load_from_flow_id_auto(flow_id, module_name, context) do
+    with {:ok, flow} <- fetch_flow_by_id(flow_id, context) do
+      module = FlowConverter.flow_to_module_auto(flow.definition, module_name)
+      {:ok, module}
+    end
+  end
+
+  defp load_from_flow_name(flow_name, module_name, port_specs, context) do
+    with {:ok, flow} <- fetch_flow_by_name(flow_name, context),
+         {:ok, module} <- convert_flow_to_module(flow, module_name, port_specs) do
+      {:ok, module}
+    end
+  end
+
+  defp load_from_flow_name_auto(flow_name, module_name, context) do
+    with {:ok, flow} <- fetch_flow_by_name(flow_name, context) do
+      module = FlowConverter.flow_to_module_auto(flow.definition, module_name)
+      {:ok, module}
+    end
+  end
+
+  defp fetch_flow_by_id(flow_id, %{repo: repo}) do
+    case repo.get(Schemas.Flow, flow_id) do
+      nil -> {:error, {:flow_not_found, flow_id}}
+      flow -> {:ok, flow}
+    end
+  end
+
+  defp fetch_flow_by_name(flow_name, %{repo: repo}) do
+    import Ecto.Query
+
+    query = from f in Schemas.Flow, where: f.name == ^flow_name
+
+    case repo.one(query) do
+      nil -> {:error, {:flow_not_found, flow_name}}
+      flow -> {:ok, flow}
+    end
+  end
+
+  defp convert_flow_to_module(flow, module_name, port_specs) do
+    module = FlowConverter.flow_to_module(
+      flow.definition,
+      name: module_name,
+      port_specs: port_specs
+    )
+
+    {:ok, module}
+  rescue
+    error -> {:error, {:conversion_failed, error}}
+  end
+end
+```
+
+### 4. Resolution Function
+
+```elixir
+# Add to lib/coloured_flow/definition/coloured_petri_net.ex
+
+defmodule ColouredFlow.Definition.ColouredPetriNet do
+  # ... existing code ...
+
+  alias ColouredFlow.Runtime.ModuleResolver
+
+  @doc """
+  Resolves all module references in the CPN using the provided resolver.
+
+  ## Parameters
+  - `cpnet`: The ColouredPetriNet to resolve
+  - `resolver_impl`: Module implementing ModuleResolver behaviour
+  - `context`: Context passed to resolver.resolve/2
+
+  ## Returns
+  - `{:ok, resolved_cpnet}`: CPN with all references resolved
+  - `{:error, reason}`: Resolution failed
+
+  ## Examples
+
+      # Using default resolver
+      resolver = ModuleResolver.Default.new(repo: MyApp.Repo)
+      {:ok, resolved} = ColouredPetriNet.resolve_modules(cpnet,
+        ModuleResolver.Default,
+        resolver
+      )
+
+      # Using custom resolver
+      {:ok, resolved} = ColouredPetriNet.resolve_modules(cpnet,
+        MyApp.CustomResolver,
+        custom_context
+      )
+  """
+  @spec resolve_modules(t(), module(), ModuleResolver.context()) ::
+    {:ok, t()} | {:error, term()}
+  def resolve_modules(%__MODULE__{} = cpnet, resolver_impl, context) do
+    # Find all substitution transitions with module_ref
+    refs_to_resolve =
+      cpnet.transitions
+      |> Enum.filter(&is_module_ref?(&1.subst))
+      |> Enum.map(fn transition -> {transition, transition.subst} end)
+
+    # Resolve each reference
+    case resolve_all_refs(refs_to_resolve, resolver_impl, context, %{}) do
+      {:ok, resolved_modules} ->
+        # Update CPN with resolved modules and static references
+        updated_cpnet = apply_resolved_modules(cpnet, resolved_modules)
+        {:ok, updated_cpnet}
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp is_module_ref?({:module_ref, _opts}), do: true
+  defp is_module_ref?(_), do: false
+
+  defp resolve_all_refs([], _resolver_impl, _context, resolved) do
+    {:ok, resolved}
+  end
+
+  defp resolve_all_refs([{transition, ref} | rest], resolver_impl, context, resolved) do
+    # Check if already resolved (dedup)
+    ref_key = ref_to_key(ref)
+
+    if Map.has_key?(resolved, ref_key) do
+      resolve_all_refs(rest, resolver_impl, context, resolved)
+    else
+      case resolver_impl.resolve(ref, context) do
+        {:ok, module} ->
+          updated_resolved = Map.put(resolved, ref_key, module)
+          resolve_all_refs(rest, resolver_impl, context, updated_resolved)
+
+        {:error, reason} ->
+          {:error, {:module_resolution_failed, transition.name, reason}}
+      end
+    end
+  end
+
+  defp ref_to_key({:module_ref, opts}), do: {:module_ref, Enum.sort(opts)}
+
+  defp apply_resolved_modules(cpnet, resolved_modules) do
+    # Add resolved modules to cpnet.modules
+    new_modules = Map.values(resolved_modules)
+
+    # Update transitions to use static module names
+    updated_transitions =
+      Enum.map(cpnet.transitions, fn transition ->
+        if is_module_ref?(transition.subst) do
+          ref_key = ref_to_key(transition.subst)
+          module = Map.fetch!(resolved_modules, ref_key)
+          %{transition | subst: module.name}
+        else
+          transition
+        end
+      end)
+
+    %{cpnet |
+      modules: cpnet.modules ++ new_modules,
+      transitions: updated_transitions
+    }
+  end
+end
+```
+
+## Usage Examples
+
+### Example 1: Using Default Resolver
+
+```elixir
+# 1. Define CPN with module references
+cpnet = %ColouredPetriNet{
+  colour_sets: [...],
+  places: [...],
+  transitions: [
+    %Transition{
+      name: "authenticate",
+      subst: {:module_ref,
+        flow_id: 123,
+        port_specs: [
+          {"credentials", :input},
+          {"success", :output},
+          {"failure", :output}
+        ]
+      },
+      socket_assignments: [...]
+    }
+  ],
+  arcs: [...]
+}
+
+# 2. Create resolver
+resolver = ColouredFlow.Runtime.ModuleResolver.Default.new(repo: MyApp.Repo)
+
+# 3. Resolve modules
+{:ok, resolved_cpnet} = ColouredPetriNet.resolve_modules(
+  cpnet,
+  ColouredFlow.Runtime.ModuleResolver.Default,
+  resolver
+)
+
+# 4. Now resolved_cpnet has the module loaded
+# resolved_cpnet.modules contains the authentication module
+# The transition now uses static reference: subst: "flow_123_module"
+```
+
+### Example 2: Custom Resolver (Load from File)
+
+```elixir
+defmodule MyApp.FileModuleResolver do
+  @behaviour ColouredFlow.Runtime.ModuleResolver
+
+  @impl true
+  def resolve({:module_ref, file_path: path, module_name: name}, _context) do
+    with {:ok, content} <- File.read(path),
+         {:ok, flow} <- Jason.decode(content),
+         cpnet <- deserialize_flow(flow) do
+
+      module = FlowConverter.flow_to_module_auto(cpnet, name)
+      {:ok, module}
+    end
+  end
+end
+
+# Usage
+cpnet = %ColouredPetriNet{
+  transitions: [
+    %Transition{
+      subst: {:module_ref,
+        file_path: "/path/to/auth.json",
+        module_name: "authentication"
+      }
+    }
+  ]
+}
+
+{:ok, resolved} = ColouredPetriNet.resolve_modules(
+  cpnet,
+  MyApp.FileModuleResolver,
+  %{}
+)
+```
+
+### Example 3: Custom Resolver (Load from API)
+
+```elixir
+defmodule MyApp.APIModuleResolver do
+  @behaviour ColouredFlow.Runtime.ModuleResolver
+
+  @impl true
+  def resolve({:module_ref, api_id: id, port_specs: specs}, context) do
+    api_url = context.api_url
+
+    with {:ok, response} <- HTTPoison.get("#{api_url}/modules/#{id}"),
+         {:ok, flow_data} <- Jason.decode(response.body),
+         cpnet <- deserialize_flow(flow_data) do
+
+      module = FlowConverter.flow_to_module(cpnet,
+        name: "api_module_#{id}",
+        port_specs: specs
+      )
+      {:ok, module}
+    end
+  end
+end
+```
+
+## Benefits
+
+1. **No Global State**: No registry, no global GenServer
+2. **Flexible**: Users can implement any loading strategy
+3. **Testable**: Easy to mock resolver in tests
+4. **Composable**: Can chain or combine resolvers
+5. **Explicit**: Resolver is passed explicitly, clear dependencies
+
+## Questions?
+
+这个方案清晰吗？有什么需要调整的地方吗？

--- a/docs/module_resolver_mfa_based.md
+++ b/docs/module_resolver_mfa_based.md
@@ -6,13 +6,13 @@
 ┌──────────────────────────────────────────┐
 │  Application Initialization              │
 │  - Create resolver context               │
-│  - Form MFA: {Mod, :resolve, [context]} │
+│  - Form resolver: {Mod, [context]}       │
 └──────────────┬───────────────────────────┘
                │
                ▼
 ┌──────────────────────────────────────────┐
 │  Enactment Initialization                │
-│  - Receives resolver_mfa                 │
+│  - Receives resolver config              │
 │  - Stores in enactment state             │
 └──────────────┬───────────────────────────┘
                │
@@ -100,44 +100,44 @@ defmodule ColouredFlow.Runtime.ModuleResolver do
   # ... behaviour definition ...
 
   @typedoc """
-  Module resolver in MFA form.
+  Module resolver configuration.
 
   The tuple contains:
   - module: Module implementing ModuleResolver behaviour
-  - function: Always :resolve
   - args: List containing [context] (pre-initialized)
 
-  When calling: apply(module, :resolve, [module_ref, context, runtime_info])
+  Since the behaviour defines resolve/3, the function name is implicit.
+  When calling: apply(module, :resolve, [module_ref] ++ args ++ [runtime_info])
   """
-  @type mfa() :: {module(), :resolve, [context()]}
+  @type resolver() :: {module(), [context()]}
 
   @doc """
-  Helper to create MFA from resolver module and context.
+  Helper to create resolver configuration from module and context.
 
   ## Examples
 
       context = MyResolver.init(repo: MyApp.Repo)
-      mfa = ModuleResolver.to_mfa(MyResolver, context)
-      # Returns: {MyResolver, :resolve, [context]}
+      resolver = ModuleResolver.new(MyResolver, context)
+      # Returns: {MyResolver, [context]}
   """
-  @spec to_mfa(module(), context()) :: mfa()
-  def to_mfa(resolver_module, context) when is_atom(resolver_module) do
-    {resolver_module, :resolve, [context]}
+  @spec new(module(), context()) :: resolver()
+  def new(resolver_module, context) when is_atom(resolver_module) do
+    {resolver_module, [context]}
   end
 
   @doc """
-  Helper to call MFA with module reference and runtime info.
+  Call resolver with module reference and runtime info.
 
   ## Examples
 
-      mfa = {MyResolver, :resolve, [context]}
+      resolver = {MyResolver, [context]}
       runtime_info = %{enactment_id: 123}
-      {:ok, module} = ModuleResolver.call_mfa(mfa, module_ref, runtime_info)
+      {:ok, module} = ModuleResolver.resolve(resolver, module_ref, runtime_info)
   """
-  @spec call_mfa(mfa(), module_ref(), runtime_info()) ::
+  @spec resolve(resolver(), module_ref(), runtime_info()) ::
     {:ok, Module.t()} | {:error, term()}
-  def call_mfa({module, :resolve, [context]}, module_ref, runtime_info) do
-    apply(module, :resolve, [module_ref, context, runtime_info])
+  def resolve({resolver_module, [context]}, module_ref, runtime_info) do
+    apply(resolver_module, :resolve, [module_ref, context, runtime_info])
   end
 end
 ```
@@ -305,12 +305,12 @@ end
 
 # 1. Application level: Initialize resolver
 resolver_context = ModuleResolver.Default.init(repo: MyApp.Repo)
-resolver_mfa = ModuleResolver.to_mfa(ModuleResolver.Default, resolver_context)
+resolver = ModuleResolver.new(ModuleResolver.Default, resolver_context)
 
 # 2. Pass to enactment
 {:ok, enactment_pid} = Enactment.start_link(
   cpnet: cpnet,
-  resolver: resolver_mfa,
+  resolver: resolver,
   # ... other options
 )
 
@@ -319,7 +319,7 @@ defmodule ColouredFlow.Runner.Enactment do
   def init(opts) do
     state = %{
       cpnet: opts[:cpnet],
-      resolver_mfa: opts[:resolver],
+      resolver: opts[:resolver],
       enactment_id: generate_id(),
       # ...
     }
@@ -334,7 +334,7 @@ defmodule ColouredFlow.Runner.Enactment do
         parent_transition: transition.name
       }
 
-      case ModuleResolver.call_mfa(state.resolver_mfa, transition.subst, runtime_info) do
+      case ModuleResolver.resolve(state.resolver, transition.subst, runtime_info) do
         {:ok, module} ->
           # Use the resolved module
           execute_module(module, ...)
@@ -359,10 +359,10 @@ defmodule MyApp.Application do
   def start(_type, _args) do
     # Initialize resolver
     resolver_context = ModuleResolver.Default.init(repo: MyApp.Repo)
-    resolver_mfa = ModuleResolver.to_mfa(ModuleResolver.Default, resolver_context)
+    resolver = ModuleResolver.new(ModuleResolver.Default, resolver_context)
 
     # Store in application env or pass to supervisor
-    Application.put_env(:my_app, :module_resolver, resolver_mfa)
+    Application.put_env(:my_app, :module_resolver, resolver)
 
     # Start supervisors...
   end
@@ -388,15 +388,21 @@ cpnet = %ColouredPetriNet{
 }
 
 # 3. Start enactment with resolver
-resolver_mfa = Application.get_env(:my_app, :module_resolver)
+resolver = Application.get_env(:my_app, :module_resolver)
 
 {:ok, enactment_pid} = Enactment.start_link(
   cpnet: cpnet,
-  resolver: resolver_mfa,
+  resolver: resolver,
   initial_marking: [...]
 )
 
 # 4. When transition fires, enactment calls:
+# ModuleResolver.resolve(
+#   {ModuleResolver.Default, [resolver_context]},
+#   {:module_ref, flow_id: 123, port_specs: [...]},
+#   %{enactment_id: "abc123", parent_transition: "authenticate"}
+# )
+# Which internally does:
 # apply(ModuleResolver.Default, :resolve, [
 #   {:module_ref, flow_id: 123, port_specs: [...]},
 #   resolver_context,
@@ -412,10 +418,11 @@ resolver_mfa = Application.get_env(:my_app, :module_resolver)
 4. **Testable**: Easy to mock MFA in tests
 5. **Flexible**: Can use different resolvers for different enactments
 
-## Key Changes from Previous Design
+## Key Design Points
 
-1. **Behaviour signature**: `resolve/3` instead of `resolve/2`
+1. **Behaviour signature**: `resolve/3` with module_ref, context, runtime_info
 2. **Third parameter**: `runtime_info` with enactment context
-3. **MFA format**: `{Module, :resolve, [context]}` for easy passing
-4. **Helper functions**: `to_mfa/2` and `call_mfa/3` for convenience
+3. **Resolver format**: `{Module, [context]}` - function name implicit from behaviour
+4. **Helper functions**: `new/2` and `resolve/3` for convenience
 5. **Lazy loading**: Resolution happens at runtime, not upfront
+6. **No redundancy**: Function name omitted since behaviour defines it

--- a/docs/module_resolver_mfa_based.md
+++ b/docs/module_resolver_mfa_based.md
@@ -1,0 +1,421 @@
+# Module Resolver Design (MFA-Based)
+
+## Architecture Overview
+
+```
+┌──────────────────────────────────────────┐
+│  Application Initialization              │
+│  - Create resolver context               │
+│  - Form MFA: {Mod, :resolve, [context]} │
+└──────────────┬───────────────────────────┘
+               │
+               ▼
+┌──────────────────────────────────────────┐
+│  Enactment Initialization                │
+│  - Receives resolver_mfa                 │
+│  - Stores in enactment state             │
+└──────────────┬───────────────────────────┘
+               │
+               ▼
+┌──────────────────────────────────────────┐
+│  Runtime (when module needed)            │
+│  - apply(Mod, :resolve, [ref, ctx, info])│
+│  - Returns resolved module               │
+└──────────────────────────────────────────┘
+```
+
+## Core Design
+
+### 1. Behaviour Definition (3 parameters)
+
+```elixir
+# lib/coloured_flow/runtime/module_resolver.ex
+
+defmodule ColouredFlow.Runtime.ModuleResolver do
+  @moduledoc """
+  Behaviour for module resolution.
+
+  Implement this behaviour to provide custom module loading strategies.
+  The resolver is configured externally and passed to enactment as MFA.
+  """
+
+  alias ColouredFlow.Definition.Module
+  alias ColouredFlow.Runtime.ModuleReference
+
+  @typedoc """
+  Context for module resolution.
+
+  This is initialized once by the application and passed as part of MFA.
+  Contains configuration like database repo, cache settings, etc.
+  """
+  @type context() :: term()
+
+  @typedoc """
+  Runtime information from enactment.
+
+  This is provided at resolution time and contains dynamic information
+  like enactment_id, current state, etc.
+  """
+  @type runtime_info() :: %{
+    optional(:enactment_id) => term(),
+    optional(:parent_transition) => binary(),
+    optional(atom()) => term()
+  }
+
+  @type module_ref() :: ModuleReference.t()
+
+  @doc """
+  Resolves a module reference to a concrete Module.
+
+  ## Parameters
+  - `module_ref`: The module reference to resolve
+  - `context`: Resolver context (initialized externally)
+  - `runtime_info`: Runtime information from enactment
+
+  ## Returns
+  - `{:ok, module}`: Successfully resolved module
+  - `{:error, reason}`: Failed to resolve
+
+  ## Examples
+
+      # Called by enactment via MFA
+      @impl true
+      def resolve(module_ref, context, runtime_info) do
+        # Use context for configuration (repo, cache, etc.)
+        # Use runtime_info for dynamic decisions
+        {:ok, module}
+      end
+  """
+  @callback resolve(module_ref(), context(), runtime_info()) ::
+    {:ok, Module.t()} | {:error, term()}
+end
+```
+
+### 2. MFA Type Definition
+
+```elixir
+# lib/coloured_flow/runtime/module_resolver.ex
+
+defmodule ColouredFlow.Runtime.ModuleResolver do
+  # ... behaviour definition ...
+
+  @typedoc """
+  Module resolver in MFA form.
+
+  The tuple contains:
+  - module: Module implementing ModuleResolver behaviour
+  - function: Always :resolve
+  - args: List containing [context] (pre-initialized)
+
+  When calling: apply(module, :resolve, [module_ref, context, runtime_info])
+  """
+  @type mfa() :: {module(), :resolve, [context()]}
+
+  @doc """
+  Helper to create MFA from resolver module and context.
+
+  ## Examples
+
+      context = MyResolver.init(repo: MyApp.Repo)
+      mfa = ModuleResolver.to_mfa(MyResolver, context)
+      # Returns: {MyResolver, :resolve, [context]}
+  """
+  @spec to_mfa(module(), context()) :: mfa()
+  def to_mfa(resolver_module, context) when is_atom(resolver_module) do
+    {resolver_module, :resolve, [context]}
+  end
+
+  @doc """
+  Helper to call MFA with module reference and runtime info.
+
+  ## Examples
+
+      mfa = {MyResolver, :resolve, [context]}
+      runtime_info = %{enactment_id: 123}
+      {:ok, module} = ModuleResolver.call_mfa(mfa, module_ref, runtime_info)
+  """
+  @spec call_mfa(mfa(), module_ref(), runtime_info()) ::
+    {:ok, Module.t()} | {:error, term()}
+  def call_mfa({module, :resolve, [context]}, module_ref, runtime_info) do
+    apply(module, :resolve, [module_ref, context, runtime_info])
+  end
+end
+```
+
+### 3. Default Resolver Implementation
+
+```elixir
+# lib/coloured_flow/runtime/module_resolver/default.ex
+
+defmodule ColouredFlow.Runtime.ModuleResolver.Default do
+  @moduledoc """
+  Default module resolver implementation.
+
+  Loads modules from the database using FlowConverter.
+  """
+
+  @behaviour ColouredFlow.Runtime.ModuleResolver
+
+  alias ColouredFlow.Builder.FlowConverter
+  alias ColouredFlow.Runner.Storage.Schemas
+
+  @typedoc """
+  Context for default resolver.
+  """
+  @type context() :: %{
+    repo: module(),
+    cache: boolean(),
+    cache_store: map()
+  }
+
+  @doc """
+  Initialize resolver context.
+
+  ## Options
+  - `:repo` (required) - Ecto repo for loading flows
+  - `:cache` (optional) - Enable caching (default: false)
+
+  ## Examples
+
+      context = Default.init(repo: MyApp.Repo)
+      mfa = ModuleResolver.to_mfa(Default, context)
+  """
+  @spec init(Keyword.t()) :: context()
+  def init(opts) do
+    repo = Keyword.fetch!(opts, :repo)
+
+    %{
+      repo: repo,
+      cache: Keyword.get(opts, :cache, false),
+      cache_store: %{}
+    }
+  end
+
+  @impl ColouredFlow.Runtime.ModuleResolver
+  def resolve(module_ref, context, runtime_info)
+
+  # Resolve by flow_id with port_specs
+  def resolve({:module_ref, opts}, context, runtime_info) when is_list(opts) do
+    cond do
+      Keyword.has_key?(opts, :flow_id) and Keyword.has_key?(opts, :port_specs) ->
+        flow_id = Keyword.fetch!(opts, :flow_id)
+        port_specs = Keyword.fetch!(opts, :port_specs)
+
+        # Can use runtime_info to customize module name
+        module_name = build_module_name("flow_#{flow_id}", runtime_info)
+
+        load_from_flow_id(flow_id, module_name, port_specs, context)
+
+      Keyword.has_key?(opts, :flow_id) and Keyword.has_key?(opts, :module_name) ->
+        flow_id = Keyword.fetch!(opts, :flow_id)
+        module_name = Keyword.fetch!(opts, :module_name)
+
+        load_from_flow_id_auto(flow_id, module_name, context)
+
+      Keyword.has_key?(opts, :flow_name) and Keyword.has_key?(opts, :port_specs) ->
+        flow_name = Keyword.fetch!(opts, :flow_name)
+        port_specs = Keyword.fetch!(opts, :port_specs)
+        module_name = build_module_name(flow_name, runtime_info)
+
+        load_from_flow_name(flow_name, module_name, port_specs, context)
+
+      Keyword.has_key?(opts, :flow_name) and Keyword.has_key?(opts, :module_name) ->
+        flow_name = Keyword.fetch!(opts, :flow_name)
+        module_name = Keyword.fetch!(opts, :module_name)
+
+        load_from_flow_name_auto(flow_name, module_name, context)
+
+      true ->
+        {:error, {:invalid_module_ref, "Unknown module reference format"}}
+    end
+  end
+
+  defp build_module_name(base_name, runtime_info) do
+    # Can incorporate enactment_id to create unique module names
+    case Map.get(runtime_info, :enactment_id) do
+      nil -> "#{base_name}_module"
+      enactment_id -> "#{base_name}_enactment_#{enactment_id}_module"
+    end
+  end
+
+  defp load_from_flow_id(flow_id, module_name, port_specs, context) do
+    with {:ok, flow} <- fetch_flow_by_id(flow_id, context),
+         {:ok, module} <- convert_flow_to_module(flow, module_name, port_specs) do
+      {:ok, module}
+    end
+  end
+
+  defp load_from_flow_id_auto(flow_id, module_name, context) do
+    with {:ok, flow} <- fetch_flow_by_id(flow_id, context) do
+      module = FlowConverter.flow_to_module_auto(flow.definition, module_name)
+      {:ok, module}
+    end
+  end
+
+  defp load_from_flow_name(flow_name, module_name, port_specs, context) do
+    with {:ok, flow} <- fetch_flow_by_name(flow_name, context),
+         {:ok, module} <- convert_flow_to_module(flow, module_name, port_specs) do
+      {:ok, module}
+    end
+  end
+
+  defp load_from_flow_name_auto(flow_name, module_name, context) do
+    with {:ok, flow} <- fetch_flow_by_name(flow_name, context) do
+      module = FlowConverter.flow_to_module_auto(flow.definition, module_name)
+      {:ok, module}
+    end
+  end
+
+  defp fetch_flow_by_id(flow_id, %{repo: repo}) do
+    case repo.get(Schemas.Flow, flow_id) do
+      nil -> {:error, {:flow_not_found, flow_id}}
+      flow -> {:ok, flow}
+    end
+  end
+
+  defp fetch_flow_by_name(flow_name, %{repo: repo}) do
+    import Ecto.Query
+
+    query = from f in Schemas.Flow, where: f.name == ^flow_name
+
+    case repo.one(query) do
+      nil -> {:error, {:flow_not_found, flow_name}}
+      flow -> {:ok, flow}
+    end
+  end
+
+  defp convert_flow_to_module(flow, module_name, port_specs) do
+    module = FlowConverter.flow_to_module(
+      flow.definition,
+      name: module_name,
+      port_specs: port_specs
+    )
+
+    {:ok, module}
+  rescue
+    error -> {:error, {:conversion_failed, error}}
+  end
+end
+```
+
+### 4. Usage in Enactment
+
+```elixir
+# When starting an enactment
+
+# 1. Application level: Initialize resolver
+resolver_context = ModuleResolver.Default.init(repo: MyApp.Repo)
+resolver_mfa = ModuleResolver.to_mfa(ModuleResolver.Default, resolver_context)
+
+# 2. Pass to enactment
+{:ok, enactment_pid} = Enactment.start_link(
+  cpnet: cpnet,
+  resolver: resolver_mfa,
+  # ... other options
+)
+
+# 3. Inside Enactment GenServer
+defmodule ColouredFlow.Runner.Enactment do
+  def init(opts) do
+    state = %{
+      cpnet: opts[:cpnet],
+      resolver_mfa: opts[:resolver],
+      enactment_id: generate_id(),
+      # ...
+    }
+    {:ok, state}
+  end
+
+  # When a substitution transition fires
+  defp fire_substitution_transition(transition, state) do
+    if is_module_ref?(transition.subst) do
+      runtime_info = %{
+        enactment_id: state.enactment_id,
+        parent_transition: transition.name
+      }
+
+      case ModuleResolver.call_mfa(state.resolver_mfa, transition.subst, runtime_info) do
+        {:ok, module} ->
+          # Use the resolved module
+          execute_module(module, ...)
+
+        {:error, reason} ->
+          {:error, {:module_resolution_failed, reason}}
+      end
+    else
+      # Static module reference
+      module = find_module_in_cpnet(state.cpnet, transition.subst)
+      execute_module(module, ...)
+    end
+  end
+end
+```
+
+## Complete Example
+
+```elixir
+# 1. Application startup
+defmodule MyApp.Application do
+  def start(_type, _args) do
+    # Initialize resolver
+    resolver_context = ModuleResolver.Default.init(repo: MyApp.Repo)
+    resolver_mfa = ModuleResolver.to_mfa(ModuleResolver.Default, resolver_context)
+
+    # Store in application env or pass to supervisor
+    Application.put_env(:my_app, :module_resolver, resolver_mfa)
+
+    # Start supervisors...
+  end
+end
+
+# 2. Create CPN with module reference
+cpnet = %ColouredPetriNet{
+  places: [...],
+  transitions: [
+    %Transition{
+      name: "authenticate",
+      subst: {:module_ref,
+        flow_id: 123,
+        port_specs: [
+          {"credentials", :input},
+          {"success", :output},
+          {"failure", :output}
+        ]
+      },
+      socket_assignments: [...]
+    }
+  ]
+}
+
+# 3. Start enactment with resolver
+resolver_mfa = Application.get_env(:my_app, :module_resolver)
+
+{:ok, enactment_pid} = Enactment.start_link(
+  cpnet: cpnet,
+  resolver: resolver_mfa,
+  initial_marking: [...]
+)
+
+# 4. When transition fires, enactment calls:
+# apply(ModuleResolver.Default, :resolve, [
+#   {:module_ref, flow_id: 123, port_specs: [...]},
+#   resolver_context,
+#   %{enactment_id: "abc123", parent_transition: "authenticate"}
+# ])
+```
+
+## Benefits
+
+1. **Lazy Resolution**: Modules resolved only when needed (at transition fire time)
+2. **Runtime Context**: Resolver can use enactment info for decisions
+3. **No Global State**: Resolver configured per enactment
+4. **Testable**: Easy to mock MFA in tests
+5. **Flexible**: Can use different resolvers for different enactments
+
+## Key Changes from Previous Design
+
+1. **Behaviour signature**: `resolve/3` instead of `resolve/2`
+2. **Third parameter**: `runtime_info` with enactment context
+3. **MFA format**: `{Module, :resolve, [context]}` for easy passing
+4. **Helper functions**: `to_mfa/2` and `call_mfa/3` for convenience
+5. **Lazy loading**: Resolution happens at runtime, not upfront

--- a/docs/module_resolver_simplified.md
+++ b/docs/module_resolver_simplified.md
@@ -1,0 +1,371 @@
+# Module Resolver Design (Simplified)
+
+## Architecture Overview
+
+```
+┌──────────────────────────────────────────┐
+│  Application Initialization              │
+│  - resolver = Resolver.Default.new(...)  │
+└──────────────┬───────────────────────────┘
+               │
+               ▼
+┌──────────────────────────────────────────┐
+│  Enactment Initialization                │
+│  - {resolver, additional_options}        │
+└──────────────┬───────────────────────────┘
+               │
+               ▼
+┌──────────────────────────────────────────┐
+│  Runtime (when module needed)            │
+│  - resolver.resolve(ref, options)        │
+└──────────────────────────────────────────┘
+```
+
+## Design Options
+
+### Option 1: Protocol-Based (Recommended)
+
+```elixir
+# Define protocol
+defprotocol ColouredFlow.Runtime.ModuleResolver do
+  @doc """
+  Resolves a module reference.
+
+  ## Parameters
+  - `resolver`: The resolver instance (struct implementing this protocol)
+  - `module_ref`: The module reference to resolve
+  - `options`: Runtime options (merged from base + additional)
+
+  ## Returns
+  - `{:ok, module}`: Successfully resolved
+  - `{:error, reason}`: Resolution failed
+  """
+  @spec resolve(t(), module_ref(), Keyword.t()) ::
+    {:ok, Module.t()} | {:error, term()}
+  def resolve(resolver, module_ref, options)
+end
+
+# Default implementation
+defmodule ColouredFlow.Runtime.ModuleResolver.Default do
+  @moduledoc """
+  Default resolver that loads from database.
+  """
+
+  defstruct [:repo, :cache]
+
+  @type t :: %__MODULE__{
+    repo: module(),
+    cache: boolean()
+  }
+
+  @doc """
+  Create a new default resolver.
+
+  ## Examples
+
+      resolver = Default.new(repo: MyApp.Repo)
+      resolver = Default.new(repo: MyApp.Repo, cache: true)
+  """
+  def new(opts) do
+    %__MODULE__{
+      repo: Keyword.fetch!(opts, :repo),
+      cache: Keyword.get(opts, :cache, false)
+    }
+  end
+end
+
+# Protocol implementation
+defimpl ColouredFlow.Runtime.ModuleResolver, for: ColouredFlow.Runtime.ModuleResolver.Default do
+  alias ColouredFlow.Builder.FlowConverter
+  alias ColouredFlow.Runner.Storage.Schemas
+
+  def resolve(%{repo: repo} = _resolver, module_ref, options) do
+    # options contains merged base_options ++ additional_options
+    # Can include: enactment_id, parent_transition, etc.
+
+    case module_ref do
+      {:module_ref, ref_opts} ->
+        load_from_ref(ref_opts, repo, options)
+
+      _ ->
+        {:error, {:invalid_module_ref, module_ref}}
+    end
+  end
+
+  defp load_from_ref(ref_opts, repo, runtime_opts) do
+    cond do
+      Keyword.has_key?(ref_opts, :flow_id) and Keyword.has_key?(ref_opts, :port_specs) ->
+        flow_id = Keyword.fetch!(ref_opts, :flow_id)
+        port_specs = Keyword.fetch!(ref_opts, :port_specs)
+        module_name = build_module_name("flow_#{flow_id}", runtime_opts)
+
+        load_from_flow_id(flow_id, module_name, port_specs, repo)
+
+      Keyword.has_key?(ref_opts, :flow_id) ->
+        flow_id = Keyword.fetch!(ref_opts, :flow_id)
+        module_name = build_module_name("flow_#{flow_id}", runtime_opts)
+
+        load_from_flow_id_auto(flow_id, module_name, repo)
+
+      true ->
+        {:error, {:invalid_module_ref, "Unknown format"}}
+    end
+  end
+
+  defp build_module_name(base, opts) do
+    case Keyword.get(opts, :enactment_id) do
+      nil -> "#{base}_module"
+      id -> "#{base}_enactment_#{id}_module"
+    end
+  end
+
+  defp load_from_flow_id(flow_id, module_name, port_specs, repo) do
+    with {:ok, flow} <- fetch_flow(flow_id, repo) do
+      module = FlowConverter.flow_to_module(
+        flow.definition,
+        name: module_name,
+        port_specs: port_specs
+      )
+      {:ok, module}
+    end
+  end
+
+  defp load_from_flow_id_auto(flow_id, module_name, repo) do
+    with {:ok, flow} <- fetch_flow(flow_id, repo) do
+      module = FlowConverter.flow_to_module_auto(flow.definition, module_name)
+      {:ok, module}
+    end
+  end
+
+  defp fetch_flow(flow_id, repo) do
+    case repo.get(Schemas.Flow, flow_id) do
+      nil -> {:error, {:flow_not_found, flow_id}}
+      flow -> {:ok, flow}
+    end
+  end
+end
+```
+
+### Option 2: Behaviour + Wrapper (Alternative)
+
+```elixir
+# Define behaviour
+defmodule ColouredFlow.Runtime.ModuleResolver.Behaviour do
+  @callback resolve(context :: term(), module_ref(), options :: Keyword.t()) ::
+    {:ok, Module.t()} | {:error, term()}
+end
+
+# Resolver config wrapper
+defmodule ColouredFlow.Runtime.ModuleResolver do
+  @moduledoc """
+  Wrapper for module resolver with pre-configured context.
+  """
+
+  defstruct [:impl, :context]
+
+  @type t :: %__MODULE__{
+    impl: module(),
+    context: term()
+  }
+
+  @doc """
+  Create a new resolver from implementation and context.
+  """
+  def new(impl, context) do
+    %__MODULE__{impl: impl, context: context}
+  end
+
+  @doc """
+  Resolve a module reference.
+
+  This is the main entry point that Enactment will call.
+  """
+  def resolve(%__MODULE__{impl: impl, context: context}, module_ref, options) do
+    impl.resolve(context, module_ref, options)
+  end
+end
+
+# Default implementation
+defmodule ColouredFlow.Runtime.ModuleResolver.Default do
+  @behaviour ColouredFlow.Runtime.ModuleResolver.Behaviour
+
+  def new(opts) do
+    context = %{
+      repo: Keyword.fetch!(opts, :repo),
+      cache: Keyword.get(opts, :cache, false)
+    }
+
+    ColouredFlow.Runtime.ModuleResolver.new(__MODULE__, context)
+  end
+
+  @impl true
+  def resolve(context, module_ref, options) do
+    # Same implementation as protocol version
+    # ...
+  end
+end
+```
+
+## Usage Comparison
+
+### Protocol-Based (Option 1)
+
+```elixir
+# 1. Initialize
+resolver = ModuleResolver.Default.new(repo: MyApp.Repo)
+
+# 2. Pass to enactment with additional options
+additional_opts = [cache_ttl: 60_000]
+{:ok, enactment} = start_enactment(
+  cpnet: cpnet,
+  resolver: {resolver, additional_opts}
+)
+
+# 3. In Enactment
+defmodule Enactment do
+  def handle_substitution_transition(transition, state) do
+    {resolver, additional_opts} = state.resolver
+
+    runtime_opts = [
+      enactment_id: state.id,
+      parent_transition: transition.name
+    ] ++ additional_opts
+
+    # Call using protocol
+    case ModuleResolver.resolve(resolver, transition.subst, runtime_opts) do
+      {:ok, module} -> # ...
+      {:error, reason} -> # ...
+    end
+  end
+end
+```
+
+### Behaviour-Based (Option 2)
+
+```elixir
+# 1. Initialize
+resolver = ModuleResolver.Default.new(repo: MyApp.Repo)
+
+# 2. Pass to enactment
+additional_opts = [cache_ttl: 60_000]
+{:ok, enactment} = start_enactment(
+  cpnet: cpnet,
+  resolver: {resolver, additional_opts}
+)
+
+# 3. In Enactment (same as Option 1)
+runtime_opts = [enactment_id: state.id] ++ additional_opts
+ModuleResolver.resolve(resolver, ref, runtime_opts)
+```
+
+## Recommendation
+
+**Use Option 1 (Protocol-Based)** because:
+
+1. ✅ More idiomatic Elixir
+2. ✅ Cleaner syntax: `ModuleResolver.resolve(resolver, ref, opts)`
+3. ✅ Easy to implement custom resolvers
+4. ✅ Protocol dispatch is efficient
+5. ✅ Type safety with structs
+
+## Complete Example (Protocol-Based)
+
+```elixir
+# Application startup
+defmodule MyApp.Application do
+  def start(_type, _args) do
+    # Create resolver instance
+    resolver = ModuleResolver.Default.new(repo: MyApp.Repo, cache: true)
+
+    # Store in application env
+    Application.put_env(:my_app, :module_resolver, resolver)
+
+    # ...
+  end
+end
+
+# Define CPN with module reference
+cpnet = %ColouredPetriNet{
+  transitions: [
+    %Transition{
+      name: "auth",
+      subst: {:module_ref, flow_id: 123, port_specs: [...]},
+      socket_assignments: [...]
+    }
+  ]
+}
+
+# Start enactment
+resolver = Application.get_env(:my_app, :module_resolver)
+additional_opts = [custom_key: "value"]
+
+{:ok, enactment} = start_enactment(
+  cpnet: cpnet,
+  resolver: {resolver, additional_opts}
+)
+
+# Inside Enactment (when transition fires)
+defmodule ColouredFlow.Runner.Enactment do
+  def fire_substitution_transition(transition, state) do
+    {resolver, additional_opts} = state.resolver_config
+
+    runtime_opts = [
+      enactment_id: state.id,
+      parent_transition: transition.name
+    ] ++ additional_opts
+
+    # Clean syntax!
+    case ModuleResolver.resolve(resolver, transition.subst, runtime_opts) do
+      {:ok, module} ->
+        execute_module(module, ...)
+
+      {:error, reason} ->
+        {:error, {:module_resolution_failed, reason}}
+    end
+  end
+end
+```
+
+## Custom Resolver Example
+
+```elixir
+# Define custom resolver struct
+defmodule MyApp.FileResolver do
+  defstruct [:base_path]
+
+  def new(opts) do
+    %__MODULE__{
+      base_path: Keyword.fetch!(opts, :base_path)
+    }
+  end
+end
+
+# Implement protocol
+defimpl ModuleResolver, for: MyApp.FileResolver do
+  def resolve(%{base_path: path}, {:module_ref, file: filename}, _opts) do
+    file_path = Path.join(path, filename)
+
+    with {:ok, content} <- File.read(file_path),
+         {:ok, flow_data} <- Jason.decode(content),
+         cpnet <- deserialize(flow_data) do
+      module = FlowConverter.flow_to_module_auto(cpnet, filename)
+      {:ok, module}
+    end
+  end
+end
+
+# Use it
+resolver = MyApp.FileResolver.new(base_path: "/modules")
+{:ok, enactment} = start_enactment(
+  cpnet: cpnet,
+  resolver: {resolver, []}
+)
+```
+
+## Benefits
+
+1. **Simple**: `ModuleResolver.resolve(resolver, ref, opts)`
+2. **Flexible**: Easy to add custom resolvers
+3. **Type-safe**: Structs ensure correct configuration
+4. **Composable**: Options merge cleanly
+5. **Testable**: Easy to mock resolvers

--- a/docs/module_support.md
+++ b/docs/module_support.md
@@ -1,0 +1,213 @@
+# Module Support in ColouredFlow
+
+This document describes the module support implementation in ColouredFlow, which enables hierarchical composition and reuse in Coloured Petri Nets.
+
+## Overview
+
+Module support allows you to create reusable subnet definitions that can be instantiated multiple times within a workflow. This is based on the substitution transition concept from CPN theory.
+
+## Key Concepts
+
+### 1. Module
+
+A `Module` represents a reusable subnet with a defined interface. It contains:
+
+- **Port Places**: Interface points for communication with the parent net
+- **Internal Places**: Places that are internal to the module
+- **Transitions**: Can be regular or substitution transitions (modules can contain modules)
+- **Arcs**: Connections between places and transitions
+- **Colour Sets, Variables, Constants, Functions**: Supporting definitions
+
+```elixir
+%ColouredFlow.Definition.Module{
+  name: "authentication",
+  port_places: [
+    %PortPlace{name: "credentials_in", colour_set: :credentials, port_type: :input},
+    %PortPlace{name: "success_out", colour_set: :unit, port_type: :output},
+    %PortPlace{name: "failure_out", colour_set: :string, port_type: :output}
+  ],
+  places: [
+    %Place{name: "verify", colour_set: :credentials}
+  ],
+  transitions: [...],
+  arcs: [...]
+}
+```
+
+### 2. Port Places
+
+Port places define the interface of a module. There are three types:
+
+- **Input (`:input`)**: Receives tokens from the parent net
+- **Output (`:output`)**: Sends tokens to the parent net
+- **I/O (`:io`)**: Bidirectional communication
+
+```elixir
+%ColouredFlow.Definition.PortPlace{
+  name: "input_data",
+  colour_set: :string,
+  port_type: :input
+}
+```
+
+### 3. Substitution Transition
+
+A substitution transition is a transition in the parent net that references a module. When it fires, it executes the referenced module.
+
+```elixir
+%ColouredFlow.Definition.Transition{
+  name: "authenticate_user",
+  subst: "authentication",  # References the module
+  socket_assignments: [
+    %SocketAssignment{socket: "user_creds", port: "credentials_in"},
+    %SocketAssignment{socket: "auth_success", port: "success_out"},
+    %SocketAssignment{socket: "auth_failure", port: "failure_out"}
+  ]
+}
+```
+
+### 4. Socket Assignment
+
+Socket assignments map places in the parent net (sockets) to port places in the module. The colour sets must match.
+
+```elixir
+%ColouredFlow.Definition.SocketAssignment{
+  socket: "parent_place",  # Place in parent net
+  port: "module_port"      # Port place in module
+}
+```
+
+## Usage Example
+
+### Defining a Module
+
+```elixir
+import ColouredFlow.Builder.ModuleHelper
+import ColouredFlow.Notation.Colset
+
+# Define a simple authentication module
+auth_module = build_module!(
+  name: "authentication",
+  port_places: [
+    input_port("credentials", :credentials),
+    output_port("success", :unit),
+    output_port("failure", :string)
+  ],
+  places: [
+    %Place{name: "validate", colour_set: :credentials}
+  ],
+  transitions: [
+    build_transition!(name: "check_creds", action: [payload: "..."])
+  ],
+  arcs: [
+    arc(check_creds <~ credentials :: "bind {1, creds}"),
+    arc(check_creds ~> success :: "{1, {}}"),
+    arc(check_creds ~> failure :: "{1, error_msg}")
+  ]
+)
+```
+
+### Using a Module with Substitution Transition
+
+```elixir
+%ColouredPetriNet{
+  colour_sets: [
+    colset(credentials() :: {username: string(), password: string()}),
+    colset(unit() :: {}),
+    colset(string() :: String.t())
+  ],
+  modules: [auth_module],
+  places: [
+    %Place{name: "user_input", colour_set: :credentials},
+    %Place{name: "authenticated", colour_set: :unit},
+    %Place{name: "auth_error", colour_set: :string}
+  ],
+  transitions: [
+    build_substitution_transition!(
+      name: "do_auth",
+      subst: "authentication",
+      socket_assignments: [
+        socket("user_input", "credentials"),
+        socket("authenticated", "success"),
+        socket("auth_error", "failure")
+      ]
+    )
+  ],
+  arcs: [...]
+}
+```
+
+## Validation
+
+The `ModuleValidator` ensures:
+
+1. **Unique Module Names**: No duplicate module names
+2. **Valid Port Places**: No duplicate or overlapping port/internal place names
+3. **Valid Arcs**: All arcs reference existing places and transitions
+4. **Module References**: Substitution transitions reference existing modules
+5. **Complete Socket Assignments**: All port places are assigned to sockets
+6. **Colour Set Matching**: Socket and port colour sets match
+7. **No Circular References**: Modules don't have circular dependencies
+
+## Storage
+
+Modules are automatically persisted as part of the `ColouredPetriNet` definition. The JSON codec handles serialization of all module components.
+
+## Implementation Details
+
+### Files Added
+
+#### Definition Layer
+- `lib/coloured_flow/definition/module.ex` - Module definition
+- `lib/coloured_flow/definition/port_place.ex` - Port place definition
+- `lib/coloured_flow/definition/socket_assignment.ex` - Socket assignment definition
+
+#### Enactment Layer
+- `lib/coloured_flow/enactment/module_instance.ex` - Runtime module instance tracking
+
+#### Validation Layer
+- `lib/coloured_flow/validators/definition/module_validator.ex` - Module validator
+- `lib/coloured_flow/validators/exceptions/invalid_module_error.ex` - Module validation exception
+
+#### Storage Layer
+- `lib/coloured_flow/runner/storage/schemas/json_instance/codec/module.ex` - Module codec
+- `lib/coloured_flow/runner/storage/schemas/json_instance/codec/port_place.ex` - Port place codec
+- `lib/coloured_flow/runner/storage/schemas/json_instance/codec/socket_assignment.ex` - Socket assignment codec
+
+#### Builder Layer
+- `lib/coloured_flow/builder/module_helper.ex` - Module builder helpers
+
+#### Tests
+- `test/coloured_flow/definition/module_test.exs` - Module tests
+- `test/coloured_flow/validators/definition/module_validator_test.exs` - Validator tests
+
+### Files Modified
+
+- `lib/coloured_flow/definition/coloured_petri_net.ex` - Added `modules` field
+- `lib/coloured_flow/definition/transition.ex` - Added `subst` and `socket_assignments` fields
+- `lib/coloured_flow/validators/validators.ex` - Integrated ModuleValidator
+- `lib/coloured_flow/runner/storage/schemas/json_instance/codec/transition.ex` - Updated codec
+- `lib/coloured_flow/runner/storage/schemas/json_instance/codec/coloured_petri_net.ex` - Updated codec
+
+## Future Enhancements
+
+### Module Execution
+Currently, the module execution logic in the enactment layer provides the data structures but not the full execution semantics. Future work should include:
+
+1. **Module Instantiation**: Create module instances when substitution transitions fire
+2. **Token Flow**: Transfer tokens between sockets and ports
+3. **Module Lifecycle**: Manage module instance state (initializing, running, completed, failed)
+4. **Nested Enactments**: Support modules containing substitution transitions
+5. **Module Termination**: Detect when a module instance has completed
+
+### Additional Features
+- **Fusion Places**: Allow multiple places to share the same marking
+- **Module Parameters**: Support parameterized modules
+- **Module Libraries**: Create reusable module libraries
+- **Visual Tools**: Support for visualizing module hierarchies
+
+## References
+
+- [CPN Tools - Substitution Transitions](https://cpntools.org/documentation/gui/sim/subpages/subpages/)
+- [Coloured Petri Nets Book](https://github.com/lmkr/cpnbook)
+- Jensen, K. & Kristensen, L.M. (2009). Coloured Petri Nets: Modelling and Validation of Concurrent Systems

--- a/docs/module_support.md
+++ b/docs/module_support.md
@@ -77,6 +77,179 @@ Socket assignments map places in the parent net (sockets) to port places in the 
 }
 ```
 
+## Converting Existing Flows to Modules
+
+The `FlowConverter` module provides utilities to transform existing `ColouredPetriNet` flows into reusable modules. This is particularly useful when you want to:
+
+- Convert standalone flows into composable components
+- Create module libraries from existing workflows
+- Enable flow reuse without manual restructuring
+
+### Method 1: Manual Port Specification
+
+Explicitly specify which places should become port places and their types:
+
+```elixir
+alias ColouredFlow.Builder.FlowConverter
+
+# You have an existing authentication flow
+auth_flow = %ColouredPetriNet{
+  places: [
+    %Place{name: "credentials", colour_set: :credentials},
+    %Place{name: "verify_step", colour_set: :credentials},
+    %Place{name: "success", colour_set: :unit},
+    %Place{name: "failure", colour_set: :string}
+  ],
+  transitions: [...],
+  arcs: [...]
+}
+
+# Convert it to a module
+auth_module = FlowConverter.flow_to_module(
+  auth_flow,
+  name: "authentication",
+  port_specs: [
+    {"credentials", :input},    # Input port
+    {"success", :output},       # Output port
+    {"failure", :output}        # Output port
+    # "verify_step" becomes an internal place automatically
+  ]
+)
+
+# Now use it in other flows
+main_flow = %ColouredPetriNet{
+  modules: [auth_module],
+  places: [
+    %Place{name: "user_creds", colour_set: :credentials},
+    %Place{name: "auth_ok", colour_set: :unit},
+    %Place{name: "auth_failed", colour_set: :string}
+  ],
+  transitions: [
+    build_substitution_transition!(
+      name: "do_auth",
+      subst: "authentication",
+      socket_assignments: [
+        socket("user_creds", "credentials"),
+        socket("auth_ok", "success"),
+        socket("auth_failed", "failure")
+      ]
+    )
+  ]
+}
+```
+
+### Method 2: Automatic Port Detection
+
+Let the system automatically detect ports based on arc patterns:
+
+```elixir
+# Places with no incoming arcs -> input ports
+# Places with no outgoing arcs -> output ports
+# Places with both -> internal places
+
+auth_module = FlowConverter.flow_to_module_auto(auth_flow, "authentication")
+```
+
+### Validation Before Conversion
+
+Check if a flow can be safely converted:
+
+```elixir
+case FlowConverter.validate_conversion(flow,
+  name: "my_module",
+  port_specs: [{"input", :input}, {"output", :output}]
+) do
+  {:ok, []} ->
+    # Safe to convert, no warnings
+    module = FlowConverter.flow_to_module(flow, ...)
+
+  {:ok, warnings} ->
+    # Can convert, but with warnings
+    IO.puts("Warnings: #{inspect(warnings)}")
+    module = FlowConverter.flow_to_module(flow, ...)
+
+  {:error, errors} ->
+    # Cannot convert
+    IO.puts("Errors: #{inspect(errors)}")
+end
+```
+
+### Common Patterns
+
+#### Pattern 1: Service Flows
+
+Convert service-like flows that have clear inputs and outputs:
+
+```elixir
+# Email service flow
+email_module = FlowConverter.flow_to_module(email_flow,
+  name: "email_sender",
+  port_specs: [
+    {"email_data", :input},
+    {"sent_successfully", :output},
+    {"send_failed", :output}
+  ]
+)
+
+# Notification service flow
+notif_module = FlowConverter.flow_to_module(notification_flow,
+  name: "notifier",
+  port_specs: [
+    {"notification_request", :input},
+    {"notification_sent", :output}
+  ]
+)
+```
+
+#### Pattern 2: Pipeline Stages
+
+Convert pipeline stages into modules:
+
+```elixir
+# Data validation stage
+validate_module = FlowConverter.flow_to_module(validation_flow,
+  name: "validator",
+  port_specs: [
+    {"raw_data", :input},
+    {"valid_data", :output},
+    {"invalid_data", :output}
+  ]
+)
+
+# Data transformation stage
+transform_module = FlowConverter.flow_to_module(transform_flow,
+  name: "transformer",
+  port_specs: [
+    {"valid_data", :input},
+    {"transformed_data", :output}
+  ]
+)
+
+# Compose them in a pipeline
+pipeline = %ColouredPetriNet{
+  modules: [validate_module, transform_module],
+  transitions: [
+    build_substitution_transition!(
+      name: "validate",
+      subst: "validator",
+      socket_assignments: [
+        socket("input", "raw_data"),
+        socket("validated", "valid_data"),
+        socket("errors", "invalid_data")
+      ]
+    ),
+    build_substitution_transition!(
+      name: "transform",
+      subst: "transformer",
+      socket_assignments: [
+        socket("validated", "valid_data"),
+        socket("output", "transformed_data")
+      ]
+    )
+  ]
+}
+```
+
 ## Usage Example
 
 ### Defining a Module

--- a/docs/runtime_module_loading.md
+++ b/docs/runtime_module_loading.md
@@ -1,0 +1,342 @@
+# Runtime Module Loading
+
+This document describes the runtime module loading and management system in ColouredFlow.
+
+## Architecture Overview
+
+The runtime module loading system consists of four main components:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                   ColouredPetriNet                       │
+│  ┌─────────────────────────────────────────────────┐   │
+│  │  Substitution Transition                         │   │
+│  │  - subst: {:module_ref, ...}                    │   │
+│  └──────────────────┬──────────────────────────────┘   │
+└─────────────────────┼──────────────────────────────────┘
+                      │
+                      ▼
+         ┌────────────────────────┐
+         │   ModuleResolver       │
+         │  (Resolve references)  │
+         └────────────┬───────────┘
+                      │
+                      ▼
+         ┌────────────────────────┐
+         │   ModuleLoader         │
+         │  (Load from sources)   │
+         └────────────┬───────────┘
+                      │
+         ┌────────────┴───────────┐
+         │                        │
+         ▼                        ▼
+┌────────────────┐      ┌────────────────┐
+│ ModuleRegistry │      │ ModuleSource   │
+│  (In-memory)   │      │ (DB/File/API)  │
+└────────────────┘      └────────────────┘
+```
+
+## Key Concepts
+
+### 1. Module Reference
+
+A module reference allows substitution transitions to reference modules dynamically:
+
+```elixir
+# Reference by name (from registry)
+%Transition{
+  name: "auth",
+  subst: {:module_ref, name: "authentication"}
+}
+
+# Reference by Flow ID (load from database)
+%Transition{
+  name: "auth",
+  subst: {:module_ref, flow_id: 123, port_specs: [...]}
+}
+
+# Reference by Flow name (load from database)
+%Transition{
+  name: "auth",
+  subst: {:module_ref, flow_name: "auth_flow_v2", port_specs: [...]}
+}
+
+# Direct module name (static, as before)
+%Transition{
+  name: "auth",
+  subst: "authentication"  # Must be in cpnet.modules
+}
+```
+
+### 2. Module Registry
+
+An in-memory registry that stores loaded modules:
+
+```elixir
+# Start the registry
+{:ok, _pid} = ColouredFlow.Runtime.ModuleRegistry.start_link()
+
+# Register a module
+ModuleRegistry.register("authentication", auth_module)
+
+# Get a module
+{:ok, module} = ModuleRegistry.get("authentication")
+
+# List all modules
+modules = ModuleRegistry.list()
+
+# Unregister
+:ok = ModuleRegistry.unregister("authentication")
+```
+
+### 3. Module Loader
+
+Loads modules from various sources:
+
+```elixir
+# Load from database by Flow ID
+{:ok, module} = ModuleLoader.load_from_flow(
+  flow_id: 123,
+  port_specs: [{"input", :input}, {"output", :output}]
+)
+
+# Load from database by Flow name
+{:ok, module} = ModuleLoader.load_from_flow(
+  flow_name: "authentication_v2",
+  port_specs: [...]
+)
+
+# Auto-detect and load
+{:ok, module} = ModuleLoader.load_from_flow_auto(
+  flow_id: 123,
+  module_name: "authentication"
+)
+```
+
+### 4. Module Resolver
+
+Resolves module references at runtime:
+
+```elixir
+# Resolve a module reference
+{:ok, module} = ModuleResolver.resolve(
+  {:module_ref, flow_id: 123, port_specs: [...]},
+  context
+)
+
+# Resolve all module references in a CPN
+{:ok, cpnet_with_modules} = ModuleResolver.resolve_all(cpnet)
+```
+
+## Usage Scenarios
+
+### Scenario 1: Load Flow as Module on Demand
+
+```elixir
+# Define a transition that references a Flow by ID
+cpnet = %ColouredPetriNet{
+  places: [...],
+  transitions: [
+    %Transition{
+      name: "authenticate",
+      subst: {:module_ref,
+        flow_id: 123,
+        port_specs: [
+          {"credentials", :input},
+          {"success", :output},
+          {"failure", :output}
+        ]
+      },
+      socket_assignments: [...]
+    }
+  ]
+}
+
+# At runtime, before execution
+{:ok, resolved_cpnet} = ModuleResolver.resolve_all(cpnet)
+
+# Now resolved_cpnet has the module loaded
+# resolved_cpnet.modules contains the authentication module
+```
+
+### Scenario 2: Module Registry for Shared Modules
+
+```elixir
+# Application startup: Pre-register common modules
+defmodule MyApp.Application do
+  def start(_type, _args) do
+    # Load and register authentication module
+    {:ok, auth_module} = ModuleLoader.load_from_flow(
+      flow_id: 123,
+      port_specs: [...]
+    )
+    ModuleRegistry.register("authentication", auth_module)
+
+    # Load and register other modules
+    ModuleRegistry.register("notification", notif_module)
+    ModuleRegistry.register("email", email_module)
+
+    # ... start supervisors
+  end
+end
+
+# In your flows: Reference by name
+cpnet = %ColouredPetriNet{
+  transitions: [
+    %Transition{
+      name: "auth",
+      subst: {:module_ref, name: "authentication"},
+      socket_assignments: [...]
+    }
+  ]
+}
+```
+
+### Scenario 3: Versioned Modules
+
+```elixir
+# Register multiple versions
+ModuleRegistry.register("authentication:v1", auth_module_v1)
+ModuleRegistry.register("authentication:v2", auth_module_v2)
+ModuleRegistry.register("authentication", auth_module_v2)  # Latest
+
+# Reference specific version
+%Transition{
+  subst: {:module_ref, name: "authentication:v1"}
+}
+
+# Or use latest
+%Transition{
+  subst: {:module_ref, name: "authentication"}
+}
+```
+
+### Scenario 4: Hot Reload
+
+```elixir
+# Update a module at runtime
+new_auth_module = build_new_auth_module()
+ModuleRegistry.update("authentication", new_auth_module)
+
+# New enactments will use the updated module
+# Existing enactments continue with their original module
+```
+
+## Implementation Details
+
+### Module Reference Types
+
+```elixir
+@type module_ref() ::
+  # Reference by name in registry
+  {:module_ref, name: String.t()} |
+
+  # Reference by Flow ID with port specs
+  {:module_ref, flow_id: integer(), port_specs: [port_spec()]} |
+
+  # Reference by Flow ID with auto-detection
+  {:module_ref, flow_id: integer(), module_name: String.t()} |
+
+  # Reference by Flow name
+  {:module_ref, flow_name: String.t(), port_specs: [port_spec()]} |
+
+  # Reference by Flow name with auto-detection
+  {:module_ref, flow_name: String.t(), module_name: String.t()}
+```
+
+### Caching Strategy
+
+1. **Registry Cache**: Modules in registry are kept in memory
+2. **Loader Cache**: Recently loaded modules are cached (with TTL)
+3. **Enactment Cache**: Each enactment keeps its resolved modules
+
+### Error Handling
+
+```elixir
+# Module not found
+{:error, :module_not_found}
+
+# Flow not found
+{:error, :flow_not_found}
+
+# Invalid port specs
+{:error, {:invalid_port_specs, reason}}
+
+# Load failure
+{:error, {:load_failed, reason}}
+```
+
+## Configuration
+
+```elixir
+# In config/config.exs
+config :coloured_flow, ColouredFlow.Runtime.ModuleRegistry,
+  # Enable/disable registry
+  enabled: true,
+
+  # Cache TTL for loaded modules (milliseconds)
+  cache_ttl: 60_000,
+
+  # Max cached modules
+  max_cache_size: 100
+
+config :coloured_flow, ColouredFlow.Runtime.ModuleLoader,
+  # Default repo for loading flows
+  repo: MyApp.Repo,
+
+  # Auto-register loaded modules
+  auto_register: true
+```
+
+## Migration Guide
+
+### Before (Static Modules)
+
+```elixir
+# Define module in the same CPN
+cpnet = %ColouredPetriNet{
+  modules: [auth_module, email_module],
+  transitions: [
+    %Transition{
+      name: "auth",
+      subst: "authentication"  # Static reference
+    }
+  ]
+}
+```
+
+### After (Dynamic Loading)
+
+```elixir
+# Just reference, no need to embed
+cpnet = %ColouredPetriNet{
+  modules: [],  # Empty!
+  transitions: [
+    %Transition{
+      name: "auth",
+      subst: {:module_ref, flow_id: 123, port_specs: [...]}
+    }
+  ]
+}
+
+# Resolve at runtime
+{:ok, resolved_cpnet} = ModuleResolver.resolve_all(cpnet)
+# Now resolved_cpnet.modules contains the loaded module
+```
+
+## Benefits
+
+1. **Separation of Concerns**: Flows and modules can be managed independently
+2. **Reusability**: One Flow can be used as a module in many other flows
+3. **Versioning**: Easy to manage multiple versions of modules
+4. **Hot Updates**: Update modules without restarting
+5. **Lazy Loading**: Load modules only when needed
+6. **Memory Efficiency**: Share module definitions across enactments
+
+## Future Enhancements
+
+1. **Remote Module Loading**: Load modules from remote services
+2. **Module Marketplace**: Share modules across organizations
+3. **Dependency Management**: Resolve transitive module dependencies
+4. **Module Signing**: Verify module integrity
+5. **Performance Monitoring**: Track module load times and cache hits

--- a/docs/subflow_manager_callback_timeline.md
+++ b/docs/subflow_manager_callback_timeline.md
@@ -1,0 +1,632 @@
+# SubFlowManager Callback Invocation Timeline
+
+## Overview
+
+This document describes **when**, **where**, and **why** each SubFlowManager callback is invoked during the execution of a substitution transition.
+
+## Timeline Diagram
+
+```
+Substitution Transition Fires
+           │
+           ▼
+┌─────────────────────────────────────────────────────────┐
+│ 1. resolve_module()                                     │
+│    WHEN: Immediately when transition becomes enabled    │
+│    WHERE: In Enactment process                          │
+│    WHY: Need Module definition to understand interface  │
+└───────────────────────┬─────────────────────────────────┘
+                        │
+                        ▼
+┌─────────────────────────────────────────────────────────┐
+│ 2. start_subflow()                                      │
+│    WHEN: After module resolved, before transition fires │
+│    WHERE: In Enactment process                          │
+│    WHY: Start sub-flow execution with input tokens      │
+└───────────────────────┬─────────────────────────────────┘
+                        │
+                        ▼
+                   ┌────────┐
+                   │ WAIT   │ ← Sub-flow executing
+                   └────┬───┘
+                        │
+                        ▼
+┌─────────────────────────────────────────────────────────┐
+│ 3. query_subflow() (polling loop)                       │
+│    WHEN: Periodically while waiting                     │
+│    WHERE: In Enactment process                          │
+│    WHY: Check if sub-flow completed                     │
+└───────────────────────┬─────────────────────────────────┘
+                        │
+                        ▼
+                 Sub-flow completes
+                        │
+                        ▼
+┌─────────────────────────────────────────────────────────┐
+│ 4. get_subflow_result()                                 │
+│    WHEN: After sub-flow state is :completed             │
+│    WHERE: In Enactment process                          │
+│    WHY: Retrieve output tokens from sub-flow            │
+└───────────────────────┬─────────────────────────────────┘
+                        │
+                        ▼
+              Apply output tokens to
+              parent marking & complete
+                   transition
+
+Optional:
+┌─────────────────────────────────────────────────────────┐
+│ 5. cancel_subflow()                                     │
+│    WHEN: On timeout, error, or explicit cancellation    │
+│    WHERE: In Enactment process                          │
+│    WHY: Clean up sub-flow resources                     │
+└─────────────────────────────────────────────────────────┘
+```
+
+## Detailed Callback Documentation
+
+### 1. `resolve_module/3`
+
+#### When is it called?
+
+**Timing**: When a substitution transition becomes **enabled**
+
+**Trigger**:
+- Transition has all input tokens available
+- Guard evaluates to true
+- Enactment determines the transition can fire
+
+**Frequency**: Once per transition firing (may be cached)
+
+#### Where is it called?
+
+**Caller**: `ColouredFlow.Runner.Enactment` process
+
+**Context**: During binding element computation or transition firing preparation
+
+#### Call Signature
+
+```elixir
+SubFlowManager.resolve_module(
+  manager,
+  module_ref,
+  options
+)
+```
+
+**Parameters**:
+- `manager`: The SubFlowManager instance
+- `module_ref`: `{:module_ref, flow_id: 123, port_specs: [...]}`
+- `options`: Runtime context
+  ```elixir
+  [
+    enactment_id: "parent_enactment_123",
+    parent_transition: "authenticate_user",
+    # ... additional options from enactment config
+  ]
+  ```
+
+**Returns**:
+```elixir
+{:ok, %Module{
+  name: "flow_123_module",
+  port_places: [...],
+  places: [...],
+  transitions: [...],
+  arcs: [...]
+}}
+```
+
+#### Example Usage
+
+```elixir
+defmodule ColouredFlow.Runner.Enactment do
+  def handle_transition_fire(transition, state) do
+    if Transition.substitution?(transition) do
+      # CALL POINT 1: Resolve module
+      case SubFlowManager.resolve_module(
+        state.subflow_manager,
+        transition.subst,
+        enactment_id: state.id,
+        parent_transition: transition.name
+      ) do
+        {:ok, module} ->
+          # Continue with module
+          start_subflow_execution(module, transition, state)
+
+        {:error, reason} ->
+          {:error, {:module_resolution_failed, reason}}
+      end
+    else
+      # Regular transition
+      fire_regular_transition(transition, state)
+    end
+  end
+end
+```
+
+---
+
+### 2. `start_subflow/4`
+
+#### When is it called?
+
+**Timing**: Immediately after module is resolved, before transition is considered "fired"
+
+**Trigger**:
+- Module successfully resolved
+- Input tokens prepared from socket assignments
+- Ready to begin sub-flow execution
+
+**Frequency**: Once per substitution transition firing
+
+#### Where is it called?
+
+**Caller**: `ColouredFlow.Runner.Enactment` process
+
+**Context**: In the transition firing handler, after consuming input tokens
+
+#### Call Signature
+
+```elixir
+SubFlowManager.start_subflow(
+  manager,
+  module,
+  initial_marking,
+  options
+)
+```
+
+**Parameters**:
+- `manager`: The SubFlowManager instance
+- `module`: The resolved Module struct
+- `initial_marking`: Initial tokens for port places
+  ```elixir
+  [
+    %{place: "credentials_in", tokens: %{username: "alice", password: "..."}},
+    # Only INPUT and IO port places
+  ]
+  ```
+- `options`: Execution context
+  ```elixir
+  [
+    parent_enactment_id: "parent_123",
+    parent_transition: "authenticate_user",
+    timeout: 30_000,  # Optional timeout
+    # ... additional options
+  ]
+  ```
+
+**Returns**:
+```elixir
+{:ok, subflow_id}
+# where subflow_id might be: {:enactment, #PID<0.123.0>}
+# or: "subflow_uuid_123"
+```
+
+#### Example Usage
+
+```elixir
+defmodule ColouredFlow.Runner.Enactment do
+  defp start_subflow_execution(module, transition, state) do
+    # Prepare input tokens from socket assignments
+    input_marking = build_input_marking(
+      transition.socket_assignments,
+      state.marking,
+      module
+    )
+
+    # CALL POINT 2: Start sub-flow
+    case SubFlowManager.start_subflow(
+      state.subflow_manager,
+      module,
+      input_marking,
+      parent_enactment_id: state.id,
+      parent_transition: transition.name,
+      timeout: 60_000
+    ) do
+      {:ok, subflow_id} ->
+        # Store subflow_id in state and wait for completion
+        wait_for_subflow(subflow_id, transition, state)
+
+      {:error, reason} ->
+        {:error, {:subflow_start_failed, reason}}
+    end
+  end
+
+  defp build_input_marking(socket_assignments, parent_marking, module) do
+    input_ports = Module.input_ports(module)
+
+    Enum.map(input_ports, fn port_place ->
+      # Find corresponding socket assignment
+      socket_assignment = Enum.find(
+        socket_assignments,
+        &(&1.port == port_place.name)
+      )
+
+      # Get tokens from parent marking at socket place
+      tokens = get_tokens(parent_marking, socket_assignment.socket)
+
+      %{place: port_place.name, tokens: tokens}
+    end)
+  end
+end
+```
+
+---
+
+### 3. `query_subflow/3`
+
+#### When is it called?
+
+**Timing**: Repeatedly while waiting for sub-flow completion
+
+**Trigger**:
+- Sub-flow has been started
+- Parent enactment is waiting for completion
+- Polling interval reached (e.g., every 100ms)
+
+**Frequency**: Multiple times (polling) until sub-flow completes
+
+#### Where is it called?
+
+**Caller**: `ColouredFlow.Runner.Enactment` process
+
+**Context**: In a polling loop or timeout handler
+
+#### Call Signature
+
+```elixir
+SubFlowManager.query_subflow(
+  manager,
+  subflow_id,
+  options
+)
+```
+
+**Parameters**:
+- `manager`: The SubFlowManager instance
+- `subflow_id`: The identifier returned from `start_subflow`
+- `options`: Query options (usually empty)
+
+**Returns**:
+```elixir
+{:ok, :initializing}  # Sub-flow starting up
+{:ok, :running}       # Sub-flow executing
+{:ok, :completed}     # Sub-flow finished successfully
+{:ok, :failed}        # Sub-flow failed
+{:ok, :cancelled}     # Sub-flow was cancelled
+```
+
+#### Example Usage
+
+```elixir
+defmodule ColouredFlow.Runner.Enactment do
+  defp wait_for_subflow(subflow_id, transition, state) do
+    # CALL POINT 3: Query sub-flow status (polling)
+    Stream.repeatedly(fn ->
+      :timer.sleep(100)  # Poll interval
+
+      case SubFlowManager.query_subflow(
+        state.subflow_manager,
+        subflow_id
+      ) do
+        {:ok, status} -> status
+        {:error, _} -> :error
+      end
+    end)
+    |> Stream.take_while(fn status ->
+      status in [:initializing, :running]
+    end)
+    |> Stream.run()
+
+    # Final status check
+    case SubFlowManager.query_subflow(
+      state.subflow_manager,
+      subflow_id
+    ) do
+      {:ok, :completed} ->
+        retrieve_subflow_results(subflow_id, transition, state)
+
+      {:ok, :failed} ->
+        {:error, :subflow_failed}
+
+      {:error, reason} ->
+        {:error, {:query_failed, reason}}
+    end
+  end
+end
+```
+
+**Alternative: Event-based (if supported)**
+
+```elixir
+# Instead of polling, subscribe to events
+defp wait_for_subflow_async(subflow_id, transition, state) do
+  # Subscribe to sub-flow completion event
+  :ok = SubFlowManager.subscribe(state.subflow_manager, subflow_id)
+
+  receive do
+    {:subflow_completed, ^subflow_id} ->
+      retrieve_subflow_results(subflow_id, transition, state)
+
+    {:subflow_failed, ^subflow_id, reason} ->
+      {:error, {:subflow_failed, reason}}
+  after
+    60_000 ->
+      # Timeout: cancel sub-flow
+      SubFlowManager.cancel_subflow(state.subflow_manager, subflow_id)
+      {:error, :timeout}
+  end
+end
+```
+
+---
+
+### 4. `get_subflow_result/3`
+
+#### When is it called?
+
+**Timing**: After sub-flow state becomes `:completed`
+
+**Trigger**:
+- `query_subflow` returned `{:ok, :completed}`
+- Ready to retrieve output tokens
+
+**Frequency**: Once per successful sub-flow execution
+
+#### Where is it called?
+
+**Caller**: `ColouredFlow.Runner.Enactment` process
+
+**Context**: After confirming sub-flow completion, before applying output tokens
+
+#### Call Signature
+
+```elixir
+SubFlowManager.get_subflow_result(
+  manager,
+  subflow_id,
+  options
+)
+```
+
+**Parameters**:
+- `manager`: The SubFlowManager instance
+- `subflow_id`: The sub-flow identifier
+- `options`: Retrieval options
+  ```elixir
+  [
+    include_internal_places: false,  # Only output ports by default
+    # ... other options
+  ]
+  ```
+
+**Returns**:
+```elixir
+{:ok, [
+  %{place: "success_out", tokens: %{user_id: 123}},
+  %{place: "failure_out", tokens: []}
+]}
+```
+
+#### Example Usage
+
+```elixir
+defmodule ColouredFlow.Runner.Enactment do
+  defp retrieve_subflow_results(subflow_id, transition, state) do
+    # CALL POINT 4: Get sub-flow results
+    case SubFlowManager.get_subflow_result(
+      state.subflow_manager,
+      subflow_id
+    ) do
+      {:ok, output_marking} ->
+        # Apply output tokens to parent marking via socket assignments
+        new_marking = apply_output_tokens(
+          output_marking,
+          transition.socket_assignments,
+          state.marking
+        )
+
+        # Update state and complete transition
+        {:ok, %{state | marking: new_marking}}
+
+      {:error, reason} ->
+        {:error, {:result_retrieval_failed, reason}}
+    end
+  end
+
+  defp apply_output_tokens(output_marking, socket_assignments, parent_marking) do
+    Enum.reduce(output_marking, parent_marking, fn output, marking ->
+      # Find socket assignment for this output port
+      socket_assignment = Enum.find(
+        socket_assignments,
+        &(&1.port == output.place)
+      )
+
+      # Add tokens to parent marking at socket place
+      add_tokens(marking, socket_assignment.socket, output.tokens)
+    end)
+  end
+end
+```
+
+---
+
+### 5. `cancel_subflow/3` (Optional)
+
+#### When is it called?
+
+**Timing**: When sub-flow needs to be terminated prematurely
+
+**Trigger**:
+- Timeout exceeded
+- Parent enactment stopping/crashing
+- Explicit cancellation request
+- Error in parent enactment
+
+**Frequency**: Zero or once per sub-flow (only if needed)
+
+#### Where is it called?
+
+**Caller**: `ColouredFlow.Runner.Enactment` process
+
+**Context**: In timeout handler or error recovery
+
+#### Call Signature
+
+```elixir
+SubFlowManager.cancel_subflow(
+  manager,
+  subflow_id,
+  options
+)
+```
+
+**Parameters**:
+- `manager`: The SubFlowManager instance
+- `subflow_id`: The sub-flow to cancel
+- `options`: Cancellation options
+  ```elixir
+  [
+    reason: :timeout,
+    cleanup: true  # Clean up resources
+  ]
+  ```
+
+**Returns**:
+```elixir
+:ok
+{:error, :already_completed}  # Can't cancel completed sub-flow
+```
+
+#### Example Usage
+
+```elixir
+defmodule ColouredFlow.Runner.Enactment do
+  defp wait_for_subflow_with_timeout(subflow_id, transition, state) do
+    task = Task.async(fn ->
+      wait_for_subflow(subflow_id, transition, state)
+    end)
+
+    case Task.yield(task, 30_000) || Task.shutdown(task) do
+      {:ok, result} ->
+        result
+
+      nil ->
+        # Timeout!
+        # CALL POINT 5: Cancel sub-flow
+        SubFlowManager.cancel_subflow(
+          state.subflow_manager,
+          subflow_id,
+          reason: :timeout
+        )
+        {:error, :subflow_timeout}
+    end
+  end
+
+  # Also call on enactment termination
+  def terminate(reason, state) do
+    # Cancel all running sub-flows
+    Enum.each(state.active_subflows, fn subflow_id ->
+      SubFlowManager.cancel_subflow(
+        state.subflow_manager,
+        subflow_id,
+        reason: {:parent_terminating, reason}
+      )
+    end)
+  end
+end
+```
+
+---
+
+## Complete Flow Example
+
+```elixir
+defmodule ColouredFlow.Runner.Enactment do
+  @doc """
+  Handle a substitution transition firing.
+
+  This shows the complete flow with all callback invocations.
+  """
+  def handle_substitution_transition(transition, state) do
+    with(
+      # 1. RESOLVE MODULE
+      {:ok, module} <-
+        SubFlowManager.resolve_module(
+          state.subflow_manager,
+          transition.subst,
+          enactment_id: state.id
+        ),
+
+      # 2. START SUB-FLOW
+      input_marking = build_input_marking(transition, state, module),
+      {:ok, subflow_id} <-
+        SubFlowManager.start_subflow(
+          state.subflow_manager,
+          module,
+          input_marking,
+          parent_enactment_id: state.id,
+          parent_transition: transition.name
+        ),
+
+      # 3. WAIT FOR COMPLETION (queries internally)
+      {:ok, :completed} <- wait_for_completion(state.subflow_manager, subflow_id),
+
+      # 4. GET RESULTS
+      {:ok, output_marking} <-
+        SubFlowManager.get_subflow_result(
+          state.subflow_manager,
+          subflow_id
+        ),
+
+      # Apply outputs to parent
+      new_marking = apply_outputs(output_marking, transition, state.marking)
+    ) do
+      {:ok, %{state | marking: new_marking}}
+    else
+      {:error, reason} ->
+        # 5. CANCEL on error (if sub-flow started)
+        if subflow_id do
+          SubFlowManager.cancel_subflow(
+            state.subflow_manager,
+            subflow_id,
+            reason: reason
+          )
+        end
+
+        {:error, reason}
+    end
+  end
+
+  defp wait_for_completion(manager, subflow_id) do
+    # Polling with query_subflow
+    Stream.repeatedly(fn ->
+      :timer.sleep(100)
+      SubFlowManager.query_subflow(manager, subflow_id)
+    end)
+    |> Stream.take_while(fn
+      {:ok, status} when status in [:initializing, :running] -> true
+      _ -> false
+    end)
+    |> Stream.run()
+
+    SubFlowManager.query_subflow(manager, subflow_id)
+  end
+end
+```
+
+## Summary Table
+
+| Callback | When | Frequency | Caller | Purpose |
+|----------|------|-----------|--------|---------|
+| `resolve_module` | Transition enabled | Once | Enactment | Get Module definition |
+| `start_subflow` | After module resolved | Once | Enactment | Start sub-flow execution |
+| `query_subflow` | While waiting | Multiple (polling) | Enactment | Check completion status |
+| `get_subflow_result` | After completion | Once | Enactment | Retrieve output tokens |
+| `cancel_subflow` | On timeout/error | Zero or once | Enactment | Clean up resources |
+
+## Questions?
+
+这个调用时机清晰吗？有什么需要补充或调整的地方吗？

--- a/docs/subflow_manager_design.md
+++ b/docs/subflow_manager_design.md
@@ -1,0 +1,402 @@
+# SubFlowManager Design
+
+## Overview
+
+`SubFlowManager` is responsible for the complete lifecycle of module execution:
+1. **Resolve** module references to concrete Module definitions
+2. **Start** sub-flow instances (module executions)
+3. **Query** sub-flow status and state
+4. **Retrieve** sub-flow results (output tokens)
+5. **Manage** sub-flow lifecycle (optional: pause, resume, cancel)
+
+## Naming Consideration
+
+**Why not "ModuleResolver"?**
+- Too narrow - only implies resolution
+- Doesn't convey lifecycle management
+
+**Why "SubFlowManager"?**
+- ✅ Covers entire lifecycle
+- ✅ Emphasizes that modules are executed as sub-flows
+- ✅ Clear responsibility: manage sub-flow instances
+
+**Alternatives considered:**
+- `ModuleExecutor` - focuses on execution, misses query/management
+- `ModuleRuntime` - too vague
+- `SubstitutionHandler` - tied to CPN terminology, not intuitive
+
+## Behaviour Callbacks
+
+### Option A: Detailed Lifecycle (Recommended)
+
+```elixir
+defprotocol ColouredFlow.Runtime.SubFlowManager do
+  @moduledoc """
+  Protocol for managing sub-flow (module) lifecycle.
+
+  A sub-flow is an instance of a module being executed as part of
+  a substitution transition.
+  """
+
+  alias ColouredFlow.Definition.Module
+  alias ColouredFlow.Runtime.ModuleReference
+
+  @typedoc "Sub-flow instance identifier"
+  @type subflow_id() :: term()
+
+  @typedoc "Sub-flow execution state"
+  @type subflow_state() :: :initializing | :running | :completed | :failed | :cancelled
+
+  @typedoc "Token marking for a place"
+  @type marking() :: %{place: String.t(), tokens: term()}
+
+  @doc """
+  Resolve a module reference to a concrete Module definition.
+
+  ## Parameters
+  - `manager`: The manager instance
+  - `module_ref`: Module reference to resolve
+  - `options`: Runtime options (enactment_id, etc.)
+
+  ## Returns
+  - `{:ok, module}`: Successfully resolved
+  - `{:error, reason}`: Resolution failed
+
+  ## Examples
+
+      {:ok, module} = SubFlowManager.resolve_module(
+        manager,
+        {:module_ref, flow_id: 123, port_specs: [...]},
+        enactment_id: "parent_123"
+      )
+  """
+  @spec resolve_module(t(), ModuleReference.t(), Keyword.t()) ::
+    {:ok, Module.t()} | {:error, term()}
+  def resolve_module(manager, module_ref, options)
+
+  @doc """
+  Start a sub-flow instance.
+
+  ## Parameters
+  - `manager`: The manager instance
+  - `module`: The module to execute
+  - `initial_marking`: Initial tokens for port places
+  - `options`: Execution options
+
+  ## Returns
+  - `{:ok, subflow_id}`: Sub-flow started successfully
+  - `{:error, reason}`: Failed to start
+
+  ## Examples
+
+      {:ok, subflow_id} = SubFlowManager.start_subflow(
+        manager,
+        auth_module,
+        [%{place: "credentials", tokens: creds}],
+        parent_enactment_id: "parent_123",
+        parent_transition: "authenticate"
+      )
+  """
+  @spec start_subflow(t(), Module.t(), [marking()], Keyword.t()) ::
+    {:ok, subflow_id()} | {:error, term()}
+  def start_subflow(manager, module, initial_marking, options)
+
+  @doc """
+  Query the current state of a sub-flow.
+
+  ## Parameters
+  - `manager`: The manager instance
+  - `subflow_id`: The sub-flow to query
+  - `options`: Query options
+
+  ## Returns
+  - `{:ok, state}`: Current state
+  - `{:error, reason}`: Query failed
+
+  ## Examples
+
+      {:ok, :running} = SubFlowManager.query_subflow(manager, subflow_id)
+  """
+  @spec query_subflow(t(), subflow_id(), Keyword.t()) ::
+    {:ok, subflow_state()} | {:error, term()}
+  def query_subflow(manager, subflow_id, options \\ [])
+
+  @doc """
+  Get the final marking (output tokens) from a completed sub-flow.
+
+  ## Parameters
+  - `manager`: The manager instance
+  - `subflow_id`: The sub-flow to get results from
+  - `options`: Retrieval options
+
+  ## Returns
+  - `{:ok, marking}`: Final marking (output port tokens)
+  - `{:error, reason}`: Failed to get results
+
+  ## Examples
+
+      {:ok, outputs} = SubFlowManager.get_subflow_result(manager, subflow_id)
+      # outputs: [%{place: "success", tokens: {...}}, ...]
+  """
+  @spec get_subflow_result(t(), subflow_id(), Keyword.t()) ::
+    {:ok, [marking()]} | {:error, term()}
+  def get_subflow_result(manager, subflow_id, options \\ [])
+
+  @doc """
+  Cancel a running sub-flow (optional).
+
+  ## Parameters
+  - `manager`: The manager instance
+  - `subflow_id`: The sub-flow to cancel
+  - `options`: Cancellation options
+
+  ## Returns
+  - `:ok`: Successfully cancelled
+  - `{:error, reason}`: Cancellation failed
+  """
+  @spec cancel_subflow(t(), subflow_id(), Keyword.t()) ::
+    :ok | {:error, term()}
+  def cancel_subflow(manager, subflow_id, options \\ [])
+end
+```
+
+### Option B: Simplified (Execute-based)
+
+```elixir
+defprotocol ColouredFlow.Runtime.SubFlowManager do
+  @doc """
+  Resolve and execute a module reference synchronously.
+
+  This is a simplified API that combines resolve + start + wait.
+
+  ## Parameters
+  - `manager`: The manager instance
+  - `module_ref`: Module reference to execute
+  - `input_tokens`: Input tokens for port places
+  - `options`: Execution options
+
+  ## Returns
+  - `{:ok, output_tokens}`: Execution completed
+  - `{:error, reason}`: Execution failed
+
+  ## Examples
+
+      {:ok, outputs} = SubFlowManager.execute(
+        manager,
+        {:module_ref, flow_id: 123, port_specs: [...]},
+        [%{place: "input", tokens: data}],
+        timeout: 5000
+      )
+  """
+  @spec execute(t(), ModuleReference.t(), [marking()], Keyword.t()) ::
+    {:ok, [marking()]} | {:error, term()}
+  def execute(manager, module_ref, input_tokens, options)
+
+  @doc """
+  Start asynchronous execution (optional).
+
+  Returns immediately with a handle for later querying.
+  """
+  @spec execute_async(t(), ModuleReference.t(), [marking()], Keyword.t()) ::
+    {:ok, async_handle()} | {:error, term()}
+  def execute_async(manager, module_ref, input_tokens, options)
+
+  @doc """
+  Wait for async execution to complete.
+  """
+  @spec await(t(), async_handle(), timeout()) ::
+    {:ok, [marking()]} | {:error, term()}
+  def await(manager, handle, timeout \\ 5000)
+end
+```
+
+## Comparison
+
+### Option A: Detailed Lifecycle
+
+**Pros:**
+- ✅ Full control over sub-flow lifecycle
+- ✅ Can query intermediate state
+- ✅ Can cancel long-running flows
+- ✅ Matches CPN theory (module instances)
+
+**Cons:**
+- ❌ More complex API
+- ❌ Need to manage subflow_id
+
+**Use when:**
+- Sub-flows are long-running
+- Need to monitor progress
+- Need cancellation support
+
+### Option B: Simplified Execute
+
+**Pros:**
+- ✅ Simpler API (one call)
+- ✅ No subflow_id management
+- ✅ Easier to implement
+
+**Cons:**
+- ❌ Less control
+- ❌ Blocking (unless async)
+- ❌ Can't query intermediate state
+
+**Use when:**
+- Sub-flows are quick
+- Don't need progress monitoring
+- Simple use cases
+
+## Recommendation
+
+**Use Option A (Detailed Lifecycle)** because:
+
+1. **Aligns with CPN theory** - Modules are instantiated as sub-enactments
+2. **Future-proof** - Can add monitoring, debugging later
+3. **Flexibility** - Supports both sync and async patterns
+4. **Realistic** - Sub-flows may be long-running (user approval, API calls, etc.)
+
+## Default Implementation Structure
+
+```elixir
+defmodule ColouredFlow.Runtime.SubFlowManager.Default do
+  @moduledoc """
+  Default sub-flow manager that:
+  1. Resolves modules from database using FlowConverter
+  2. Starts sub-flows as separate Enactment processes
+  3. Tracks sub-flow state
+  """
+
+  defstruct [:repo, :supervisor, :cache]
+
+  def new(opts) do
+    %__MODULE__{
+      repo: Keyword.fetch!(opts, :repo),
+      supervisor: Keyword.get(opts, :supervisor),
+      cache: Keyword.get(opts, :cache, false)
+    }
+  end
+end
+
+defimpl SubFlowManager, for: SubFlowManager.Default do
+  def resolve_module(%{repo: repo}, module_ref, opts) do
+    # Load from database using FlowConverter
+    # Same as before
+  end
+
+  def start_subflow(%{supervisor: sup}, module, initial_marking, opts) do
+    # Create CPN from module
+    cpnet = module_to_cpnet(module)
+
+    # Start as child enactment under supervisor
+    {:ok, pid} = Enactment.start_link(
+      cpnet: cpnet,
+      initial_marking: initial_marking,
+      parent: opts[:parent_enactment_id]
+    )
+
+    # Return identifier
+    {:ok, {:enactment, pid}}
+  end
+
+  def query_subflow(_manager, {:enactment, pid}, _opts) do
+    # Query enactment state
+    case Enactment.get_state(pid) do
+      %{status: status} -> {:ok, status}
+      _ -> {:error, :not_found}
+    end
+  end
+
+  def get_subflow_result(_manager, {:enactment, pid}, _opts) do
+    # Get final marking from enactment
+    case Enactment.get_final_marking(pid) do
+      {:ok, marking} ->
+        # Filter to only output port places
+        {:ok, marking}
+      error -> error
+    end
+  end
+
+  def cancel_subflow(_manager, {:enactment, pid}, _opts) do
+    # Terminate enactment
+    Enactment.stop(pid)
+  end
+end
+```
+
+## Usage Example
+
+```elixir
+# 1. Initialize manager
+manager = SubFlowManager.Default.new(
+  repo: MyApp.Repo,
+  supervisor: MyApp.EnactmentSupervisor
+)
+
+# 2. In substitution transition handler
+def fire_substitution_transition(transition, state) do
+  # Resolve module
+  {:ok, module} = SubFlowManager.resolve_module(
+    manager,
+    transition.subst,
+    enactment_id: state.id
+  )
+
+  # Prepare input tokens (from socket assignments)
+  input_tokens = prepare_input_tokens(transition, state.marking)
+
+  # Start sub-flow
+  {:ok, subflow_id} = SubFlowManager.start_subflow(
+    manager,
+    module,
+    input_tokens,
+    parent_enactment_id: state.id,
+    parent_transition: transition.name
+  )
+
+  # Wait for completion (or handle async)
+  case wait_for_subflow(manager, subflow_id) do
+    {:ok, :completed} ->
+      # Get results
+      {:ok, output_tokens} = SubFlowManager.get_subflow_result(
+        manager,
+        subflow_id
+      )
+
+      # Apply output tokens to parent marking
+      apply_output_tokens(output_tokens, transition, state)
+
+    {:ok, :failed} ->
+      {:error, :subflow_failed}
+  end
+end
+
+defp wait_for_subflow(manager, subflow_id) do
+  # Poll or subscribe to state changes
+  Stream.repeatedly(fn ->
+    SubFlowManager.query_subflow(manager, subflow_id)
+  end)
+  |> Stream.take_while(fn
+    {:ok, state} when state in [:initializing, :running] -> true
+    _ -> false
+  end)
+  |> Stream.run()
+
+  SubFlowManager.query_subflow(manager, subflow_id)
+end
+```
+
+## Questions for Confirmation
+
+1. **Naming**: Is `SubFlowManager` a good name? Alternatives?
+2. **Callbacks**: Should we use Option A (detailed) or Option B (simplified)?
+3. **Additional callbacks**: Any other operations needed?
+   - Pause/resume?
+   - Get intermediate state/marking?
+   - List all sub-flows?
+4. **Sync vs Async**: Should we support both patterns?
+5. **Error handling**: What error scenarios to handle?
+   - Sub-flow crashes?
+   - Timeout?
+   - Deadlock detection?
+
+Let's confirm the design before implementation!

--- a/docs/subflow_manager_revised.md
+++ b/docs/subflow_manager_revised.md
@@ -1,0 +1,564 @@
+# SubFlowManager Design (Revised)
+
+## Naming Decision
+
+**Recommendation: Use "Child Enactment"**
+
+### Comparison
+
+| Term | Pros | Cons | Score |
+|------|------|------|-------|
+| **sub enactment** | Clear hierarchy | "sub" prefix less common | 7/10 |
+| **child enactment** | ✅ Standard parent-child terminology<br>✅ Matches OTP supervisor pattern<br>✅ Clear relationship | None | **9/10** ✅ |
+| **subflow** | Short | Not aligned with CPN terminology | 5/10 |
+
+**Decision**: Use **"child enactment"** because:
+- Aligns with OTP conventions (supervisor-child)
+- Makes parent-child relationship explicit
+- Consistent with ColouredFlow terminology (enactment is core concept)
+- More accurate: modules execute as enactment instances
+
+---
+
+## Core Design Principles
+
+### 1. Message-Based Communication (No Polling)
+
+Child enactments send messages to parent when state changes:
+
+```elixir
+# Child enactment sends messages to parent
+send(parent_pid, {:child_enactment_completed, child_id, output_marking})
+send(parent_pid, {:child_enactment_failed, child_id, reason})
+```
+
+**Benefits**:
+- ✅ More efficient (no polling overhead)
+- ✅ Reactive (immediate notification)
+- ✅ Idiomatic Elixir/OTP
+- ✅ Supports both sync and async patterns
+
+### 2. No Direct Cancellation (Token-Based Control)
+
+Child enactments cannot be forcefully cancelled. Termination is controlled through Petri Net semantics:
+
+**Wrong approach** (imperative):
+```elixir
+# ❌ Direct cancellation breaks CPN semantics
+SubFlowManager.cancel_child_enactment(child_id)
+```
+
+**Correct approach** (declarative):
+```elixir
+# ✅ Send cancellation token to child enactment
+# Child enactment decides how to handle based on its CPN definition
+SubFlowManager.send_cancellation_token(child_id, cancel_token)
+```
+
+**Why?**
+- Maintains Petri Net semantics
+- Child enactment controls its own lifecycle
+- Cancellation is part of the workflow logic, not external control
+- More predictable and testable
+
+### 3. Token Sharing Through Port/Socket Mapping
+
+Parent and child enactments share tokens through **socket assignments**:
+
+```
+Parent Enactment                    Child Enactment (Module)
+┌──────────────────┐               ┌──────────────────┐
+│ Socket Place     │               │ Port Place       │
+│ "user_input"     │──────────────>│ "credentials_in" │ (INPUT)
+│ tokens: {...}    │   Copy        │ tokens: {...}    │
+└──────────────────┘   tokens      └──────────────────┘
+                                              │
+                                              │ Execute
+                                              ▼
+┌──────────────────┐               ┌──────────────────┐
+│ Socket Place     │<──────────────│ Port Place       │ (OUTPUT)
+│ "auth_result"    │   Copy        │ "success_out"    │
+│ tokens: {...}    │   tokens      │ tokens: {...}    │
+└──────────────────┘               └──────────────────┘
+```
+
+**Token Flow**:
+1. **Before child starts**: Copy input tokens from parent sockets → child input ports
+2. **Child executes**: Tokens flow through child enactment's CPN
+3. **After child completes**: Copy output tokens from child output ports → parent sockets
+
+---
+
+## Revised Behaviour Definition
+
+```elixir
+defprotocol ColouredFlow.Runtime.SubFlowManager do
+  @moduledoc """
+  Protocol for managing child enactment (module execution) lifecycle.
+
+  A child enactment is an instance of a module being executed as part of
+  a substitution transition. Communication happens via messages, not polling.
+  """
+
+  alias ColouredFlow.Definition.Module
+  alias ColouredFlow.Runtime.ModuleReference
+
+  @typedoc "Child enactment identifier (typically a PID)"
+  @type child_id() :: pid() | term()
+
+  @typedoc "Token marking for a place"
+  @type marking() :: %{place: String.t(), tokens: term()}
+
+  @doc """
+  Resolve a module reference to a concrete Module definition.
+
+  ## When
+  - Called when substitution transition becomes enabled
+  - Before child enactment starts
+
+  ## Parameters
+  - `manager`: The manager instance
+  - `module_ref`: Module reference to resolve
+  - `options`: Runtime options (enactment_id, etc.)
+
+  ## Returns
+  - `{:ok, module}`: Successfully resolved
+  - `{:error, reason}`: Resolution failed
+
+  ## Example
+      {:ok, module} = SubFlowManager.resolve_module(
+        manager,
+        {:module_ref, flow_id: 123, port_specs: [...]},
+        enactment_id: "parent_123"
+      )
+  """
+  @spec resolve_module(t(), ModuleReference.t(), Keyword.t()) ::
+    {:ok, Module.t()} | {:error, term()}
+  def resolve_module(manager, module_ref, options)
+
+  @doc """
+  Start a child enactment.
+
+  The child enactment will send messages back to the parent when:
+  - Initialization completes: `{:child_enactment_ready, child_id}`
+  - Execution completes: `{:child_enactment_completed, child_id, output_marking}`
+  - Execution fails: `{:child_enactment_failed, child_id, reason}`
+
+  ## When
+  - Called after module resolved
+  - After input tokens prepared from socket assignments
+
+  ## Parameters
+  - `manager`: The manager instance
+  - `module`: The module to execute
+  - `initial_marking`: Initial tokens for input port places
+  - `options`: Execution options
+    - `:parent_pid` (required) - Parent enactment PID for sending messages
+    - `:parent_enactment_id` - Parent enactment ID for context
+    - `:parent_transition` - Name of substitution transition
+
+  ## Returns
+  - `{:ok, child_id}`: Child enactment started, will send messages to parent
+  - `{:error, reason}`: Failed to start
+
+  ## Example
+      {:ok, child_id} = SubFlowManager.start_child_enactment(
+        manager,
+        auth_module,
+        [%{place: "credentials_in", tokens: creds}],
+        parent_pid: self(),
+        parent_enactment_id: "parent_123",
+        parent_transition: "authenticate"
+      )
+
+      # Later, parent receives:
+      receive do
+        {:child_enactment_completed, ^child_id, output_marking} ->
+          # Apply output tokens to parent marking
+          apply_outputs(output_marking, ...)
+      end
+  """
+  @spec start_child_enactment(t(), Module.t(), [marking()], Keyword.t()) ::
+    {:ok, child_id()} | {:error, term()}
+  def start_child_enactment(manager, module, initial_marking, options)
+
+  @doc """
+  Get current state of a child enactment (optional, for debugging).
+
+  This is NOT for waiting/polling. Parent should use message-based waiting.
+
+  ## When
+  - Called for debugging or monitoring purposes only
+
+  ## Parameters
+  - `manager`: The manager instance
+  - `child_id`: The child enactment identifier
+
+  ## Returns
+  - `{:ok, state_info}`: Current state information
+  - `{:error, :not_found}`: Child enactment not found
+
+  ## Example
+      {:ok, info} = SubFlowManager.get_child_state(manager, child_id)
+      # info: %{status: :running, marking: {...}, ...}
+  """
+  @spec get_child_state(t(), child_id()) ::
+    {:ok, map()} | {:error, term()}
+  def get_child_state(manager, child_id)
+end
+```
+
+---
+
+## Message Protocol
+
+### Messages Sent by Child Enactment
+
+```elixir
+# 1. Child enactment initialized and ready
+{:child_enactment_ready, child_id}
+
+# 2. Child enactment completed successfully
+{:child_enactment_completed, child_id, output_marking}
+# where output_marking is:
+# [
+#   %{place: "success_out", tokens: %{user_id: 123}},
+#   %{place: "failure_out", tokens: []}
+# ]
+
+# 3. Child enactment failed
+{:child_enactment_failed, child_id, reason}
+# where reason is:
+# - {:deadlock, marking} - No enabled transitions
+# - {:error_in_action, transition, error} - Action failed
+# - {:timeout, duration} - Execution timeout
+```
+
+### Parent Enactment Message Handling
+
+```elixir
+defmodule ColouredFlow.Runner.Enactment do
+  def handle_info({:child_enactment_completed, child_id, output_marking}, state) do
+    # Find the substitution transition associated with this child
+    case Map.get(state.active_children, child_id) do
+      nil ->
+        # Unknown child, ignore
+        {:noreply, state}
+
+      %{transition: transition, awaiting: true} ->
+        # Apply output tokens to parent marking
+        new_marking = apply_child_outputs(
+          output_marking,
+          transition.socket_assignments,
+          state.marking
+        )
+
+        # Remove from active children
+        new_children = Map.delete(state.active_children, child_id)
+
+        # Continue enactment execution
+        new_state = %{state |
+          marking: new_marking,
+          active_children: new_children
+        }
+
+        {:noreply, new_state}
+    end
+  end
+
+  def handle_info({:child_enactment_failed, child_id, reason}, state) do
+    # Handle child failure
+    case Map.get(state.active_children, child_id) do
+      nil ->
+        {:noreply, state}
+
+      %{transition: transition} ->
+        # Log error, potentially mark failure place, etc.
+        Logger.error("Child enactment failed: #{inspect(reason)}")
+
+        # Remove from active children
+        new_children = Map.delete(state.active_children, child_id)
+
+        # Optionally: add failure token to a failure place
+        # This allows parent CPN to handle child failure as part of workflow
+
+        {:noreply, %{state | active_children: new_children}}
+    end
+  end
+end
+```
+
+---
+
+## Token Sharing Detailed Design
+
+### Input Token Flow (Parent → Child)
+
+```elixir
+defmodule ColouredFlow.Runner.Enactment do
+  defp prepare_child_input_marking(transition, parent_marking, module) do
+    # Get input and I/O port places from module
+    input_ports = Module.input_ports(module)  # Returns input + io ports
+
+    Enum.map(input_ports, fn port_place ->
+      # Find socket assignment for this port
+      socket_assignment = Enum.find(
+        transition.socket_assignments,
+        &(&1.port == port_place.name)
+      )
+
+      # Get tokens from parent marking at socket place
+      socket_tokens = get_tokens_from_marking(
+        parent_marking,
+        socket_assignment.socket
+      )
+
+      # Create initial marking for child port place
+      %{place: port_place.name, tokens: socket_tokens}
+    end)
+  end
+end
+```
+
+**Token Copy Semantics**:
+- **Copy, not move**: Tokens are copied from parent to child
+- **Consumption**: Parent socket tokens are consumed when transition fires
+- **Independence**: Child has its own copy, modifications don't affect parent
+
+### Output Token Flow (Child → Parent)
+
+```elixir
+defmodule ColouredFlow.Runner.Enactment do
+  defp apply_child_outputs(child_output_marking, socket_assignments, parent_marking) do
+    Enum.reduce(child_output_marking, parent_marking, fn output, marking ->
+      # Find corresponding socket assignment
+      socket_assignment = Enum.find(
+        socket_assignments,
+        &(&1.port == output.place)
+      )
+
+      # Add tokens from child output port to parent socket place
+      add_tokens_to_marking(
+        marking,
+        socket_assignment.socket,
+        output.tokens
+      )
+    end)
+  end
+end
+```
+
+**Token Production Semantics**:
+- **Copy**: Tokens from child output ports are copied to parent sockets
+- **Addition**: New tokens are added to parent marking
+- **Completion**: Only happens after child reports completion
+
+### I/O Port Places
+
+For **bidirectional (I/O) ports**, tokens flow both ways:
+
+```elixir
+# Before child starts: Copy from parent socket → child I/O port
+initial_marking = [
+  %{place: "shared_state", tokens: %{counter: 0}}
+]
+
+# After child completes: Copy from child I/O port → parent socket
+output_marking = [
+  %{place: "shared_state", tokens: %{counter: 5}}
+]
+
+# Parent socket updated with new value
+```
+
+**I/O Semantics**:
+- Input phase: Consume from parent socket, copy to child I/O port
+- Output phase: Copy from child I/O port, produce to parent socket
+- Net effect: Bidirectional data flow
+
+---
+
+## Complete Example with Message-Based Flow
+
+```elixir
+defmodule ColouredFlow.Runner.Enactment do
+  @doc """
+  Handle substitution transition firing with message-based child enactment.
+  """
+  def handle_transition_fire(%Transition{subst: subst} = transition, state)
+      when not is_nil(subst) do
+
+    with(
+      # 1. Resolve module
+      {:ok, module} <-
+        SubFlowManager.resolve_module(
+          state.subflow_manager,
+          subst,
+          enactment_id: state.id
+        ),
+
+      # 2. Prepare input tokens
+      input_marking = prepare_child_input_marking(transition, state.marking, module),
+
+      # 3. Start child enactment
+      {:ok, child_id} <-
+        SubFlowManager.start_child_enactment(
+          state.subflow_manager,
+          module,
+          input_marking,
+          parent_pid: self(),  # ← Will receive messages
+          parent_enactment_id: state.id,
+          parent_transition: transition.name
+        )
+    ) do
+      # 4. Track active child
+      new_children = Map.put(
+        state.active_children,
+        child_id,
+        %{transition: transition, started_at: System.monotonic_time()}
+      )
+
+      # 5. Consume input tokens from parent marking
+      new_marking = consume_input_tokens(
+        state.marking,
+        transition.socket_assignments,
+        module
+      )
+
+      # Return updated state
+      # Parent will receive {:child_enactment_completed, ...} message later
+      {:ok, %{state |
+        active_children: new_children,
+        marking: new_marking
+      }}
+    else
+      {:error, reason} ->
+        {:error, {:substitution_transition_failed, reason}}
+    end
+  end
+
+  # Message handler: Child completed
+  def handle_info({:child_enactment_completed, child_id, output_marking}, state) do
+    case Map.pop(state.active_children, child_id) do
+      {nil, _} ->
+        # Unknown child
+        {:noreply, state}
+
+      {child_info, remaining_children} ->
+        # Apply output tokens
+        new_marking = apply_child_outputs(
+          output_marking,
+          child_info.transition.socket_assignments,
+          state.marking
+        )
+
+        # Continue enactment (may enable new transitions)
+        new_state = %{state |
+          marking: new_marking,
+          active_children: remaining_children
+        }
+
+        # Check for newly enabled transitions
+        new_state = compute_enabled_transitions(new_state)
+
+        {:noreply, new_state}
+    end
+  end
+
+  # Message handler: Child failed
+  def handle_info({:child_enactment_failed, child_id, reason}, state) do
+    case Map.pop(state.active_children, child_id) do
+      {nil, _} ->
+        {:noreply, state}
+
+      {child_info, remaining_children} ->
+        Logger.error("""
+        Child enactment failed:
+          Transition: #{child_info.transition.name}
+          Reason: #{inspect(reason)}
+        """)
+
+        # Option 1: Fail parent enactment
+        {:stop, {:child_enactment_failed, reason}, state}
+
+        # Option 2: Add failure token to allow workflow to handle it
+        # failure_marking = %{
+        #   place: "#{child_info.transition.name}_failed",
+        #   tokens: %{reason: reason}
+        # }
+        # new_marking = add_tokens_to_marking(state.marking, failure_marking)
+        # {:noreply, %{state | marking: new_marking, active_children: remaining_children}}
+    end
+  end
+
+  defp consume_input_tokens(marking, socket_assignments, module) do
+    input_ports = Module.input_ports(module)
+
+    Enum.reduce(input_ports, marking, fn port_place, acc_marking ->
+      socket = find_socket_for_port(socket_assignments, port_place.name)
+      tokens = get_tokens_from_marking(acc_marking, socket)
+
+      # Remove tokens from parent socket place
+      remove_tokens_from_marking(acc_marking, socket, tokens)
+    end)
+  end
+
+  defp apply_child_outputs(output_marking, socket_assignments, parent_marking) do
+    Enum.reduce(output_marking, parent_marking, fn output, acc_marking ->
+      socket = find_socket_for_port(socket_assignments, output.place)
+
+      # Add tokens to parent socket place
+      add_tokens_to_marking(acc_marking, socket, output.tokens)
+    end)
+  end
+end
+```
+
+---
+
+## Advantages of This Design
+
+### 1. Message-Based (No Polling)
+✅ Efficient - No CPU waste on polling
+✅ Reactive - Immediate response to child completion
+✅ Scalable - Can handle many children without performance degradation
+✅ Idiomatic - Standard Elixir/OTP pattern
+
+### 2. No Direct Cancellation (Token Control)
+✅ Preserves Petri Net semantics
+✅ Predictable behavior
+✅ Testable workflow logic
+✅ Child enactments are autonomous
+
+### 3. Clear Token Sharing Semantics
+✅ Explicit input/output token flow
+✅ Socket assignments define the mapping
+✅ Copy semantics (not shared state)
+✅ Supports I/O (bidirectional) ports
+
+### 4. Child Enactment Terminology
+✅ Accurate - Modules execute as enactments
+✅ Clear - Parent-child relationship explicit
+✅ Consistent - Matches ColouredFlow concepts
+
+---
+
+## Questions for Confirmation
+
+1. ✅ **Naming**: "child enactment" vs "sub enactment"?
+   - My recommendation: **child enactment**
+
+2. ✅ **Message-based**: Agree with message notification instead of polling?
+
+3. ✅ **No cancellation**: Agree that termination should be token-based?
+
+4. ✅ **Token sharing**: Is the copy semantics clear?
+   - Input: Copy from parent socket → child input port
+   - Output: Copy from child output port → parent socket
+
+5. **Additional questions**:
+   - Should we support synchronous waiting (block until child completes)?
+   - Should we support multiple concurrent children per substitution transition?
+   - How to handle child timeout? (Add timeout token to child? Monitor and log?)
+
+Please confirm or suggest adjustments!

--- a/lib/coloured_flow/builder/flow_converter.ex
+++ b/lib/coloured_flow/builder/flow_converter.ex
@@ -1,0 +1,372 @@
+defmodule ColouredFlow.Builder.FlowConverter do
+  @moduledoc """
+  Converts ColouredPetriNet flows into reusable modules.
+
+  This module provides utilities to transform existing flows into modules that can be
+  instantiated through substitution transitions. This is useful for:
+
+  - Creating reusable workflow components
+  - Building module libraries from existing flows
+  - Converting standalone flows into composable parts
+  - Enabling flow composition and hierarchical workflows
+
+  ## Example
+
+      # You have an existing authentication flow
+      auth_flow = %ColouredPetriNet{
+        places: [
+          %Place{name: "credentials", colour_set: :credentials},
+          %Place{name: "success", colour_set: :unit},
+          %Place{name: "failure", colour_set: :string}
+        ],
+        transitions: [...],
+        arcs: [...]
+      }
+
+      # Convert it to a module, specifying which places are ports
+      auth_module = FlowConverter.flow_to_module(
+        auth_flow,
+        name: "authentication",
+        port_specs: [
+          {"credentials", :input},
+          {"success", :output},
+          {"failure", :output}
+        ]
+      )
+
+      # Now use it in other flows
+      main_flow = %ColouredPetriNet{
+        modules: [auth_module],
+        transitions: [
+          build_substitution_transition!(
+            name: "do_auth",
+            subst: "authentication",
+            socket_assignments: [...]
+          )
+        ]
+      }
+  """
+
+  alias ColouredFlow.Definition.ColouredPetriNet
+  alias ColouredFlow.Definition.Module
+  alias ColouredFlow.Definition.Place
+  alias ColouredFlow.Definition.PortPlace
+
+  @type port_spec() :: {Place.name(), PortPlace.port_type()}
+  @type convert_options() :: [
+          name: Module.name(),
+          port_specs: [port_spec()]
+        ]
+
+  @doc """
+  Converts a ColouredPetriNet flow into a Module.
+
+  ## Parameters
+
+  - `flow`: The ColouredPetriNet to convert
+  - `opts`: Conversion options
+    - `:name` (required) - The name for the resulting module
+    - `:port_specs` (required) - List of `{place_name, port_type}` tuples specifying
+      which places should become port places and their types (`:input`, `:output`, or `:io`)
+
+  ## Returns
+
+  A `Module` struct that can be used in other flows.
+
+  ## Examples
+
+      iex> flow = %ColouredPetriNet{
+      ...>   places: [
+      ...>     %Place{name: "input", colour_set: :string},
+      ...>     %Place{name: "output", colour_set: :string},
+      ...>     %Place{name: "internal", colour_set: :string}
+      ...>   ],
+      ...>   transitions: [...],
+      ...>   arcs: [...]
+      ...> }
+      iex> module = FlowConverter.flow_to_module(flow,
+      ...>   name: "processor",
+      ...>   port_specs: [
+      ...>     {"input", :input},
+      ...>     {"output", :output}
+      ...>   ]
+      ...> )
+      iex> module.name
+      "processor"
+      iex> length(module.port_places)
+      2
+      iex> length(module.places)
+      1
+
+  ## Errors
+
+  Raises if:
+  - Required options are missing
+  - Port specs reference non-existent places
+  - A place is specified as both port and internal place
+  """
+  @spec flow_to_module(ColouredPetriNet.t(), convert_options()) :: Module.t()
+  def flow_to_module(%ColouredPetriNet{} = flow, opts) do
+    opts = validate_options!(opts)
+    name = Keyword.fetch!(opts, :name)
+    port_specs = Keyword.fetch!(opts, :port_specs)
+
+    validate_port_specs!(flow, port_specs)
+
+    port_place_names = MapSet.new(port_specs, fn {name, _type} -> name end)
+
+    %Module{
+      name: name,
+      colour_sets: flow.colour_sets,
+      port_places: create_port_places(flow.places, port_specs),
+      places: create_internal_places(flow.places, port_place_names),
+      transitions: flow.transitions,
+      arcs: flow.arcs,
+      variables: flow.variables,
+      constants: flow.constants,
+      functions: flow.functions
+    }
+  end
+
+  @doc """
+  Converts a ColouredPetriNet flow into a Module with automatic port detection.
+
+  This version automatically treats all places that have no incoming arcs as input ports
+  and all places that have no outgoing arcs as output ports. Places with both incoming
+  and outgoing arcs become internal places.
+
+  ## Parameters
+
+  - `flow`: The ColouredPetriNet to convert
+  - `name`: The name for the resulting module
+
+  ## Returns
+
+  A `Module` struct with automatically detected ports.
+
+  ## Examples
+
+      iex> flow = %ColouredPetriNet{
+      ...>   places: [
+      ...>     %Place{name: "start", colour_set: :unit},      # No incoming -> input
+      ...>     %Place{name: "end", colour_set: :unit},        # No outgoing -> output
+      ...>     %Place{name: "middle", colour_set: :unit}      # Has both -> internal
+      ...>   ],
+      ...>   transitions: [%Transition{name: "t1"}],
+      ...>   arcs: [
+      ...>     %Arc{place: "start", transition: "t1", orientation: :p_to_t, ...},
+      ...>     %Arc{place: "middle", transition: "t1", orientation: :t_to_p, ...},
+      ...>     %Arc{place: "end", transition: "t1", orientation: :t_to_p, ...}
+      ...>   ]
+      ...> }
+      iex> module = FlowConverter.flow_to_module_auto(flow, "auto_module")
+      iex> module.port_places
+      # Contains "start" (input) and "end" (output)
+  """
+  @spec flow_to_module_auto(ColouredPetriNet.t(), Module.name()) :: Module.t()
+  def flow_to_module_auto(%ColouredPetriNet{} = flow, name) do
+    port_specs = detect_port_specs(flow)
+    flow_to_module(flow, name: name, port_specs: port_specs)
+  end
+
+  # Private functions
+
+  defp validate_options!(opts) do
+    Keyword.validate!(opts, [:name, :port_specs])
+  end
+
+  defp validate_port_specs!(%ColouredPetriNet{places: places}, port_specs) do
+    place_names = MapSet.new(places, & &1.name)
+    port_place_names = MapSet.new(port_specs, fn {name, _type} -> name end)
+
+    # Check if all port specs reference existing places
+    missing_places = MapSet.difference(port_place_names, place_names)
+
+    unless MapSet.size(missing_places) == 0 do
+      raise ArgumentError, """
+      Port specs reference non-existent places: #{Enum.join(missing_places, ", ")}
+      Available places: #{Enum.join(place_names, ", ")}
+      """
+    end
+
+    # Check for duplicate port specs
+    port_spec_names = Enum.map(port_specs, fn {name, _type} -> name end)
+    duplicates = port_spec_names -- Enum.uniq(port_spec_names)
+
+    unless duplicates == [] do
+      raise ArgumentError, """
+      Duplicate port specs for places: #{Enum.join(duplicates, ", ")}
+      """
+    end
+
+    # Validate port types
+    Enum.each(port_specs, fn {name, type} ->
+      unless type in [:input, :output, :io] do
+        raise ArgumentError, """
+        Invalid port type #{inspect(type)} for place "#{name}".
+        Must be :input, :output, or :io
+        """
+      end
+    end)
+  end
+
+  defp create_port_places(places, port_specs) do
+    place_map = Map.new(places, fn place -> {place.name, place} end)
+
+    Enum.map(port_specs, fn {place_name, port_type} ->
+      place = Map.fetch!(place_map, place_name)
+
+      %PortPlace{
+        name: place.name,
+        colour_set: place.colour_set,
+        port_type: port_type
+      }
+    end)
+  end
+
+  defp create_internal_places(places, port_place_names) do
+    Enum.reject(places, fn place ->
+      MapSet.member?(port_place_names, place.name)
+    end)
+  end
+
+  defp detect_port_specs(%ColouredPetriNet{places: places, arcs: arcs}) do
+    # Analyze arcs to determine which places are input/output
+    place_arc_info =
+      Enum.reduce(places, %{}, fn place, acc ->
+        Map.put(acc, place.name, %{has_incoming: false, has_outgoing: false})
+      end)
+
+    place_arc_info =
+      Enum.reduce(arcs, place_arc_info, fn arc, acc ->
+        case arc.orientation do
+          # Place to Transition - this place has an outgoing arc
+          :p_to_t ->
+            Map.update!(acc, arc.place, &%{&1 | has_outgoing: true})
+
+          # Transition to Place - this place has an incoming arc
+          :t_to_p ->
+            Map.update!(acc, arc.place, &%{&1 | has_incoming: true})
+        end
+      end)
+
+    # Determine port types
+    Enum.flat_map(place_arc_info, fn {place_name, info} ->
+      cond do
+        # No incoming arcs -> input port
+        not info.has_incoming and info.has_outgoing ->
+          [{place_name, :input}]
+
+        # No outgoing arcs -> output port
+        info.has_incoming and not info.has_outgoing ->
+          [{place_name, :output}]
+
+        # Has both or neither -> not a port (internal or isolated)
+        true ->
+          []
+      end
+    end)
+  end
+
+  @doc """
+  Validates that a flow can be safely converted to a module.
+
+  Returns `{:ok, warnings}` if conversion is possible, where warnings is a list of
+  potential issues that won't prevent conversion but might indicate problems.
+
+  Returns `{:error, reasons}` if conversion would fail.
+
+  ## Examples
+
+      iex> flow = %ColouredPetriNet{...}
+      iex> FlowConverter.validate_conversion(flow, port_specs: [...])
+      {:ok, []}
+
+      iex> FlowConverter.validate_conversion(bad_flow, port_specs: [...])
+      {:error, ["Port spec references non-existent place: foo"]}
+  """
+  @spec validate_conversion(ColouredPetriNet.t(), convert_options()) ::
+          {:ok, [String.t()]} | {:error, [String.t()]}
+  def validate_conversion(%ColouredPetriNet{} = flow, opts) do
+    warnings = []
+    errors = []
+
+    # Check if name is provided
+    {errors, warnings} =
+      if Keyword.has_key?(opts, :name) do
+        {errors, warnings}
+      else
+        {["Missing required option: name" | errors], warnings}
+      end
+
+    # Check if port_specs is provided
+    {errors, warnings} =
+      if Keyword.has_key?(opts, :port_specs) do
+        {errors, warnings}
+      else
+        {["Missing required option: port_specs" | errors], warnings}
+      end
+
+    # Validate port specs if provided
+    {errors, warnings} =
+      if port_specs = Keyword.get(opts, :port_specs) do
+        place_names = MapSet.new(flow.places, & &1.name)
+        port_place_names = MapSet.new(port_specs, fn {name, _type} -> name end)
+        missing = MapSet.difference(port_place_names, place_names)
+
+        if MapSet.size(missing) > 0 do
+          error_msg = "Port specs reference non-existent places: #{Enum.join(missing, ", ")}"
+          {[error_msg | errors], warnings}
+        else
+          {errors, warnings}
+        end
+      else
+        {errors, warnings}
+      end
+
+    # Check for isolated places (warning only)
+    {errors, warnings} =
+      case find_isolated_places(flow) do
+        [] ->
+          {errors, warnings}
+
+        isolated ->
+          warning = "Flow contains isolated places: #{Enum.join(isolated, ", ")}"
+          {errors, [warning | warnings]}
+      end
+
+    # Check for places that will become internal but might be intended as ports
+    {errors, warnings} =
+      if port_specs = Keyword.get(opts, :port_specs) do
+        port_names = MapSet.new(port_specs, fn {name, _type} -> name end)
+        all_place_names = MapSet.new(flow.places, & &1.name)
+        internal_count = MapSet.size(MapSet.difference(all_place_names, port_names))
+
+        if internal_count > length(flow.places) * 0.8 do
+          warning =
+            "More than 80% of places will be internal. " <>
+              "Consider using flow_to_module_auto for automatic port detection."
+
+          {errors, [warning | warnings]}
+        else
+          {errors, warnings}
+        end
+      else
+        {errors, warnings}
+      end
+
+    if errors == [] do
+      {:ok, Enum.reverse(warnings)}
+    else
+      {:error, Enum.reverse(errors)}
+    end
+  end
+
+  defp find_isolated_places(%ColouredPetriNet{places: places, arcs: arcs}) do
+    connected_places = MapSet.new(arcs, & &1.place)
+
+    places
+    |> Enum.map(& &1.name)
+    |> Enum.reject(&MapSet.member?(connected_places, &1))
+  end
+end

--- a/lib/coloured_flow/builder/module_helper.ex
+++ b/lib/coloured_flow/builder/module_helper.ex
@@ -1,0 +1,180 @@
+defmodule ColouredFlow.Builder.ModuleHelper do
+  @moduledoc """
+  Helper functions for building modules and substitution transitions.
+
+  This module provides convenient functions to create module definitions,
+  port places, socket assignments, and substitution transitions.
+  """
+
+  alias ColouredFlow.Definition.Action
+  alias ColouredFlow.Definition.Module
+  alias ColouredFlow.Definition.PortPlace
+  alias ColouredFlow.Definition.SocketAssignment
+  alias ColouredFlow.Definition.Transition
+
+  @doc """
+  Builds a module with the given parameters.
+
+  ## Examples
+
+      iex> build_module!(
+      ...>   name: "authentication",
+      ...>   port_places: [
+      ...>     %PortPlace{name: "credentials_in", colour_set: :credentials, port_type: :input},
+      ...>     %PortPlace{name: "result_out", colour_set: :boolean, port_type: :output}
+      ...>   ],
+      ...>   places: [
+      ...>     %Place{name: "verify", colour_set: :credentials}
+      ...>   ]
+      ...> )
+  """
+  @spec build_module!(Keyword.t()) :: Module.t()
+  def build_module!(params) do
+    params =
+      Keyword.validate!(params, [
+        :name,
+        colour_sets: [],
+        port_places: [],
+        places: [],
+        transitions: [],
+        arcs: [],
+        variables: [],
+        constants: [],
+        functions: []
+      ])
+
+    struct!(Module, params)
+  end
+
+  @doc """
+  Builds a port place with the given parameters.
+
+  ## Examples
+
+      iex> build_port_place!(
+      ...>   name: "input_data",
+      ...>   colour_set: :string,
+      ...>   port_type: :input
+      ...> )
+  """
+  @spec build_port_place!(Keyword.t()) :: PortPlace.t()
+  def build_port_place!(params) do
+    params = Keyword.validate!(params, [:name, :colour_set, :port_type])
+    struct!(PortPlace, params)
+  end
+
+  @doc """
+  Builds multiple port places.
+
+  ## Examples
+
+      iex> build_port_places!([
+      ...>   [name: "input", colour_set: :string, port_type: :input],
+      ...>   [name: "output", colour_set: :string, port_type: :output]
+      ...> ])
+  """
+  @spec build_port_places!([Keyword.t()]) :: [PortPlace.t()]
+  def build_port_places!(params_list) when is_list(params_list) do
+    Enum.map(params_list, &build_port_place!/1)
+  end
+
+  @doc """
+  Builds a socket assignment mapping a parent place to a module port.
+
+  ## Examples
+
+      iex> build_socket_assignment!(
+      ...>   socket: "parent_place",
+      ...>   port: "module_port"
+      ...> )
+  """
+  @spec build_socket_assignment!(Keyword.t()) :: SocketAssignment.t()
+  def build_socket_assignment!(params) do
+    params = Keyword.validate!(params, [:socket, :port])
+    struct!(SocketAssignment, params)
+  end
+
+  @doc """
+  Builds multiple socket assignments.
+
+  ## Examples
+
+      iex> build_socket_assignments!([
+      ...>   [socket: "place_a", port: "port_a"],
+      ...>   [socket: "place_b", port: "port_b"]
+      ...> ])
+  """
+  @spec build_socket_assignments!([Keyword.t()]) :: [SocketAssignment.t()]
+  def build_socket_assignments!(params_list) when is_list(params_list) do
+    Enum.map(params_list, &build_socket_assignment!/1)
+  end
+
+  @doc """
+  Builds a substitution transition that references a module.
+
+  ## Examples
+
+      iex> build_substitution_transition!(
+      ...>   name: "auth",
+      ...>   subst: "authentication_module",
+      ...>   socket_assignments: [
+      ...>     %SocketAssignment{socket: "user_creds", port: "credentials_in"},
+      ...>     %SocketAssignment{socket: "auth_result", port: "result_out"}
+      ...>   ]
+      ...> )
+  """
+  @spec build_substitution_transition!(Keyword.t()) :: Transition.t()
+  def build_substitution_transition!(params) do
+    params =
+      Keyword.validate!(params, [
+        :name,
+        :subst,
+        guard: nil,
+        action: %Action{},
+        socket_assignments: []
+      ])
+
+    # Substitution transitions typically don't have complex actions
+    # since the work is done by the module
+    params =
+      params
+      |> Keyword.update(:action, %Action{}, fn
+        %Action{} = action -> action
+        action_params when is_list(action_params) -> struct!(Action, action_params)
+      end)
+
+    struct!(Transition, params)
+  end
+
+  @doc """
+  Convenient function to build a simple input port place.
+  """
+  @spec input_port(name :: binary(), colour_set :: atom()) :: PortPlace.t()
+  def input_port(name, colour_set) do
+    %PortPlace{name: name, colour_set: colour_set, port_type: :input}
+  end
+
+  @doc """
+  Convenient function to build a simple output port place.
+  """
+  @spec output_port(name :: binary(), colour_set :: atom()) :: PortPlace.t()
+  def output_port(name, colour_set) do
+    %PortPlace{name: name, colour_set: colour_set, port_type: :output}
+  end
+
+  @doc """
+  Convenient function to build a simple I/O port place.
+  """
+  @spec io_port(name :: binary(), colour_set :: atom()) :: PortPlace.t()
+  def io_port(name, colour_set) do
+    %PortPlace{name: name, colour_set: colour_set, port_type: :io}
+  end
+
+  @doc """
+  Convenient function to build a socket assignment.
+  """
+  @spec socket(socket :: binary(), port :: binary()) :: SocketAssignment.t()
+  def socket(socket, port) do
+    %SocketAssignment{socket: socket, port: port}
+  end
+end

--- a/lib/coloured_flow/definition/coloured_petri_net.ex
+++ b/lib/coloured_flow/definition/coloured_petri_net.ex
@@ -1,6 +1,11 @@
 defmodule ColouredFlow.Definition.ColouredPetriNet do
   @moduledoc """
-  The petri net is consists of places, transitions, arcs,
+  The petri net is consists of places, transitions, arcs.
+
+  ## Modules
+
+  A CPN can define reusable modules that can be instantiated through substitution transitions.
+  Modules enable hierarchical composition and better organization of complex workflows.
   """
 
   use TypedStructor
@@ -8,6 +13,7 @@ defmodule ColouredFlow.Definition.ColouredPetriNet do
   alias ColouredFlow.Definition.Arc
   alias ColouredFlow.Definition.ColourSet
   alias ColouredFlow.Definition.Constant
+  alias ColouredFlow.Definition.Module
   alias ColouredFlow.Definition.Place
   alias ColouredFlow.Definition.Procedure
   alias ColouredFlow.Definition.TerminationCriteria
@@ -17,6 +23,11 @@ defmodule ColouredFlow.Definition.ColouredPetriNet do
   typed_structor enforce: true do
     # data types
     field :colour_sets, [ColourSet.t()]
+
+    # modules
+    field :modules, [Module.t()],
+      default: [],
+      doc: "Reusable module definitions that can be instantiated by substitution transitions."
 
     # net
     field :places, [Place.t()]
@@ -30,5 +41,29 @@ defmodule ColouredFlow.Definition.ColouredPetriNet do
     field :functions, [Procedure.t()], default: []
 
     field :termination_criteria, TerminationCriteria.t(), enforce: false
+  end
+
+  @doc """
+  Gets a module by name.
+  """
+  @spec get_module(t(), Module.name()) :: Module.t() | nil
+  def get_module(%__MODULE__{modules: modules}, name) do
+    Enum.find(modules, &(&1.name == name))
+  end
+
+  @doc """
+  Returns all substitution transitions in the net.
+  """
+  @spec substitution_transitions(t()) :: [Transition.t()]
+  def substitution_transitions(%__MODULE__{transitions: transitions}) do
+    Enum.filter(transitions, &Transition.substitution?/1)
+  end
+
+  @doc """
+  Returns all regular (non-substitution) transitions in the net.
+  """
+  @spec regular_transitions(t()) :: [Transition.t()]
+  def regular_transitions(%__MODULE__{transitions: transitions}) do
+    Enum.filter(transitions, &Transition.regular?/1)
   end
 end

--- a/lib/coloured_flow/definition/module.ex
+++ b/lib/coloured_flow/definition/module.ex
@@ -1,0 +1,112 @@
+defmodule ColouredFlow.Definition.Module do
+  @moduledoc """
+  A module represents a reusable subnet that can be instantiated by substitution transitions.
+
+  Modules enable hierarchical composition and reuse in Coloured Petri Nets.
+  A module is essentially a complete CPN with designated port places that define its interface.
+
+  ## Key Concepts
+
+  - **Port Places**: Special places that define the module's input/output interface
+  - **Substitution Transition**: A transition in the parent net that references this module
+  - **Socket Assignment**: Mapping between parent net places and module port places
+  - **Module Instance**: A runtime instantiation of a module with its own state
+
+  ## Example
+
+  A simple authentication module might have:
+  - Input port: `credentials` (username/password)
+  - Output ports: `authenticated`, `failed`
+  - Internal places and transitions for the authentication logic
+
+  This module can then be instantiated multiple times in different workflows.
+  """
+
+  use TypedStructor
+
+  alias ColouredFlow.Definition.Arc
+  alias ColouredFlow.Definition.ColourSet
+  alias ColouredFlow.Definition.Constant
+  alias ColouredFlow.Definition.Place
+  alias ColouredFlow.Definition.PortPlace
+  alias ColouredFlow.Definition.Procedure
+  alias ColouredFlow.Definition.Transition
+  alias ColouredFlow.Definition.Variable
+
+  @type name() :: binary()
+
+  typed_structor enforce: true do
+    plugin TypedStructor.Plugins.DocFields
+
+    field :name, name(),
+      doc: "Unique name of the module."
+
+    # Data types (inherited or module-specific)
+    field :colour_sets, [ColourSet.t()],
+      default: [],
+      doc: "Colour sets specific to this module."
+
+    # Port places - the interface of the module
+    field :port_places, [PortPlace.t()],
+      default: [],
+      doc: "Port places that define the module's interface."
+
+    # Internal net structure
+    field :places, [Place.t()],
+      default: [],
+      doc: "Internal places of the module (non-port places)."
+
+    field :transitions, [Transition.t()],
+      default: [],
+      doc: "Transitions within the module."
+
+    field :arcs, [Arc.t()],
+      default: [],
+      doc: "Arcs connecting places and transitions within the module."
+
+    # Variables and constants
+    field :variables, [Variable.t()],
+      default: [],
+      doc: "Variables used in the module."
+
+    field :constants, [Constant.t()],
+      default: [],
+      doc: "Constants used in the module."
+
+    field :functions, [Procedure.t()],
+      default: [],
+      doc: "Functions/procedures defined in the module."
+  end
+
+  @doc """
+  Returns all places in the module (both port places and internal places).
+  """
+  @spec all_places(t()) :: [Place.t() | PortPlace.t()]
+  def all_places(%__MODULE__{port_places: port_places, places: places}) do
+    port_places ++ places
+  end
+
+  @doc """
+  Gets a port place by name.
+  """
+  @spec get_port_place(t(), PortPlace.name()) :: PortPlace.t() | nil
+  def get_port_place(%__MODULE__{port_places: port_places}, name) do
+    Enum.find(port_places, &(&1.name == name))
+  end
+
+  @doc """
+  Returns all input port places.
+  """
+  @spec input_ports(t()) :: [PortPlace.t()]
+  def input_ports(%__MODULE__{port_places: port_places}) do
+    Enum.filter(port_places, &PortPlace.input?/1)
+  end
+
+  @doc """
+  Returns all output port places.
+  """
+  @spec output_ports(t()) :: [PortPlace.t()]
+  def output_ports(%__MODULE__{port_places: port_places}) do
+    Enum.filter(port_places, &PortPlace.output?/1)
+  end
+end

--- a/lib/coloured_flow/definition/port_place.ex
+++ b/lib/coloured_flow/definition/port_place.ex
@@ -1,0 +1,50 @@
+defmodule ColouredFlow.Definition.PortPlace do
+  @moduledoc """
+  A port place is a special place that defines the interface of a module.
+
+  Port places allow communication between a module and its parent net.
+  There are three types of port places:
+  - Input: receives tokens from the parent net
+  - Output: sends tokens to the parent net
+  - I/O: bidirectional communication
+
+  In the parent net, regular places are connected to these port places through
+  socket assignments in substitution transitions.
+  """
+
+  use TypedStructor
+
+  alias ColouredFlow.Definition.ColourSet
+
+  @type name() :: binary()
+  @type port_type() :: :input | :output | :io
+
+  typed_structor enforce: true do
+    plugin TypedStructor.Plugins.DocFields
+
+    field :name, name()
+
+    field :colour_set, ColourSet.name(),
+      doc: "The data type of the tokens that can be stored in the place."
+
+    field :port_type, port_type(),
+      doc: """
+      The type of the port:
+      - `:input`: receives tokens from parent net (input port)
+      - `:output`: sends tokens to parent net (output port)
+      - `:io`: bidirectional communication (input/output port)
+      """
+  end
+
+  @doc """
+  Checks if a port place is an input port (can receive tokens from parent).
+  """
+  @spec input?(t()) :: boolean()
+  def input?(%__MODULE__{port_type: port_type}), do: port_type in [:input, :io]
+
+  @doc """
+  Checks if a port place is an output port (can send tokens to parent).
+  """
+  @spec output?(t()) :: boolean()
+  def output?(%__MODULE__{port_type: port_type}), do: port_type in [:output, :io]
+end

--- a/lib/coloured_flow/definition/socket_assignment.ex
+++ b/lib/coloured_flow/definition/socket_assignment.ex
@@ -1,0 +1,23 @@
+defmodule ColouredFlow.Definition.SocketAssignment do
+  @moduledoc """
+  A socket assignment maps a place in the parent net (socket) to a port place in a module.
+
+  When a substitution transition fires, tokens flow between the socket places
+  in the parent net and the port places in the module instance according to these assignments.
+  """
+
+  use TypedStructor
+
+  alias ColouredFlow.Definition.Place
+  alias ColouredFlow.Definition.PortPlace
+
+  typed_structor enforce: true do
+    plugin TypedStructor.Plugins.DocFields
+
+    field :socket, Place.name(),
+      doc: "The name of the place in the parent net (socket)."
+
+    field :port, PortPlace.name(),
+      doc: "The name of the port place in the module."
+  end
+end

--- a/lib/coloured_flow/definition/transition.ex
+++ b/lib/coloured_flow/definition/transition.ex
@@ -2,12 +2,20 @@ defmodule ColouredFlow.Definition.Transition do
   @moduledoc """
   Transition t is enabled at a binding if there are tokens matching the values of
   the in-coming arc inscriptions and the guard of t evaluates to true.
+
+  ## Substitution Transitions
+
+  A transition can be a substitution transition, which means it references a module.
+  When a substitution transition fires, it instantiates and executes the referenced module.
+  The module's port places are connected to the parent net's places through socket assignments.
   """
 
   use TypedStructor
 
   alias ColouredFlow.Definition.Action
   alias ColouredFlow.Definition.Expression
+  alias ColouredFlow.Definition.Module
+  alias ColouredFlow.Definition.SocketAssignment
 
   @type name() :: binary()
 
@@ -36,5 +44,32 @@ defmodule ColouredFlow.Definition.Transition do
       you can utilize it to do side effects,
       and update unbonud variables in the out-going arcs.
       """
+
+    field :subst, Module.name(),
+      enforce: false,
+      doc: """
+      If present, this transition is a substitution transition that references a module.
+      When fired, the module will be instantiated and executed.
+      """
+
+    field :socket_assignments, [SocketAssignment.t()],
+      enforce: false,
+      default: [],
+      doc: """
+      Socket assignments map places in the parent net to port places in the referenced module.
+      Only relevant for substitution transitions (when `subst` is not nil).
+      """
   end
+
+  @doc """
+  Checks if this transition is a substitution transition.
+  """
+  @spec substitution?(t()) :: boolean()
+  def substitution?(%__MODULE__{subst: subst}), do: not is_nil(subst)
+
+  @doc """
+  Checks if this transition is a regular (non-substitution) transition.
+  """
+  @spec regular?(t()) :: boolean()
+  def regular?(transition), do: not substitution?(transition)
 end

--- a/lib/coloured_flow/enactment/module_instance.ex
+++ b/lib/coloured_flow/enactment/module_instance.ex
@@ -1,0 +1,110 @@
+defmodule ColouredFlow.Enactment.ModuleInstance do
+  @moduledoc """
+  Represents a runtime instance of a module.
+
+  A module instance is created when a substitution transition fires.
+  It maintains the state of the module execution including:
+  - The module definition being executed
+  - The current marking of the module's places
+  - The mapping between parent sockets and module ports
+  - The execution state (running, completed, failed)
+  """
+
+  use TypedStructor
+
+  alias ColouredFlow.Definition.Module
+  alias ColouredFlow.Definition.SocketAssignment
+  alias ColouredFlow.Enactment.Marking
+
+  @type instance_id() :: binary()
+  @type state() :: :initializing | :running | :completed | :failed
+
+  typed_structor enforce: true do
+    plugin TypedStructor.Plugins.DocFields
+
+    field :id, instance_id(),
+      doc: "Unique identifier for this module instance."
+
+    field :module_name, Module.name(),
+      doc: "The name of the module being instantiated."
+
+    field :socket_assignments, [SocketAssignment.t()],
+      doc: "Mapping between parent net sockets and module ports."
+
+    field :markings, %{binary() => Marking.tokens()},
+      default: %{},
+      doc: "Current marking of the module's places (both port and internal)."
+
+    field :state, state(),
+      default: :initializing,
+      doc: "Current execution state of the module instance."
+
+    field :parent_enactment_id, binary(),
+      enforce: false,
+      doc: "ID of the parent enactment that created this instance."
+
+    field :parent_transition, binary(),
+      enforce: false,
+      doc: "Name of the substitution transition that created this instance."
+  end
+
+  @doc """
+  Creates a new module instance.
+  """
+  @spec new(Keyword.t()) :: t()
+  def new(opts) do
+    id = Keyword.get(opts, :id, generate_id())
+    module_name = Keyword.fetch!(opts, :module_name)
+    socket_assignments = Keyword.fetch!(opts, :socket_assignments)
+
+    %__MODULE__{
+      id: id,
+      module_name: module_name,
+      socket_assignments: socket_assignments,
+      markings: %{},
+      state: :initializing,
+      parent_enactment_id: Keyword.get(opts, :parent_enactment_id),
+      parent_transition: Keyword.get(opts, :parent_transition)
+    }
+  end
+
+  @doc """
+  Checks if the module instance is running.
+  """
+  @spec running?(t()) :: boolean()
+  def running?(%__MODULE__{state: state}), do: state == :running
+
+  @doc """
+  Checks if the module instance is completed.
+  """
+  @spec completed?(t()) :: boolean()
+  def completed?(%__MODULE__{state: state}), do: state == :completed
+
+  @doc """
+  Checks if the module instance has failed.
+  """
+  @spec failed?(t()) :: boolean()
+  def failed?(%__MODULE__{state: state}), do: state == :failed
+
+  @doc """
+  Marks the module instance as running.
+  """
+  @spec mark_running(t()) :: t()
+  def mark_running(%__MODULE__{} = instance), do: %{instance | state: :running}
+
+  @doc """
+  Marks the module instance as completed.
+  """
+  @spec mark_completed(t()) :: t()
+  def mark_completed(%__MODULE__{} = instance), do: %{instance | state: :completed}
+
+  @doc """
+  Marks the module instance as failed.
+  """
+  @spec mark_failed(t()) :: t()
+  def mark_failed(%__MODULE__{} = instance), do: %{instance | state: :failed}
+
+  defp generate_id do
+    :crypto.strong_rand_bytes(16) |> Base.encode16(case: :lower)
+  end
+end

--- a/lib/coloured_flow/runner/storage/schemas/json_instance/codec/module.ex
+++ b/lib/coloured_flow/runner/storage/schemas/json_instance/codec/module.ex
@@ -1,18 +1,19 @@
-defmodule ColouredFlow.Runner.Storage.Schemas.JsonInstance.Codec.ColouredPetriNet do
+defmodule ColouredFlow.Runner.Storage.Schemas.JsonInstance.Codec.Module do
   @moduledoc false
 
-  alias ColouredFlow.Definition.ColouredPetriNet
   alias ColouredFlow.Definition.Constant
+  alias ColouredFlow.Definition.Module
   alias ColouredFlow.Definition.Place
   alias ColouredFlow.Definition.Variable
 
   use ColouredFlow.Runner.Storage.Schemas.JsonInstance.Codec,
     codec_spec: {
       :struct,
-      ColouredPetriNet,
+      Module,
       [
+        name: :string,
         colour_sets: {:list, {:codec, Codec.ColourSet}},
-        modules: {:list, {:codec, Codec.Module}},
+        port_places: {:list, {:codec, Codec.PortPlace}},
         places: {:list, {:struct, Place, [name: :string, colour_set: :atom]}},
         transitions: {:list, {:codec, Codec.Transition}},
         arcs: {:list, {:codec, Codec.Arc}},
@@ -28,8 +29,7 @@ defmodule ColouredFlow.Runner.Storage.Schemas.JsonInstance.Codec.ColouredPetriNe
                value: Codec.ColourSet.value_codec_spec()
              ]
            }},
-        functions: {:list, {:codec, Codec.Procedure}},
-        termination_criteria: {:codec, Codec.TerminationCriteria}
+        functions: {:list, {:codec, Codec.Procedure}}
       ]
     }
 end

--- a/lib/coloured_flow/runner/storage/schemas/json_instance/codec/port_place.ex
+++ b/lib/coloured_flow/runner/storage/schemas/json_instance/codec/port_place.ex
@@ -1,0 +1,16 @@
+defmodule ColouredFlow.Runner.Storage.Schemas.JsonInstance.Codec.PortPlace do
+  @moduledoc false
+
+  alias ColouredFlow.Definition.PortPlace
+
+  use ColouredFlow.Runner.Storage.Schemas.JsonInstance.Codec,
+    codec_spec: {
+      :struct,
+      PortPlace,
+      [
+        name: :string,
+        colour_set: :atom,
+        port_type: :atom
+      ]
+    }
+end

--- a/lib/coloured_flow/runner/storage/schemas/json_instance/codec/socket_assignment.ex
+++ b/lib/coloured_flow/runner/storage/schemas/json_instance/codec/socket_assignment.ex
@@ -1,0 +1,15 @@
+defmodule ColouredFlow.Runner.Storage.Schemas.JsonInstance.Codec.SocketAssignment do
+  @moduledoc false
+
+  alias ColouredFlow.Definition.SocketAssignment
+
+  use ColouredFlow.Runner.Storage.Schemas.JsonInstance.Codec,
+    codec_spec: {
+      :struct,
+      SocketAssignment,
+      [
+        socket: :string,
+        port: :string
+      ]
+    }
+end

--- a/lib/coloured_flow/runner/storage/schemas/json_instance/codec/transition.ex
+++ b/lib/coloured_flow/runner/storage/schemas/json_instance/codec/transition.ex
@@ -18,7 +18,9 @@ defmodule ColouredFlow.Runner.Storage.Schemas.JsonInstance.Codec.Transition do
             payload: :string,
             outputs: {:list, :atom}
           ]
-        }
+        },
+        subst: :string,
+        socket_assignments: {:list, {:codec, Codec.SocketAssignment}}
       ]
     }
 end

--- a/lib/coloured_flow/runtime/module_reference.ex
+++ b/lib/coloured_flow/runtime/module_reference.ex
@@ -1,0 +1,84 @@
+defmodule ColouredFlow.Runtime.ModuleReference do
+  @moduledoc """
+  Type definition for module references.
+
+  A module reference allows dynamic loading of modules at runtime.
+  It can reference a module by flow ID, flow name, or custom identifier.
+
+  ## Usage
+
+  Module references are used in substitution transitions to load modules
+  dynamically instead of embedding them statically in the CPN definition.
+
+  ## Examples
+
+      # Reference by flow ID with explicit port specifications
+      {:module_ref,
+        flow_id: 123,
+        port_specs: [
+          {"credentials", :input},
+          {"success", :output},
+          {"failure", :output}
+        ]
+      }
+
+      # Reference by flow ID with automatic port detection
+      {:module_ref,
+        flow_id: 123,
+        module_name: "authentication"
+      }
+
+      # Reference by flow name
+      {:module_ref,
+        flow_name: "auth_flow_v2",
+        port_specs: [...]
+      }
+
+      # Custom reference (for user-defined resolvers)
+      {:module_ref,
+        custom: %{api_id: "auth-123", version: "v2"}
+      }
+  """
+
+  @typedoc """
+  Port specification for a module interface.
+
+  Defines the name and direction of a port place:
+  - `:input` - Input port (receives tokens from parent)
+  - `:output` - Output port (sends tokens to parent)
+  - `:io` - Input/output port (bidirectional)
+  """
+  @type port_spec() :: {String.t(), :input | :output | :io}
+
+  @typedoc """
+  Module reference type.
+
+  A module reference can specify:
+
+  1. **Flow ID with port specs**: Load from database by ID, specify ports
+  2. **Flow ID with module name**: Load from database, auto-detect ports
+  3. **Flow name with port specs**: Load from database by name, specify ports
+  4. **Flow name with module name**: Load from database by name, auto-detect ports
+  5. **Custom**: User-defined reference format for custom resolvers
+
+  ## Examples
+
+      # Explicit port specification
+      {:module_ref, flow_id: 123, port_specs: [{"in", :input}, {"out", :output}]}
+
+      # Auto-detect ports
+      {:module_ref, flow_id: 123, module_name: "my_module"}
+
+      # By flow name
+      {:module_ref, flow_name: "authentication", port_specs: [...]}
+
+      # Custom format
+      {:module_ref, custom: %{source: :api, id: "mod-123"}}
+  """
+  @type t() ::
+          {:module_ref, flow_id: pos_integer(), port_specs: [port_spec()]}
+          | {:module_ref, flow_id: pos_integer(), module_name: String.t()}
+          | {:module_ref, flow_name: String.t(), port_specs: [port_spec()]}
+          | {:module_ref, flow_name: String.t(), module_name: String.t()}
+          | {:module_ref, custom: term()}
+end

--- a/lib/coloured_flow/runtime/subflow_manager.ex
+++ b/lib/coloured_flow/runtime/subflow_manager.ex
@@ -1,0 +1,172 @@
+defprotocol ColouredFlow.Runtime.SubFlowManager do
+  @moduledoc """
+  Protocol for managing child enactment (module execution) lifecycle.
+
+  A child enactment is an instance of a module being executed as part of
+  a substitution transition. Communication happens via messages, not polling.
+
+  ## Message Protocol
+
+  Child enactments send messages to their parent enactment:
+
+  - `{:child_enactment_ready, child_id}` - Initialization complete
+  - `{:child_enactment_completed, child_id, output_marking}` - Execution successful
+  - `{:child_enactment_failed, child_id, reason}` - Execution failed
+
+  ## Token Sharing
+
+  Tokens are shared between parent and child through socket assignments:
+
+  - **Input**: Copy from parent socket → child input port (consumed from parent)
+  - **Output**: Copy from child output port → parent socket (produced to parent)
+  - **I/O**: Bidirectional flow (both input and output)
+
+  ## Example
+
+      # Application startup
+      manager = SubFlowManager.Default.new(repo: MyApp.Repo)
+
+      # In enactment
+      {:ok, module} = SubFlowManager.resolve_module(
+        manager,
+        {:module_ref, flow_id: 123, port_specs: [...]},
+        enactment_id: "parent_123"
+      )
+
+      {:ok, child_id} = SubFlowManager.start_child_enactment(
+        manager,
+        module,
+        initial_marking,
+        parent_pid: self(),
+        parent_enactment_id: "parent_123"
+      )
+
+      # Later receive message
+      receive do
+        {:child_enactment_completed, ^child_id, output_marking} ->
+          # Apply output tokens to parent
+      end
+  """
+
+  alias ColouredFlow.Definition.Module
+  alias ColouredFlow.Runtime.ModuleReference
+
+  @typedoc "Child enactment identifier (typically a PID)"
+  @type child_id() :: pid() | term()
+
+  @typedoc "Token marking for a place"
+  @type marking() :: %{place: String.t(), tokens: term()}
+
+  @doc """
+  Resolve a module reference to a concrete Module definition.
+
+  ## When Called
+
+  - When substitution transition becomes enabled
+  - Before child enactment starts
+
+  ## Parameters
+
+  - `manager`: The manager instance (struct implementing this protocol)
+  - `module_ref`: Module reference to resolve
+  - `options`: Runtime options
+    - `:enactment_id` - Parent enactment ID for context
+    - Other custom options
+
+  ## Returns
+
+  - `{:ok, module}`: Successfully resolved module
+  - `{:error, reason}`: Resolution failed
+
+  ## Example
+
+      {:ok, module} = SubFlowManager.resolve_module(
+        manager,
+        {:module_ref, flow_id: 123, port_specs: [...]},
+        enactment_id: "parent_123"
+      )
+  """
+  @spec resolve_module(t(), ModuleReference.t(), Keyword.t()) ::
+          {:ok, Module.t()} | {:error, term()}
+  def resolve_module(manager, module_ref, options)
+
+  @doc """
+  Start a child enactment.
+
+  The child enactment will send messages back to the parent when:
+  - Initialization completes: `{:child_enactment_ready, child_id}`
+  - Execution completes: `{:child_enactment_completed, child_id, output_marking}`
+  - Execution fails: `{:child_enactment_failed, child_id, reason}`
+
+  ## When Called
+
+  - After module resolved via `resolve_module/3`
+  - After input tokens prepared from socket assignments
+
+  ## Parameters
+
+  - `manager`: The manager instance
+  - `module`: The module to execute
+  - `initial_marking`: Initial tokens for input port places
+  - `options`: Execution options
+    - `:parent_pid` (required) - Parent enactment PID for sending messages
+    - `:parent_enactment_id` - Parent enactment ID for context
+    - `:parent_transition` - Name of substitution transition
+
+  ## Returns
+
+  - `{:ok, child_id}`: Child enactment started, will send messages to parent
+  - `{:error, reason}`: Failed to start
+
+  ## Example
+
+      {:ok, child_id} = SubFlowManager.start_child_enactment(
+        manager,
+        auth_module,
+        [%{place: "credentials_in", tokens: %{user: "alice"}}],
+        parent_pid: self(),
+        parent_enactment_id: "parent_123",
+        parent_transition: "authenticate"
+      )
+
+      # Later, parent receives:
+      receive do
+        {:child_enactment_completed, ^child_id, output_marking} ->
+          # Apply output tokens to parent marking
+          apply_outputs(output_marking, socket_assignments, parent_marking)
+      end
+  """
+  @spec start_child_enactment(t(), Module.t(), [marking()], Keyword.t()) ::
+          {:ok, child_id()} | {:error, term()}
+  def start_child_enactment(manager, module, initial_marking, options)
+
+  @doc """
+  Get current state of a child enactment (optional, for debugging).
+
+  This is NOT for waiting/polling. Parent should use message-based waiting.
+
+  ## When Called
+
+  - For debugging or monitoring purposes only
+  - Not for normal workflow execution
+
+  ## Parameters
+
+  - `manager`: The manager instance
+  - `child_id`: The child enactment identifier
+
+  ## Returns
+
+  - `{:ok, state_info}`: Current state information
+    - Map containing: `:status`, `:marking`, `:started_at`, etc.
+  - `{:error, :not_found}`: Child enactment not found
+
+  ## Example
+
+      {:ok, info} = SubFlowManager.get_child_state(manager, child_id)
+      # info: %{status: :running, marking: %{...}, started_at: ~U[...]}
+  """
+  @spec get_child_state(t(), child_id()) ::
+          {:ok, map()} | {:error, term()}
+  def get_child_state(manager, child_id)
+end

--- a/lib/coloured_flow/runtime/subflow_manager/default.ex
+++ b/lib/coloured_flow/runtime/subflow_manager/default.ex
@@ -1,0 +1,182 @@
+defmodule ColouredFlow.Runtime.SubFlowManager.Default do
+  @moduledoc """
+  Default SubFlowManager implementation.
+
+  Loads modules from the database using FlowConverter and manages child enactments
+  through the ColouredFlow runtime.
+
+  ## Configuration
+
+  The default manager requires an Ecto repo for loading flows from the database.
+
+  ## Example
+
+      # Application startup
+      manager = SubFlowManager.Default.new(repo: MyApp.Repo)
+
+      # Use in enactment
+      {:ok, module} = SubFlowManager.resolve_module(
+        manager,
+        {:module_ref, flow_id: 123, port_specs: [...]},
+        []
+      )
+  """
+
+  alias ColouredFlow.Builder.FlowConverter
+  alias ColouredFlow.Runtime.ModuleReference
+  alias ColouredFlow.Runner.Storage.Schemas
+
+  defstruct [:repo]
+
+  @type t :: %__MODULE__{
+          repo: module()
+        }
+
+  @doc """
+  Create a new default SubFlowManager.
+
+  ## Options
+
+  - `:repo` (required) - Ecto repo for loading flows from database
+
+  ## Example
+
+      manager = SubFlowManager.Default.new(repo: MyApp.Repo)
+  """
+  @spec new(Keyword.t()) :: t()
+  def new(opts) do
+    repo = Keyword.fetch!(opts, :repo)
+
+    %__MODULE__{
+      repo: repo
+    }
+  end
+end
+
+defimpl ColouredFlow.Runtime.SubFlowManager, for: ColouredFlow.Runtime.SubFlowManager.Default do
+  alias ColouredFlow.Builder.FlowConverter
+  alias ColouredFlow.Definition.Module
+  alias ColouredFlow.Runner.Storage.Schemas
+
+  @impl true
+  def resolve_module(%{repo: repo}, module_ref, _options) do
+    case module_ref do
+      {:module_ref, ref_opts} ->
+        resolve_from_ref_opts(ref_opts, repo)
+
+      _ ->
+        {:error, {:invalid_module_ref, "Unknown module reference format: #{inspect(module_ref)}"}}
+    end
+  end
+
+  @impl true
+  def start_child_enactment(_manager, _module, _initial_marking, _options) do
+    # TODO: Implement child enactment starting
+    # This will require integration with the Enactment GenServer
+    {:error, :not_implemented}
+  end
+
+  @impl true
+  def get_child_state(_manager, _child_id) do
+    # TODO: Implement child state querying
+    {:error, :not_implemented}
+  end
+
+  # Private functions
+
+  defp resolve_from_ref_opts(ref_opts, repo) do
+    cond do
+      Keyword.has_key?(ref_opts, :flow_id) and Keyword.has_key?(ref_opts, :port_specs) ->
+        flow_id = Keyword.fetch!(ref_opts, :flow_id)
+        port_specs = Keyword.fetch!(ref_opts, :port_specs)
+        module_name = build_module_name("flow_#{flow_id}")
+
+        load_from_flow_id(flow_id, module_name, port_specs, repo)
+
+      Keyword.has_key?(ref_opts, :flow_id) and Keyword.has_key?(ref_opts, :module_name) ->
+        flow_id = Keyword.fetch!(ref_opts, :flow_id)
+        module_name = Keyword.fetch!(ref_opts, :module_name)
+
+        load_from_flow_id_auto(flow_id, module_name, repo)
+
+      Keyword.has_key?(ref_opts, :flow_name) and Keyword.has_key?(ref_opts, :port_specs) ->
+        flow_name = Keyword.fetch!(ref_opts, :flow_name)
+        port_specs = Keyword.fetch!(ref_opts, :port_specs)
+        module_name = build_module_name(flow_name)
+
+        load_from_flow_name(flow_name, module_name, port_specs, repo)
+
+      Keyword.has_key?(ref_opts, :flow_name) and Keyword.has_key?(ref_opts, :module_name) ->
+        flow_name = Keyword.fetch!(ref_opts, :flow_name)
+        module_name = Keyword.fetch!(ref_opts, :module_name)
+
+        load_from_flow_name_auto(flow_name, module_name, repo)
+
+      true ->
+        {:error, {:invalid_module_ref, "Unknown module reference format: #{inspect(ref_opts)}"}}
+    end
+  end
+
+  defp build_module_name(base_name) do
+    "#{base_name}_module"
+  end
+
+  defp load_from_flow_id(flow_id, module_name, port_specs, repo) do
+    with {:ok, flow} <- fetch_flow_by_id(flow_id, repo),
+         {:ok, module} <- convert_flow_to_module(flow, module_name, port_specs) do
+      {:ok, module}
+    end
+  end
+
+  defp load_from_flow_id_auto(flow_id, module_name, repo) do
+    with {:ok, flow} <- fetch_flow_by_id(flow_id, repo) do
+      module = FlowConverter.flow_to_module_auto(flow.definition, module_name)
+      {:ok, module}
+    end
+  end
+
+  defp load_from_flow_name(flow_name, module_name, port_specs, repo) do
+    with {:ok, flow} <- fetch_flow_by_name(flow_name, repo),
+         {:ok, module} <- convert_flow_to_module(flow, module_name, port_specs) do
+      {:ok, module}
+    end
+  end
+
+  defp load_from_flow_name_auto(flow_name, module_name, repo) do
+    with {:ok, flow} <- fetch_flow_by_name(flow_name, repo) do
+      module = FlowConverter.flow_to_module_auto(flow.definition, module_name)
+      {:ok, module}
+    end
+  end
+
+  defp fetch_flow_by_id(flow_id, repo) do
+    case repo.get(Schemas.Flow, flow_id) do
+      nil -> {:error, {:flow_not_found, flow_id}}
+      flow -> {:ok, flow}
+    end
+  end
+
+  defp fetch_flow_by_name(flow_name, repo) do
+    import Ecto.Query
+
+    query = from(f in Schemas.Flow, where: f.name == ^flow_name)
+
+    case repo.one(query) do
+      nil -> {:error, {:flow_not_found, flow_name}}
+      flow -> {:ok, flow}
+    end
+  end
+
+  defp convert_flow_to_module(flow, module_name, port_specs) do
+    module =
+      FlowConverter.flow_to_module(
+        flow.definition,
+        name: module_name,
+        port_specs: port_specs
+      )
+
+    {:ok, module}
+  rescue
+    error -> {:error, {:conversion_failed, error}}
+  end
+end

--- a/lib/coloured_flow/validators/definition/module_validator.ex
+++ b/lib/coloured_flow/validators/definition/module_validator.ex
@@ -1,0 +1,460 @@
+defmodule ColouredFlow.Validators.Definition.ModuleValidator do
+  @moduledoc """
+  Validates module definitions and substitution transitions.
+
+  This validator ensures that:
+  1. All modules have valid internal structure (valid petri nets)
+  2. Port places are properly defined
+  3. Substitution transitions correctly reference existing modules
+  4. Socket assignments are valid (colour sets match)
+  5. There are no circular module references
+  6. All referenced modules exist
+  """
+
+  alias ColouredFlow.Definition.Arc
+  alias ColouredFlow.Definition.ColouredPetriNet
+  alias ColouredFlow.Definition.Module
+  alias ColouredFlow.Definition.Place
+  alias ColouredFlow.Definition.PortPlace
+  alias ColouredFlow.Definition.SocketAssignment
+  alias ColouredFlow.Definition.Transition
+  alias ColouredFlow.Validators.Exceptions.InvalidModuleError
+
+  @spec validate(ColouredPetriNet.t()) ::
+          {:ok, ColouredPetriNet.t()} | {:error, InvalidModuleError.t()}
+  def validate(%ColouredPetriNet{modules: []} = cpnet) do
+    # No modules to validate, but still check substitution transitions
+    validate_substitution_transitions(cpnet)
+  end
+
+  def validate(%ColouredPetriNet{} = cpnet) do
+    with :ok <- validate_module_names_unique(cpnet),
+         :ok <- validate_each_module(cpnet),
+         :ok <- validate_no_circular_references(cpnet),
+         {:ok, cpnet} <- validate_substitution_transitions(cpnet) do
+      {:ok, cpnet}
+    end
+  end
+
+  # Validate that all module names are unique
+  defp validate_module_names_unique(%ColouredPetriNet{modules: modules}) do
+    duplicates =
+      modules
+      |> Enum.group_by(& &1.name)
+      |> Enum.filter(fn {_name, list} -> length(list) > 1 end)
+      |> Enum.map(fn {name, _list} -> name end)
+
+    if duplicates == [] do
+      :ok
+    else
+      {
+        :error,
+        InvalidModuleError.exception(
+          reason: :duplicate_module_names,
+          message: """
+          Duplicate module names found:
+          #{Enum.join(duplicates, ", ")}
+          """
+        )
+      }
+    end
+  end
+
+  # Validate each module's internal structure
+  defp validate_each_module(%ColouredPetriNet{modules: modules} = cpnet) do
+    Enum.reduce_while(modules, :ok, fn module, :ok ->
+      case validate_module(module, cpnet) do
+        :ok -> {:cont, :ok}
+        {:error, _reason} = error -> {:halt, error}
+      end
+    end)
+  end
+
+  # Validate a single module
+  defp validate_module(%Module{} = module, %ColouredPetriNet{} = cpnet) do
+    with :ok <- validate_port_places_unique(module),
+         :ok <- validate_internal_places_unique(module),
+         :ok <- validate_port_and_internal_places_disjoint(module),
+         :ok <- validate_module_arcs(module),
+         :ok <- validate_module_colour_sets(module, cpnet) do
+      :ok
+    end
+  end
+
+  # Validate that port place names are unique
+  defp validate_port_places_unique(%Module{name: module_name, port_places: port_places}) do
+    duplicates =
+      port_places
+      |> Enum.group_by(& &1.name)
+      |> Enum.filter(fn {_name, list} -> length(list) > 1 end)
+      |> Enum.map(fn {name, _list} -> name end)
+
+    if duplicates == [] do
+      :ok
+    else
+      {
+        :error,
+        InvalidModuleError.exception(
+          reason: :duplicate_port_places,
+          module_name: module_name,
+          message: """
+          Module "#{module_name}" has duplicate port place names:
+          #{Enum.join(duplicates, ", ")}
+          """
+        )
+      }
+    end
+  end
+
+  # Validate that internal place names are unique
+  defp validate_internal_places_unique(%Module{name: module_name, places: places}) do
+    duplicates =
+      places
+      |> Enum.group_by(& &1.name)
+      |> Enum.filter(fn {_name, list} -> length(list) > 1 end)
+      |> Enum.map(fn {name, _list} -> name end)
+
+    if duplicates == [] do
+      :ok
+    else
+      {
+        :error,
+        InvalidModuleError.exception(
+          reason: :duplicate_internal_places,
+          module_name: module_name,
+          message: """
+          Module "#{module_name}" has duplicate internal place names:
+          #{Enum.join(duplicates, ", ")}
+          """
+        )
+      }
+    end
+  end
+
+  # Validate that port places and internal places have different names
+  defp validate_port_and_internal_places_disjoint(%Module{
+         name: module_name,
+         port_places: port_places,
+         places: places
+       }) do
+    port_names = MapSet.new(port_places, & &1.name)
+    internal_names = MapSet.new(places, & &1.name)
+
+    intersection = MapSet.intersection(port_names, internal_names)
+
+    if MapSet.size(intersection) == 0 do
+      :ok
+    else
+      {
+        :error,
+        InvalidModuleError.exception(
+          reason: :overlapping_place_names,
+          module_name: module_name,
+          message: """
+          Module "#{module_name}" has overlapping port and internal place names:
+          #{Enum.join(MapSet.to_list(intersection), ", ")}
+          Port places and internal places must have different names.
+          """
+        )
+      }
+    end
+  end
+
+  # Validate that arcs reference valid places (port or internal) and transitions
+  defp validate_module_arcs(%Module{name: module_name} = module) do
+    all_place_names = MapSet.new(Module.all_places(module), & &1.name)
+    transition_names = MapSet.new(module.transitions, & &1.name)
+
+    invalid_arcs =
+      Enum.filter(module.arcs, fn %Arc{place: place, transition: transition} ->
+        not MapSet.member?(all_place_names, place) or not MapSet.member?(transition_names, transition)
+      end)
+
+    if invalid_arcs == [] do
+      :ok
+    else
+      arc_messages =
+        Enum.map_join(invalid_arcs, "\n", fn arc ->
+          "- Place: #{arc.place}, Transition: #{arc.transition}"
+        end)
+
+      {
+        :error,
+        InvalidModuleError.exception(
+          reason: :invalid_arc_references,
+          module_name: module_name,
+          message: """
+          Module "#{module_name}" has arcs referencing non-existent places or transitions:
+          #{arc_messages}
+          """
+        )
+      }
+    end
+  end
+
+  # Validate that module colour sets exist in parent net or are defined in module
+  defp validate_module_colour_sets(%Module{name: module_name} = module, %ColouredPetriNet{} =
+                                                                           cpnet) do
+    parent_colour_sets = MapSet.new(cpnet.colour_sets, & &1.name)
+    module_colour_sets = MapSet.new(module.colour_sets, & &1.name)
+    all_colour_sets = MapSet.union(parent_colour_sets, module_colour_sets)
+
+    # Check all places reference valid colour sets
+    all_places = Module.all_places(module)
+
+    missing_colour_sets =
+      Enum.reduce(all_places, MapSet.new(), fn place, acc ->
+        colour_set_name =
+          case place do
+            %Place{colour_set: cs} -> cs
+            %PortPlace{colour_set: cs} -> cs
+          end
+
+        if MapSet.member?(all_colour_sets, colour_set_name) do
+          acc
+        else
+          MapSet.put(acc, {place.name, colour_set_name})
+        end
+      end)
+
+    if MapSet.size(missing_colour_sets) == 0 do
+      :ok
+    else
+      messages =
+        Enum.map_join(missing_colour_sets, "\n", fn {place_name, colour_set} ->
+          "- Place: #{place_name}, Missing colour set: #{colour_set}"
+        end)
+
+      {
+        :error,
+        InvalidModuleError.exception(
+          reason: :missing_colour_sets,
+          module_name: module_name,
+          message: """
+          Module "#{module_name}" references non-existent colour sets:
+          #{messages}
+          """
+        )
+      }
+    end
+  end
+
+  # Validate that there are no circular module references
+  defp validate_no_circular_references(%ColouredPetriNet{modules: modules}) do
+    # Build a dependency graph
+    dependency_graph =
+      Enum.reduce(modules, %{}, fn module, acc ->
+        dependencies =
+          module.transitions
+          |> Enum.filter(&Transition.substitution?/1)
+          |> Enum.map(& &1.subst)
+
+        Map.put(acc, module.name, dependencies)
+      end)
+
+    # Check for cycles using DFS
+    case find_cycle(dependency_graph) do
+      nil ->
+        :ok
+
+      cycle ->
+        {
+          :error,
+          InvalidModuleError.exception(
+            reason: :circular_module_reference,
+            message: """
+            Circular module reference detected:
+            #{Enum.join(cycle, " -> ")}
+            """
+          )
+        }
+    end
+  end
+
+  # Find a cycle in the dependency graph using DFS
+  defp find_cycle(graph) do
+    Enum.find_value(Map.keys(graph), fn start ->
+      dfs_cycle(graph, start, MapSet.new(), [])
+    end)
+  end
+
+  defp dfs_cycle(graph, node, visited, path) do
+    cond do
+      node in path ->
+        # Found a cycle
+        [node | Enum.take_while(Enum.reverse(path), &(&1 != node))] |> Enum.reverse()
+
+      MapSet.member?(visited, node) ->
+        # Already visited, no cycle from this node
+        nil
+
+      true ->
+        # Explore neighbors
+        neighbors = Map.get(graph, node, [])
+        visited = MapSet.put(visited, node)
+        path = [node | path]
+
+        Enum.find_value(neighbors, fn neighbor ->
+          dfs_cycle(graph, neighbor, visited, path)
+        end)
+    end
+  end
+
+  # Validate all substitution transitions
+  defp validate_substitution_transitions(%ColouredPetriNet{} = cpnet) do
+    substitution_transitions = ColouredPetriNet.substitution_transitions(cpnet)
+
+    case validate_each_substitution_transition(substitution_transitions, cpnet) do
+      :ok -> {:ok, cpnet}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp validate_each_substitution_transition(transitions, cpnet) do
+    Enum.reduce_while(transitions, :ok, fn transition, :ok ->
+      case validate_substitution_transition(transition, cpnet) do
+        :ok -> {:cont, :ok}
+        {:error, _reason} = error -> {:halt, error}
+      end
+    end)
+  end
+
+  # Validate a single substitution transition
+  defp validate_substitution_transition(%Transition{} = transition, %ColouredPetriNet{} = cpnet) do
+    with :ok <- validate_module_exists(transition, cpnet),
+         :ok <- validate_socket_assignments(transition, cpnet) do
+      :ok
+    end
+  end
+
+  # Validate that the referenced module exists
+  defp validate_module_exists(%Transition{name: trans_name, subst: module_name}, %ColouredPetriNet{} =
+                                                                                    cpnet) do
+    if ColouredPetriNet.get_module(cpnet, module_name) do
+      :ok
+    else
+      {
+        :error,
+        InvalidModuleError.exception(
+          reason: :module_not_found,
+          module_name: module_name,
+          message: """
+          Substitution transition "#{trans_name}" references non-existent module "#{module_name}".
+          """
+        )
+      }
+    end
+  end
+
+  # Validate socket assignments
+  defp validate_socket_assignments(%Transition{} = transition, %ColouredPetriNet{} = cpnet) do
+    module = ColouredPetriNet.get_module(cpnet, transition.subst)
+
+    with :ok <- validate_all_ports_assigned(transition, module),
+         :ok <- validate_socket_places_exist(transition, cpnet),
+         :ok <- validate_colour_sets_match(transition, cpnet, module) do
+      :ok
+    end
+  end
+
+  # Validate that all port places are assigned
+  defp validate_all_ports_assigned(
+         %Transition{name: trans_name, socket_assignments: assignments},
+         %Module{name: module_name, port_places: port_places}
+       ) do
+    assigned_ports = MapSet.new(assignments, & &1.port)
+    required_ports = MapSet.new(port_places, & &1.name)
+
+    missing_ports = MapSet.difference(required_ports, assigned_ports)
+
+    if MapSet.size(missing_ports) == 0 do
+      :ok
+    else
+      {
+        :error,
+        InvalidModuleError.exception(
+          reason: :missing_socket_assignments,
+          module_name: module_name,
+          message: """
+          Substitution transition "#{trans_name}" is missing socket assignments for ports:
+          #{Enum.join(MapSet.to_list(missing_ports), ", ")}
+          """
+        )
+      }
+    end
+  end
+
+  # Validate that socket places exist in the parent net
+  defp validate_socket_places_exist(
+         %Transition{name: trans_name, socket_assignments: assignments},
+         %ColouredPetriNet{places: places}
+       ) do
+    place_names = MapSet.new(places, & &1.name)
+
+    missing_places =
+      Enum.filter(assignments, fn %SocketAssignment{socket: socket} ->
+        not MapSet.member?(place_names, socket)
+      end)
+
+    if missing_places == [] do
+      :ok
+    else
+      messages =
+        Enum.map_join(missing_places, "\n", fn assignment ->
+          "- Socket: #{assignment.socket}, Port: #{assignment.port}"
+        end)
+
+      {
+        :error,
+        InvalidModuleError.exception(
+          reason: :socket_place_not_found,
+          message: """
+          Substitution transition "#{trans_name}" references non-existent socket places:
+          #{messages}
+          """
+        )
+      }
+    end
+  end
+
+  # Validate that colour sets match between sockets and ports
+  defp validate_colour_sets_match(
+         %Transition{name: trans_name, socket_assignments: assignments},
+         %ColouredPetriNet{places: places},
+         %Module{} = module
+       ) do
+    place_map = Map.new(places, fn place -> {place.name, place} end)
+
+    mismatches =
+      Enum.filter(assignments, fn %SocketAssignment{socket: socket, port: port} ->
+        socket_place = Map.get(place_map, socket)
+        port_place = Module.get_port_place(module, port)
+
+        socket_place && port_place && socket_place.colour_set != port_place.colour_set
+      end)
+
+    if mismatches == [] do
+      :ok
+    else
+      messages =
+        Enum.map_join(mismatches, "\n", fn assignment ->
+          socket_place = Map.get(place_map, assignment.socket)
+          port_place = Module.get_port_place(module, assignment.port)
+
+          "- Socket: #{assignment.socket} (#{socket_place.colour_set}) " <>
+            "-> Port: #{assignment.port} (#{port_place.colour_set})"
+        end)
+
+      {
+        :error,
+        InvalidModuleError.exception(
+          reason: :colour_set_mismatch,
+          message: """
+          Substitution transition "#{trans_name}" has colour set mismatches:
+          #{messages}
+          """
+        )
+      }
+    end
+  end
+end

--- a/lib/coloured_flow/validators/exceptions/invalid_module_error.ex
+++ b/lib/coloured_flow/validators/exceptions/invalid_module_error.ex
@@ -1,0 +1,26 @@
+defmodule ColouredFlow.Validators.Exceptions.InvalidModuleError do
+  @moduledoc """
+  Exception raised when a module definition is invalid.
+  """
+
+  defexception [:reason, :module_name, :message]
+
+  @type t() :: %__MODULE__{
+          reason: atom(),
+          module_name: binary() | nil,
+          message: binary()
+        }
+
+  @impl Exception
+  def exception(opts) do
+    reason = Keyword.fetch!(opts, :reason)
+    module_name = Keyword.get(opts, :module_name)
+    message = Keyword.fetch!(opts, :message)
+
+    %__MODULE__{
+      reason: reason,
+      module_name: module_name,
+      message: message
+    }
+  end
+end

--- a/lib/coloured_flow/validators/validators.ex
+++ b/lib/coloured_flow/validators/validators.ex
@@ -10,6 +10,7 @@ defmodule ColouredFlow.Validators do
   alias ColouredFlow.Validators.Definition.ColourSetValidator
   alias ColouredFlow.Validators.Definition.ConstantsValidator
   alias ColouredFlow.Validators.Definition.GuardValidator
+  alias ColouredFlow.Validators.Definition.ModuleValidator
   alias ColouredFlow.Validators.Definition.StructureValidator
   alias ColouredFlow.Validators.Definition.TerminationCriteriaValidator
   alias ColouredFlow.Validators.Definition.UniqueNameValidator
@@ -22,6 +23,7 @@ defmodule ColouredFlow.Validators do
       {:ok, cpnet} <- StructureValidator.validate(cpnet),
       {:ok, cpnet} <- UniqueNameValidator.validate(cpnet),
       {:ok, cpnet} <- ColourSetValidator.validate(cpnet),
+      {:ok, cpnet} <- ModuleValidator.validate(cpnet),
       {:ok, constants} <- ConstantsValidator.validate(cpnet.constants, cpnet),
       cpnet = %ColouredPetriNet{cpnet | constants: constants},
       {:ok, variables} <- VariablesValidator.validate(cpnet.variables, cpnet),

--- a/test/coloured_flow/builder/flow_converter_test.exs
+++ b/test/coloured_flow/builder/flow_converter_test.exs
@@ -1,0 +1,427 @@
+defmodule ColouredFlow.Builder.FlowConverterTest do
+  use ExUnit.Case, async: true
+
+  alias ColouredFlow.Builder.FlowConverter
+  alias ColouredFlow.Definition.Arc
+  alias ColouredFlow.Definition.ColouredPetriNet
+  alias ColouredFlow.Definition.Place
+  alias ColouredFlow.Definition.Transition
+
+  import ColouredFlow.Notation.Colset
+
+  describe "flow_to_module/2" do
+    test "converts a simple flow to a module with specified ports" do
+      flow = %ColouredPetriNet{
+        colour_sets: [colset(unit() :: {})],
+        places: [
+          %Place{name: "input", colour_set: :unit},
+          %Place{name: "output", colour_set: :unit},
+          %Place{name: "internal", colour_set: :unit}
+        ],
+        transitions: [
+          %Transition{name: "process"}
+        ],
+        arcs: [
+          %Arc{
+            place: "input",
+            transition: "process",
+            orientation: :p_to_t,
+            expression: Arc.build_expression!(:p_to_t, "bind {1, u}")
+          },
+          %Arc{
+            place: "output",
+            transition: "process",
+            orientation: :t_to_p,
+            expression: Arc.build_expression!(:t_to_p, "{1, u}")
+          }
+        ],
+        variables: []
+      }
+
+      module =
+        FlowConverter.flow_to_module(flow,
+          name: "processor",
+          port_specs: [
+            {"input", :input},
+            {"output", :output}
+          ]
+        )
+
+      assert module.name == "processor"
+      assert length(module.port_places) == 2
+      assert length(module.places) == 1
+
+      input_port = Enum.find(module.port_places, &(&1.name == "input"))
+      assert input_port.port_type == :input
+      assert input_port.colour_set == :unit
+
+      output_port = Enum.find(module.port_places, &(&1.name == "output"))
+      assert output_port.port_type == :output
+      assert output_port.colour_set == :unit
+
+      internal_place = Enum.find(module.places, &(&1.name == "internal"))
+      assert internal_place != nil
+    end
+
+    test "preserves all flow definitions in the module" do
+      flow = %ColouredPetriNet{
+        colour_sets: [colset(unit() :: {}), colset(int() :: integer())],
+        places: [
+          %Place{name: "p1", colour_set: :unit}
+        ],
+        transitions: [
+          %Transition{name: "t1"},
+          %Transition{name: "t2"}
+        ],
+        arcs: [
+          %Arc{
+            place: "p1",
+            transition: "t1",
+            orientation: :p_to_t,
+            expression: Arc.build_expression!(:p_to_t, "bind {1, u}")
+          }
+        ],
+        variables: [],
+        constants: []
+      }
+
+      module =
+        FlowConverter.flow_to_module(flow,
+          name: "test_module",
+          port_specs: [{"p1", :io}]
+        )
+
+      assert length(module.colour_sets) == 2
+      assert length(module.transitions) == 2
+      assert length(module.arcs) == 1
+    end
+
+    test "supports I/O port type" do
+      flow = %ColouredPetriNet{
+        colour_sets: [colset(unit() :: {})],
+        places: [
+          %Place{name: "bidirectional", colour_set: :unit}
+        ],
+        transitions: [],
+        arcs: []
+      }
+
+      module =
+        FlowConverter.flow_to_module(flow,
+          name: "io_module",
+          port_specs: [{"bidirectional", :io}]
+        )
+
+      port = Enum.find(module.port_places, &(&1.name == "bidirectional"))
+      assert port.port_type == :io
+    end
+
+    test "raises when port spec references non-existent place" do
+      flow = %ColouredPetriNet{
+        colour_sets: [colset(unit() :: {})],
+        places: [
+          %Place{name: "existing", colour_set: :unit}
+        ],
+        transitions: [],
+        arcs: []
+      }
+
+      assert_raise ArgumentError, ~r/non-existent places: nonexistent/, fn ->
+        FlowConverter.flow_to_module(flow,
+          name: "bad_module",
+          port_specs: [{"nonexistent", :input}]
+        )
+      end
+    end
+
+    test "raises when port type is invalid" do
+      flow = %ColouredPetriNet{
+        colour_sets: [colset(unit() :: {})],
+        places: [
+          %Place{name: "p1", colour_set: :unit}
+        ],
+        transitions: [],
+        arcs: []
+      }
+
+      assert_raise ArgumentError, ~r/Invalid port type/, fn ->
+        FlowConverter.flow_to_module(flow,
+          name: "bad_module",
+          port_specs: [{"p1", :invalid_type}]
+        )
+      end
+    end
+
+    test "raises when required options are missing" do
+      flow = %ColouredPetriNet{
+        colour_sets: [colset(unit() :: {})],
+        places: [],
+        transitions: [],
+        arcs: []
+      }
+
+      assert_raise ArgumentError, fn ->
+        FlowConverter.flow_to_module(flow, [])
+      end
+
+      assert_raise ArgumentError, fn ->
+        FlowConverter.flow_to_module(flow, name: "test")
+      end
+
+      assert_raise ArgumentError, fn ->
+        FlowConverter.flow_to_module(flow, port_specs: [])
+      end
+    end
+
+    test "raises on duplicate port specs" do
+      flow = %ColouredPetriNet{
+        colour_sets: [colset(unit() :: {})],
+        places: [
+          %Place{name: "p1", colour_set: :unit}
+        ],
+        transitions: [],
+        arcs: []
+      }
+
+      assert_raise ArgumentError, ~r/Duplicate port specs/, fn ->
+        FlowConverter.flow_to_module(flow,
+          name: "dup_module",
+          port_specs: [
+            {"p1", :input},
+            {"p1", :output}
+          ]
+        )
+      end
+    end
+  end
+
+  describe "flow_to_module_auto/2" do
+    test "automatically detects input and output ports" do
+      flow = %ColouredPetriNet{
+        colour_sets: [colset(unit() :: {})],
+        places: [
+          %Place{name: "start", colour_set: :unit},
+          %Place{name: "end", colour_set: :unit},
+          %Place{name: "middle", colour_set: :unit}
+        ],
+        transitions: [
+          %Transition{name: "t1"},
+          %Transition{name: "t2"}
+        ],
+        arcs: [
+          # start has no incoming arcs -> input port
+          %Arc{
+            place: "start",
+            transition: "t1",
+            orientation: :p_to_t,
+            expression: Arc.build_expression!(:p_to_t, "bind {1, u}")
+          },
+          # middle has both incoming and outgoing -> internal
+          %Arc{
+            place: "middle",
+            transition: "t1",
+            orientation: :t_to_p,
+            expression: Arc.build_expression!(:t_to_p, "{1, u}")
+          },
+          %Arc{
+            place: "middle",
+            transition: "t2",
+            orientation: :p_to_t,
+            expression: Arc.build_expression!(:p_to_t, "bind {1, u}")
+          },
+          # end has no outgoing arcs -> output port
+          %Arc{
+            place: "end",
+            transition: "t2",
+            orientation: :t_to_p,
+            expression: Arc.build_expression!(:t_to_p, "{1, u}")
+          }
+        ],
+        variables: []
+      }
+
+      module = FlowConverter.flow_to_module_auto(flow, "auto_module")
+
+      assert module.name == "auto_module"
+      assert length(module.port_places) == 2
+      assert length(module.places) == 1
+
+      port_names = Enum.map(module.port_places, & &1.name) |> MapSet.new()
+      assert MapSet.member?(port_names, "start")
+      assert MapSet.member?(port_names, "end")
+
+      start_port = Enum.find(module.port_places, &(&1.name == "start"))
+      assert start_port.port_type == :input
+
+      end_port = Enum.find(module.port_places, &(&1.name == "end"))
+      assert end_port.port_type == :output
+
+      internal_place = Enum.find(module.places, &(&1.name == "middle"))
+      assert internal_place != nil
+    end
+
+    test "handles flow with no clear ports" do
+      flow = %ColouredPetriNet{
+        colour_sets: [colset(unit() :: {})],
+        places: [
+          %Place{name: "p1", colour_set: :unit},
+          %Place{name: "p2", colour_set: :unit}
+        ],
+        transitions: [%Transition{name: "t1"}],
+        arcs: [
+          %Arc{
+            place: "p1",
+            transition: "t1",
+            orientation: :p_to_t,
+            expression: Arc.build_expression!(:p_to_t, "bind {1, u}")
+          },
+          %Arc{
+            place: "p1",
+            transition: "t1",
+            orientation: :t_to_p,
+            expression: Arc.build_expression!(:t_to_p, "{1, u}")
+          },
+          %Arc{
+            place: "p2",
+            transition: "t1",
+            orientation: :p_to_t,
+            expression: Arc.build_expression!(:p_to_t, "bind {1, u}")
+          },
+          %Arc{
+            place: "p2",
+            transition: "t1",
+            orientation: :t_to_p,
+            expression: Arc.build_expression!(:t_to_p, "{1, u}")
+          }
+        ],
+        variables: []
+      }
+
+      module = FlowConverter.flow_to_module_auto(flow, "no_ports_module")
+
+      # All places have both incoming and outgoing, so no ports detected
+      assert module.port_places == []
+      assert length(module.places) == 2
+    end
+  end
+
+  describe "validate_conversion/2" do
+    test "returns :ok with no warnings for valid conversion" do
+      flow = %ColouredPetriNet{
+        colour_sets: [colset(unit() :: {})],
+        places: [
+          %Place{name: "p1", colour_set: :unit}
+        ],
+        transitions: [%Transition{name: "t1"}],
+        arcs: [
+          %Arc{
+            place: "p1",
+            transition: "t1",
+            orientation: :p_to_t,
+            expression: Arc.build_expression!(:p_to_t, "bind {1, u}")
+          }
+        ]
+      }
+
+      assert {:ok, []} =
+               FlowConverter.validate_conversion(flow,
+                 name: "test",
+                 port_specs: [{"p1", :input}]
+               )
+    end
+
+    test "returns error when name is missing" do
+      flow = %ColouredPetriNet{
+        colour_sets: [colset(unit() :: {})],
+        places: [],
+        transitions: [],
+        arcs: []
+      }
+
+      assert {:error, errors} =
+               FlowConverter.validate_conversion(flow, port_specs: [])
+
+      assert Enum.any?(errors, &String.contains?(&1, "Missing required option: name"))
+    end
+
+    test "returns error when port_specs is missing" do
+      flow = %ColouredPetriNet{
+        colour_sets: [colset(unit() :: {})],
+        places: [],
+        transitions: [],
+        arcs: []
+      }
+
+      assert {:error, errors} =
+               FlowConverter.validate_conversion(flow, name: "test")
+
+      assert Enum.any?(errors, &String.contains?(&1, "Missing required option: port_specs"))
+    end
+
+    test "returns error when port spec references non-existent place" do
+      flow = %ColouredPetriNet{
+        colour_sets: [colset(unit() :: {})],
+        places: [
+          %Place{name: "existing", colour_set: :unit}
+        ],
+        transitions: [],
+        arcs: []
+      }
+
+      assert {:error, errors} =
+               FlowConverter.validate_conversion(flow,
+                 name: "test",
+                 port_specs: [{"nonexistent", :input}]
+               )
+
+      assert Enum.any?(errors, &String.contains?(&1, "non-existent places"))
+    end
+
+    test "returns warning for isolated places" do
+      flow = %ColouredPetriNet{
+        colour_sets: [colset(unit() :: {})],
+        places: [
+          %Place{name: "connected", colour_set: :unit},
+          %Place{name: "isolated", colour_set: :unit}
+        ],
+        transitions: [%Transition{name: "t1"}],
+        arcs: [
+          %Arc{
+            place: "connected",
+            transition: "t1",
+            orientation: :p_to_t,
+            expression: Arc.build_expression!(:p_to_t, "bind {1, u}")
+          }
+        ]
+      }
+
+      assert {:ok, warnings} =
+               FlowConverter.validate_conversion(flow,
+                 name: "test",
+                 port_specs: [{"connected", :input}]
+               )
+
+      assert Enum.any?(warnings, &String.contains?(&1, "isolated places"))
+    end
+
+    test "returns warning when most places will be internal" do
+      flow = %ColouredPetriNet{
+        colour_sets: [colset(unit() :: {})],
+        places:
+          Enum.map(1..10, fn i ->
+            %Place{name: "p#{i}", colour_set: :unit}
+          end),
+        transitions: [],
+        arcs: []
+      }
+
+      assert {:ok, warnings} =
+               FlowConverter.validate_conversion(flow,
+                 name: "test",
+                 port_specs: [{"p1", :input}]
+               )
+
+      assert Enum.any?(warnings, &String.contains?(&1, "More than 80% of places will be internal"))
+    end
+  end
+end

--- a/test/coloured_flow/definition/module_test.exs
+++ b/test/coloured_flow/definition/module_test.exs
@@ -1,0 +1,100 @@
+defmodule ColouredFlow.Definition.ModuleTest do
+  use ExUnit.Case, async: true
+
+  alias ColouredFlow.Definition.Module
+  alias ColouredFlow.Definition.Place
+  alias ColouredFlow.Definition.PortPlace
+
+  describe "all_places/1" do
+    test "returns both port places and internal places" do
+      module = %Module{
+        name: "test_module",
+        port_places: [
+          %PortPlace{name: "port1", colour_set: :unit, port_type: :input},
+          %PortPlace{name: "port2", colour_set: :unit, port_type: :output}
+        ],
+        places: [
+          %Place{name: "internal1", colour_set: :unit},
+          %Place{name: "internal2", colour_set: :unit}
+        ]
+      }
+
+      all_places = Module.all_places(module)
+
+      assert length(all_places) == 4
+      assert Enum.any?(all_places, &(&1.name == "port1"))
+      assert Enum.any?(all_places, &(&1.name == "port2"))
+      assert Enum.any?(all_places, &(&1.name == "internal1"))
+      assert Enum.any?(all_places, &(&1.name == "internal2"))
+    end
+  end
+
+  describe "get_port_place/2" do
+    test "returns the port place with the given name" do
+      module = %Module{
+        name: "test_module",
+        port_places: [
+          %PortPlace{name: "input", colour_set: :unit, port_type: :input},
+          %PortPlace{name: "output", colour_set: :unit, port_type: :output}
+        ]
+      }
+
+      port = Module.get_port_place(module, "input")
+      assert port.name == "input"
+      assert port.port_type == :input
+    end
+
+    test "returns nil when port place does not exist" do
+      module = %Module{
+        name: "test_module",
+        port_places: []
+      }
+
+      assert Module.get_port_place(module, "nonexistent") == nil
+    end
+  end
+
+  describe "input_ports/1" do
+    test "returns only input and I/O ports" do
+      module = %Module{
+        name: "test_module",
+        port_places: [
+          %PortPlace{name: "in1", colour_set: :unit, port_type: :input},
+          %PortPlace{name: "out1", colour_set: :unit, port_type: :output},
+          %PortPlace{name: "io1", colour_set: :unit, port_type: :io},
+          %PortPlace{name: "in2", colour_set: :unit, port_type: :input}
+        ]
+      }
+
+      input_ports = Module.input_ports(module)
+
+      assert length(input_ports) == 3
+      assert Enum.any?(input_ports, &(&1.name == "in1"))
+      assert Enum.any?(input_ports, &(&1.name == "in2"))
+      assert Enum.any?(input_ports, &(&1.name == "io1"))
+      refute Enum.any?(input_ports, &(&1.name == "out1"))
+    end
+  end
+
+  describe "output_ports/1" do
+    test "returns only output and I/O ports" do
+      module = %Module{
+        name: "test_module",
+        port_places: [
+          %PortPlace{name: "in1", colour_set: :unit, port_type: :input},
+          %PortPlace{name: "out1", colour_set: :unit, port_type: :output},
+          %PortPlace{name: "io1", colour_set: :unit, port_type: :io},
+          %PortPlace{name: "out2", colour_set: :unit, port_type: :output}
+        ]
+      }
+
+      output_ports = Module.output_ports(module)
+
+      assert length(output_ports) == 3
+      assert Enum.any?(output_ports, &(&1.name == "out1"))
+      assert Enum.any?(output_ports, &(&1.name == "out2"))
+      assert Enum.any?(output_ports, &(&1.name == "io1"))
+      refute Enum.any?(output_ports, &(&1.name == "in1"))
+    end
+  end
+end

--- a/test/coloured_flow/runtime/subflow_manager/default_test.exs
+++ b/test/coloured_flow/runtime/subflow_manager/default_test.exs
@@ -1,0 +1,87 @@
+defmodule ColouredFlow.Runtime.SubFlowManager.DefaultTest do
+  use ExUnit.Case, async: true
+
+  alias ColouredFlow.Runtime.SubFlowManager
+  alias ColouredFlow.Runtime.SubFlowManager.Default
+
+  describe "new/1" do
+    test "creates a new default manager with repo" do
+      manager = Default.new(repo: MyApp.Repo)
+
+      assert %Default{repo: MyApp.Repo} = manager
+    end
+
+    test "raises when repo is not provided" do
+      assert_raise ArgumentError, fn ->
+        Default.new([])
+      end
+    end
+  end
+
+  describe "resolve_module/3" do
+    test "returns error for invalid module reference format" do
+      manager = Default.new(repo: MyApp.Repo)
+
+      # Invalid: not a tuple
+      assert {:error, {:invalid_module_ref, _}} =
+               SubFlowManager.resolve_module(manager, :invalid, [])
+
+      # Invalid: tuple but wrong format
+      assert {:error, {:invalid_module_ref, _}} =
+               SubFlowManager.resolve_module(manager, {:wrong_ref, []}, [])
+    end
+
+    test "returns error for module_ref with unknown options" do
+      manager = Default.new(repo: MyApp.Repo)
+
+      assert {:error, {:invalid_module_ref, _}} =
+               SubFlowManager.resolve_module(
+                 manager,
+                 {:module_ref, unknown_option: "value"},
+                 []
+               )
+    end
+
+    # Note: Full database integration tests would require test database setup
+    # and would test:
+    # - Loading by flow_id with port_specs
+    # - Loading by flow_id with module_name (auto-detect)
+    # - Loading by flow_name with port_specs
+    # - Loading by flow_name with module_name (auto-detect)
+    # - Error handling for non-existent flows
+    # - Error handling for conversion failures
+  end
+
+  describe "start_child_enactment/4" do
+    test "returns not_implemented error" do
+      manager = Default.new(repo: MyApp.Repo)
+
+      assert {:error, :not_implemented} =
+               SubFlowManager.start_child_enactment(
+                 manager,
+                 %ColouredFlow.Definition.Module{
+                   name: "test_module",
+                   port_places: [],
+                   places: [],
+                   transitions: [],
+                   arcs: [],
+                   colour_sets: [],
+                   variables: [],
+                   constants: [],
+                   functions: []
+                 },
+                 [],
+                 parent_pid: self()
+               )
+    end
+  end
+
+  describe "get_child_state/2" do
+    test "returns not_implemented error" do
+      manager = Default.new(repo: MyApp.Repo)
+
+      assert {:error, :not_implemented} =
+               SubFlowManager.get_child_state(manager, :some_child_id)
+    end
+  end
+end

--- a/test/coloured_flow/validators/definition/module_validator_test.exs
+++ b/test/coloured_flow/validators/definition/module_validator_test.exs
@@ -1,0 +1,310 @@
+defmodule ColouredFlow.Validators.Definition.ModuleValidatorTest do
+  use ExUnit.Case, async: true
+
+  alias ColouredFlow.Definition.Arc
+  alias ColouredFlow.Definition.ColouredPetriNet
+  alias ColouredFlow.Definition.Module
+  alias ColouredFlow.Definition.Place
+  alias ColouredFlow.Definition.PortPlace
+  alias ColouredFlow.Definition.SocketAssignment
+  alias ColouredFlow.Definition.Transition
+  alias ColouredFlow.Validators.Definition.ModuleValidator
+  alias ColouredFlow.Validators.Exceptions.InvalidModuleError
+
+  import ColouredFlow.Notation.Colset
+
+  describe "validate/1 with valid module" do
+    test "accepts a simple valid module" do
+      cpnet = %ColouredPetriNet{
+        colour_sets: [colset(unit() :: {})],
+        modules: [
+          %Module{
+            name: "simple_module",
+            port_places: [
+              %PortPlace{name: "input", colour_set: :unit, port_type: :input},
+              %PortPlace{name: "output", colour_set: :unit, port_type: :output}
+            ],
+            places: [
+              %Place{name: "internal", colour_set: :unit}
+            ],
+            transitions: [
+              %Transition{name: "process"}
+            ],
+            arcs: [
+              %Arc{
+                place: "input",
+                transition: "process",
+                orientation: :p_to_t,
+                expression: Arc.build_expression!(:p_to_t, "bind {1, u}")
+              },
+              %Arc{
+                place: "output",
+                transition: "process",
+                orientation: :t_to_p,
+                expression: Arc.build_expression!(:t_to_p, "{1, u}")
+              }
+            ],
+            variables: []
+          }
+        ],
+        places: [],
+        transitions: [],
+        arcs: []
+      }
+
+      assert {:ok, ^cpnet} = ModuleValidator.validate(cpnet)
+    end
+  end
+
+  describe "validate/1 with invalid module names" do
+    test "rejects duplicate module names" do
+      cpnet = %ColouredPetriNet{
+        colour_sets: [colset(unit() :: {})],
+        modules: [
+          %Module{name: "duplicate", port_places: [], places: [], transitions: [], arcs: []},
+          %Module{name: "duplicate", port_places: [], places: [], transitions: [], arcs: []}
+        ],
+        places: [],
+        transitions: [],
+        arcs: []
+      }
+
+      assert {:error, %InvalidModuleError{reason: :duplicate_module_names}} =
+               ModuleValidator.validate(cpnet)
+    end
+  end
+
+  describe "validate/1 with invalid port places" do
+    test "rejects duplicate port place names" do
+      cpnet = %ColouredPetriNet{
+        colour_sets: [colset(unit() :: {})],
+        modules: [
+          %Module{
+            name: "test_module",
+            port_places: [
+              %PortPlace{name: "duplicate", colour_set: :unit, port_type: :input},
+              %PortPlace{name: "duplicate", colour_set: :unit, port_type: :output}
+            ],
+            places: [],
+            transitions: [],
+            arcs: []
+          }
+        ],
+        places: [],
+        transitions: [],
+        arcs: []
+      }
+
+      assert {:error, %InvalidModuleError{reason: :duplicate_port_places}} =
+               ModuleValidator.validate(cpnet)
+    end
+
+    test "rejects overlapping port and internal place names" do
+      cpnet = %ColouredPetriNet{
+        colour_sets: [colset(unit() :: {})],
+        modules: [
+          %Module{
+            name: "test_module",
+            port_places: [
+              %PortPlace{name: "overlap", colour_set: :unit, port_type: :input}
+            ],
+            places: [
+              %Place{name: "overlap", colour_set: :unit}
+            ],
+            transitions: [],
+            arcs: []
+          }
+        ],
+        places: [],
+        transitions: [],
+        arcs: []
+      }
+
+      assert {:error, %InvalidModuleError{reason: :overlapping_place_names}} =
+               ModuleValidator.validate(cpnet)
+    end
+  end
+
+  describe "validate/1 with invalid arcs" do
+    test "rejects arcs referencing non-existent places" do
+      cpnet = %ColouredPetriNet{
+        colour_sets: [colset(unit() :: {})],
+        modules: [
+          %Module{
+            name: "test_module",
+            port_places: [],
+            places: [%Place{name: "place1", colour_set: :unit}],
+            transitions: [%Transition{name: "trans1"}],
+            arcs: [
+              %Arc{
+                place: "nonexistent",
+                transition: "trans1",
+                orientation: :p_to_t,
+                expression: Arc.build_expression!(:p_to_t, "bind {1, u}")
+              }
+            ]
+          }
+        ],
+        places: [],
+        transitions: [],
+        arcs: []
+      }
+
+      assert {:error, %InvalidModuleError{reason: :invalid_arc_references}} =
+               ModuleValidator.validate(cpnet)
+    end
+  end
+
+  describe "validate/1 with substitution transitions" do
+    test "accepts valid substitution transition" do
+      cpnet = %ColouredPetriNet{
+        colour_sets: [colset(unit() :: {})],
+        modules: [
+          %Module{
+            name: "my_module",
+            port_places: [
+              %PortPlace{name: "port_in", colour_set: :unit, port_type: :input}
+            ],
+            places: [],
+            transitions: [],
+            arcs: []
+          }
+        ],
+        places: [
+          %Place{name: "socket_place", colour_set: :unit}
+        ],
+        transitions: [
+          %Transition{
+            name: "subst_trans",
+            subst: "my_module",
+            socket_assignments: [
+              %SocketAssignment{socket: "socket_place", port: "port_in"}
+            ]
+          }
+        ],
+        arcs: []
+      }
+
+      assert {:ok, ^cpnet} = ModuleValidator.validate(cpnet)
+    end
+
+    test "rejects substitution transition referencing non-existent module" do
+      cpnet = %ColouredPetriNet{
+        colour_sets: [colset(unit() :: {})],
+        modules: [],
+        places: [%Place{name: "socket_place", colour_set: :unit}],
+        transitions: [
+          %Transition{
+            name: "subst_trans",
+            subst: "nonexistent_module",
+            socket_assignments: []
+          }
+        ],
+        arcs: []
+      }
+
+      assert {:error, %InvalidModuleError{reason: :module_not_found}} =
+               ModuleValidator.validate(cpnet)
+    end
+
+    test "rejects missing socket assignments" do
+      cpnet = %ColouredPetriNet{
+        colour_sets: [colset(unit() :: {})],
+        modules: [
+          %Module{
+            name: "my_module",
+            port_places: [
+              %PortPlace{name: "port_in", colour_set: :unit, port_type: :input},
+              %PortPlace{name: "port_out", colour_set: :unit, port_type: :output}
+            ],
+            places: [],
+            transitions: [],
+            arcs: []
+          }
+        ],
+        places: [%Place{name: "socket_place", colour_set: :unit}],
+        transitions: [
+          %Transition{
+            name: "subst_trans",
+            subst: "my_module",
+            socket_assignments: [
+              %SocketAssignment{socket: "socket_place", port: "port_in"}
+              # Missing assignment for port_out
+            ]
+          }
+        ],
+        arcs: []
+      }
+
+      assert {:error, %InvalidModuleError{reason: :missing_socket_assignments}} =
+               ModuleValidator.validate(cpnet)
+    end
+
+    test "rejects colour set mismatch between socket and port" do
+      cpnet = %ColouredPetriNet{
+        colour_sets: [colset(unit() :: {}), colset(int() :: integer())],
+        modules: [
+          %Module{
+            name: "my_module",
+            port_places: [
+              %PortPlace{name: "port_in", colour_set: :int, port_type: :input}
+            ],
+            places: [],
+            transitions: [],
+            arcs: []
+          }
+        ],
+        places: [
+          %Place{name: "socket_place", colour_set: :unit}
+        ],
+        transitions: [
+          %Transition{
+            name: "subst_trans",
+            subst: "my_module",
+            socket_assignments: [
+              %SocketAssignment{socket: "socket_place", port: "port_in"}
+            ]
+          }
+        ],
+        arcs: []
+      }
+
+      assert {:error, %InvalidModuleError{reason: :colour_set_mismatch}} =
+               ModuleValidator.validate(cpnet)
+    end
+  end
+
+  describe "validate/1 with circular references" do
+    test "detects simple circular reference" do
+      cpnet = %ColouredPetriNet{
+        colour_sets: [colset(unit() :: {})],
+        modules: [
+          %Module{
+            name: "module_a",
+            port_places: [],
+            places: [],
+            transitions: [
+              %Transition{name: "call_b", subst: "module_b", socket_assignments: []}
+            ],
+            arcs: []
+          },
+          %Module{
+            name: "module_b",
+            port_places: [],
+            places: [],
+            transitions: [
+              %Transition{name: "call_a", subst: "module_a", socket_assignments: []}
+            ],
+            arcs: []
+          }
+        ],
+        places: [],
+        transitions: [],
+        arcs: []
+      }
+
+      assert {:error, %InvalidModuleError{reason: :circular_module_reference}} =
+               ModuleValidator.validate(cpnet)
+    end
+  end
+end


### PR DESCRIPTION
This commit implements comprehensive module support for ColouredFlow, enabling hierarchical composition and reuse in Coloured Petri Nets.

## Key Features

### Definition Layer
- Module: Reusable subnet definitions with port places
- PortPlace: Input/Output/IO interface points for modules
- SocketAssignment: Mapping between parent places and module ports
- Substitution Transitions: Transitions that reference and execute modules

### Validation Layer
- ModuleValidator: Comprehensive validation of modules and substitution transitions
- Validates module structure, port places, socket assignments, colour set matching
- Detects circular module references
- Ensures all required socket assignments are present

### Storage Layer
- JSON codecs for all module-related structures
- Automatic serialization/deserialization of modules
- Updated ColouredPetriNet codec to include modules field

### Builder Layer
- ModuleHelper: Convenient builder functions for modules
- Helper functions for creating port places and socket assignments
- Support for building substitution transitions

### Enactment Layer
- ModuleInstance: Data structure for tracking module instances at runtime
- Foundation for future module execution implementation

### Tests
- Comprehensive test coverage for Module functions
- ModuleValidator tests covering all validation scenarios
- Tests for duplicate detection, circular references, and colour set matching

### Documentation
- Complete module support documentation in docs/module_support.md
- Usage examples and API reference
- Notes on future enhancements

## Implementation Details

Created files:
- Definition: module.ex, port_place.ex, socket_assignment.ex
- Validators: module_validator.ex, invalid_module_error.ex
- Storage codecs: module.ex, port_place.ex, socket_assignment.ex
- Builder: module_helper.ex
- Enactment: module_instance.ex
- Tests: module_test.exs, module_validator_test.exs
- Documentation: module_support.md

Modified files:
- ColouredPetriNet: Added modules field and helper methods
- Transition: Added subst and socket_assignments fields
- Validators: Integrated ModuleValidator into validation pipeline
- Storage codecs: Updated to support new fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)