### PR TITLE
feat(storage): adjust indexes via V2 migration (audit #4 #8 #9 #10)

### DIFF
--- a/lib/coloured_flow/runner/storage/migrations/v2.ex
+++ b/lib/coloured_flow/runner/storage/migrations/v2.ex
@@ -1,0 +1,38 @@
+defmodule ColouredFlow.Runner.Migrations.V2 do
+  @moduledoc false
+
+  use Ecto.Migration
+
+  @prefix "coloured_flow"
+
+  @spec change(prefix: String.t()) :: :ok
+  def change(opts \\ []) do
+    prefix = Keyword.get(opts, :prefix, @prefix)
+    index_options = [prefix: prefix]
+
+    # Drop indexes that duplicate composite primary keys.
+    # `occurrences` PK is `(enactment_id, step_number)` and `snapshots` PK is
+    # `enactment_id`; both PKs already provide the same coverage.
+    drop index("occurrences", [:enactment_id, :step_number], index_options)
+    drop index("snapshots", [:enactment_id], index_options)
+
+    # Add a composite `(enactment_id, state)` index covering the
+    # `list_live_workitems` query in
+    # `ColouredFlow.Runner.Storage.Default.list_live_workitems/1`. The existing
+    # single-column `workitems(state)` index is preserved because
+    # `ColouredFlow.Runner.Worklist.WorkitemStream.live_query/1` filters by
+    # `state in @live_states` without an `enactment_id` filter, which the
+    # composite cannot serve as a left prefix.
+    create index("workitems", [:enactment_id, :state], index_options)
+
+    # Cover queries that look up enactments by their parent flow, and support
+    # the foreign key reference defined in V0.
+    create index("enactments", [:flow_id], index_options)
+
+    # Speed up the `ON DELETE CASCADE` from `workitems` and any future lookup
+    # by `workitem_id`. The foreign key is defined in V1.
+    create index("workitem_logs", [:workitem_id], index_options)
+
+    :ok
+  end
+end

--- a/test/support/repo.ex
+++ b/test/support/repo.ex
@@ -9,7 +9,8 @@ defmodule ColouredFlow.TestRepo do
       __MODULE__,
       [
         {0, ColouredFlow.Runner.Migrations.V0},
-        {1, ColouredFlow.Runner.Migrations.V1}
+        {1, ColouredFlow.Runner.Migrations.V1},
+        {2, ColouredFlow.Runner.Migrations.V2}
       ],
       :up,
       all: true


### PR DESCRIPTION
## Summary

V2 migration adjusts indexes on the existing schema:

- **#10** drop redundant indexes already covered by primary keys:
  - `occurrences(enactment_id, step_number)` — PK is composite `(enactment_id, step_number)`.
  - `snapshots(enactment_id)` — PK is `enactment_id`.
- **#4** add composite `workitems(enactment_id, state)` to serve `Storage.Default.list_live_workitems/1` (`where enactment_id == ? and state in @live_states`).
- **#8** add `enactments(flow_id)` (FK had no explicit index).
- **#9** add `workitem_logs(workitem_id)` (FK with `ON DELETE CASCADE` benefits from the index).

The existing single-column `workitems(state)` index is preserved because `WorkitemStream.live_query/1` issues a bare `state in [...]` query without an `enactment_id` filter — the composite cannot serve as a left prefix.

## Test plan

- [x] `RESET_DB=1 mix test test/coloured_flow/runner/storage/ test/coloured_flow/runner/worklist/` — 37 tests, 0 failures.
- [x] Migration runs forward and rolls back cleanly.
- [ ] CI green (Postgres 15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)