### PR TITLE
perf(calibration): skip enablement re-check when input places disjoint (audit #5)

### DIFF
--- a/lib/coloured_flow/runner/enactment/workitem_calibration.ex
+++ b/lib/coloured_flow/runner/enactment/workitem_calibration.ex
@@ -157,11 +157,8 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibration do
         # those whose input places overlap with the consumed places — others
         # cannot have changed enablement since their tokens are untouched.
         {_workitem_id, %Workitem{state: :enabled} = workitem} ->
-          if disjoint_input_places?(workitem.binding_element, consumed_places) do
-            true
-          else
+          disjoint_input_places?(workitem.binding_element, consumed_places) or
             binding_element_enabled?(workitem.binding_element, place_tokens)
-          end
 
         _other ->
           true

--- a/lib/coloured_flow/runner/enactment/workitem_calibration.ex
+++ b/lib/coloured_flow/runner/enactment/workitem_calibration.ex
@@ -149,19 +149,32 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibration do
   defp withdraw_workitems(%Enactment{} = state, to_consume_markings) do
     place_tokens = Map.new(state.markings, fn {place, marking} -> {place, marking.tokens} end)
     place_tokens = consume_markings(to_consume_markings, place_tokens)
+    consumed_places = MapSet.new(to_consume_markings, & &1.place)
 
     {workitems, to_withdraw} =
       Map.split_with(state.workitems, fn
-        # TODO: only workitems that their input places share with the to_consume_markings should be re-check enabled
-        # only enabled workitems should be re-check enabled
+        # only enabled workitems should be re-checked for enablement, and only
+        # those whose input places overlap with the consumed places — others
+        # cannot have changed enablement since their tokens are untouched.
         {_workitem_id, %Workitem{state: :enabled} = workitem} ->
-          binding_element_enabled?(workitem.binding_element, place_tokens)
+          if disjoint_input_places?(workitem.binding_element, consumed_places) do
+            true
+          else
+            binding_element_enabled?(workitem.binding_element, place_tokens)
+          end
 
         _other ->
           true
       end)
 
     {%Enactment{state | workitems: workitems}, Map.values(to_withdraw)}
+  end
+
+  @spec disjoint_input_places?(BindingElement.t(), MapSet.t(Place.name())) :: boolean()
+  defp disjoint_input_places?(%BindingElement{} = binding_element, consumed_places) do
+    Enum.all?(binding_element.to_consume, fn %Marking{place: place} ->
+      not MapSet.member?(consumed_places, place)
+    end)
   end
 
   @spec produce_workitems(

--- a/test/coloured_flow/runner/enactment/workitem_calibration_test.exs
+++ b/test/coloured_flow/runner/enactment/workitem_calibration_test.exs
@@ -426,6 +426,72 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemCalibrationTest do
       assert expected_state === calibration.state
       assert [aj_workitem_2] === calibration.to_withdraw
     end
+
+    # ```mermaid
+    # flowchart LR
+    #   %% colset int() :: integer()
+    #   %% place_1 ~MS[1], place_2 ~MS[1]
+    #   p1((place_1))
+    #   p2((place_2))
+    #   o1((output_1))
+    #   o2((output_2))
+    #   pt1[pass_through_1]
+    #   pt2[pass_through_2]
+    #   p1 --{1,x}--> pt1 --> o1
+    #   p2 --{1,x}--> pt2 --> o2
+    # ```
+    test "keeps enabled workitems whose input places are disjoint from the started workitem's input places" do
+      enactment_id = Ecto.UUID.generate()
+
+      pt1_workitem = %Enactment.Workitem{
+        id: Ecto.UUID.generate(),
+        state: :enabled,
+        binding_element: %BindingElement{
+          transition: "pass_through_1",
+          binding: [x: 1],
+          to_consume: [%Marking{place: "place_1", tokens: ~MS[1]}]
+        }
+      }
+
+      pt2_workitem = %Enactment.Workitem{
+        id: Ecto.UUID.generate(),
+        state: :enabled,
+        binding_element: %BindingElement{
+          transition: "pass_through_2",
+          binding: [x: 1],
+          to_consume: [%Marking{place: "place_2", tokens: ~MS[1]}]
+        }
+      }
+
+      state = %Enactment{
+        enactment_id: enactment_id,
+        version: 0,
+        markings:
+          to_map([
+            %Marking{place: "place_1", tokens: ~MS[1]},
+            %Marking{place: "place_2", tokens: ~MS[1]}
+          ]),
+        workitems:
+          to_map([
+            %Enactment.Workitem{pt1_workitem | state: :started},
+            pt2_workitem
+          ])
+      }
+
+      expected_state = %Enactment{
+        state
+        | workitems:
+            to_map([
+              %Enactment.Workitem{pt1_workitem | state: :started},
+              pt2_workitem
+            ])
+      }
+
+      calibration = WorkitemCalibration.calibrate(state, :start, workitems: [pt1_workitem])
+
+      assert expected_state === calibration.state
+      assert [] === calibration.to_withdraw
+    end
   end
 
   describe "calibrate after completed" do


### PR DESCRIPTION
## Summary

Stacked on the runner cleanups PR.

In `WorkitemCalibration.withdraw_workitems/2`, an enabled workitem whose `binding_element.to_consume` places are disjoint from the started workitem's consumed places cannot have changed enablement: `consume_markings/2` only modifies tokens on those places. Pre-compute the consumed-place set once and short-circuit the re-check via a new `disjoint_input_places?/2` helper.

Pure optimization — behavior preserved. Adds a unit test for the no-overlap path on the parallel-split topology, which the existing test suite did not cover.

## Test plan

- [x] `RESET_DB=1 mix test test/coloured_flow/runner/` — 139 tests, 0 failures (138 prior + 1 new).
- [x] `mix credo --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)