### PR TITLE
fix: resolve Elixir 1.19 typing violations and Inspect regression

### DIFF
--- a/lib/coloured_flow/expression/expression.ex
+++ b/lib/coloured_flow/expression/expression.ex
@@ -54,14 +54,12 @@ defmodule ColouredFlow.Expression do
   defp analyse_node(quoted, scope)
 
   # {form, meta, args} when is_atom(form)
-  defp analyse_node({name, meta, context}, scope) when is_atom(name) and is_atom(context) do
+  defp analyse_node({name, meta, context}, %Scope{} = scope)
+       when is_atom(name) and is_atom(context) do
     if Scope.has_var?(scope.bound_vars, name) do
       scope
     else
-      %Scope{
-        scope
-        | free_vars: Scope.put_var(scope.free_vars, name, meta)
-      }
+      %{scope | free_vars: Scope.put_var(scope.free_vars, name, meta)}
     end
   end
 
@@ -69,7 +67,7 @@ defmodule ColouredFlow.Expression do
     analyse_node(left, scope)
   end
 
-  defp analyse_node({:^, _meta, args}, scope) do
+  defp analyse_node({:^, _meta, args}, %Scope{} = scope) do
     pin_scope = analyse_node(args, Scope.new(scope))
 
     pinned_vars =
@@ -77,14 +75,14 @@ defmodule ColouredFlow.Expression do
       |> Scope.merge_vars(pin_scope.pinned_vars)
       |> Scope.drop_vars(scope.bound_vars)
 
-    %Scope{scope | pinned_vars: pinned_vars}
+    %{scope | pinned_vars: pinned_vars}
   end
 
-  defp analyse_node({op, _meta, [left, right]}, scope) when op in [:=, :<-] do
+  defp analyse_node({op, _meta, [left, right]}, %Scope{} = scope) when op in [:=, :<-] do
     left_analysis = analyse_node(left, Scope.new(scope, bound_vars: scope.bound_vars))
     right_analysis = analyse_node(right, scope)
 
-    %Scope{
+    %{
       scope
       | bound_vars: Scope.merge_vars(scope.bound_vars, left_analysis.free_vars),
         free_vars: Scope.merge_vars(scope.free_vars, right_analysis.free_vars),
@@ -92,7 +90,7 @@ defmodule ColouredFlow.Expression do
     }
   end
 
-  defp analyse_node({:->, _meta, [[{:when, _when_meta, when_args}], body]}, scope) do
+  defp analyse_node({:->, _meta, [[{:when, _when_meta, when_args}], body]}, %Scope{} = scope) do
     {args, when_args} = split_last(when_args)
 
     args_analysis = analyse_node(args, Scope.new(scope, bound_vars: scope.bound_vars))
@@ -102,19 +100,19 @@ defmodule ColouredFlow.Expression do
     when_args_analysis = analyse_node(when_args, new_scope)
     final_analysis = analyse_node(body, when_args_analysis)
 
-    %Scope{
+    %{
       scope
       | free_vars: Scope.merge_vars(scope.free_vars, final_analysis.free_vars),
         pinned_vars: Scope.merge_vars(args_analysis.pinned_vars, final_analysis.pinned_vars)
     }
   end
 
-  defp analyse_node({:->, _meta, [args, body]}, scope) do
+  defp analyse_node({:->, _meta, [args, body]}, %Scope{} = scope) do
     args_analysis = analyse_node(args, Scope.new(scope, bound_vars: scope.bound_vars))
     bound_vars = Scope.merge_vars(scope.bound_vars, args_analysis.free_vars)
     body_analysis = analyse_node(body, Scope.new(scope, bound_vars: bound_vars))
 
-    %Scope{
+    %{
       scope
       | free_vars: Scope.merge_vars(scope.free_vars, body_analysis.free_vars),
         pinned_vars: Scope.merge_vars(args_analysis.pinned_vars, body_analysis.pinned_vars)
@@ -125,18 +123,18 @@ defmodule ColouredFlow.Expression do
     Enum.reduce(blocks, scope, &analyse_node/2)
   end
 
-  defp analyse_node({op, _meta, args}, scope) when op in [:fn, :try] do
+  defp analyse_node({op, _meta, args}, %Scope{} = scope) when op in [:fn, :try] do
     new_scope = Scope.new(scope, bound_vars: scope.bound_vars)
     new_scope = analyse_node(args, new_scope)
 
-    %Scope{
+    %{
       scope
       | free_vars: Scope.merge_vars(scope.free_vars, new_scope.free_vars),
         pinned_vars: Scope.merge_vars(scope.pinned_vars, new_scope.pinned_vars)
     }
   end
 
-  defp analyse_node({op, _meta, args}, scope) when op in [:for, :with] do
+  defp analyse_node({op, _meta, args}, %Scope{} = scope) when op in [:for, :with] do
     {clauses, blocks} = split_last(args)
     {do_block, blocks} = Keyword.split(blocks, [:do])
 
@@ -152,7 +150,7 @@ defmodule ColouredFlow.Expression do
         |> Scope.merge(acc)
       end)
 
-    %Scope{
+    %{
       scope
       | free_vars:
           scope.free_vars
@@ -183,11 +181,11 @@ defmodule ColouredFlow.Expression do
 
   # {left, right}
   @new_scope_ops [:do, :else, :after, :catch, :rescue]
-  defp analyse_node({op, value}, scope) when op in @new_scope_ops do
+  defp analyse_node({op, value}, %Scope{} = scope) when op in @new_scope_ops do
     new_scope = Scope.new(scope, bound_vars: scope.bound_vars)
     new_scope = analyse_node(value, new_scope)
 
-    %Scope{
+    %{
       scope
       | free_vars: Scope.merge_vars(scope.free_vars, new_scope.free_vars),
         pinned_vars: Scope.merge_vars(scope.pinned_vars, new_scope.pinned_vars)

--- a/lib/coloured_flow/multi_set.ex
+++ b/lib/coloured_flow/multi_set.ex
@@ -613,7 +613,7 @@ defmodule ColouredFlow.MultiSet do
     def inspect(multi_set, opts) do
       pairs = @for.to_pairs(multi_set)
 
-      concat(["#{inspect(@for)}.from_pairs(", Inspect.List.inspect(pairs, opts), ")"])
+      concat(["#{inspect(@for)}.from_pairs(", to_doc(pairs, opts), ")"])
     end
   end
 end

--- a/lib/coloured_flow/runner/enactment/enactment.ex
+++ b/lib/coloured_flow/runner/enactment/enactment.ex
@@ -171,12 +171,12 @@ defmodule ColouredFlow.Runner.Enactment do
   end
 
   @spec catchup_snapshot(enactment_id(), Snapshot.t()) :: Snapshot.t()
-  defp catchup_snapshot(enactment_id, snapshot) do
+  defp catchup_snapshot(enactment_id, %Snapshot{} = snapshot) do
     occurrences = Storage.occurrences_stream(enactment_id, snapshot.version)
 
     {steps, markings} = CatchingUp.apply(snapshot.markings, occurrences)
 
-    %Snapshot{snapshot | version: snapshot.version + steps, markings: markings}
+    %{snapshot | version: snapshot.version + steps, markings: markings}
   end
 
   defp apply_calibration(%WorkitemCalibration{state: %__MODULE__{} = state} = calibration) do
@@ -189,7 +189,9 @@ defmodule ColouredFlow.Runner.Enactment do
       fn ->
         # the workitems from calibration.to_withdraw are not in `withdrawn` state
         grouped_wokitems =
-          Enum.group_by(calibration.to_withdraw, & &1.state, &%Workitem{&1 | state: :withdrawn})
+          Enum.group_by(calibration.to_withdraw, & &1.state, fn %Workitem{} = workitem ->
+            %{workitem | state: :withdrawn}
+          end)
 
         workitems = Enum.flat_map(grouped_wokitems, &elem(&1, 1))
 
@@ -442,7 +444,10 @@ defmodule ColouredFlow.Runner.Enactment do
       # after each `start_workitems` step by `calibrate_workitems`.
       {:ok, _markings} <- WorkitemConsumption.consume_tokens(state.markings, binding_elements)
     ) do
-      started_workitems = Enum.map(enabled_workitems, &%Workitem{&1 | state: :started})
+      started_workitems =
+        Enum.map(enabled_workitems, fn %Workitem{} = workitem ->
+          %{workitem | state: :started}
+        end)
 
       new_state = %__MODULE__{
         state

--- a/lib/coloured_flow/runner/enactment/workitem_consumption.ex
+++ b/lib/coloured_flow/runner/enactment/workitem_consumption.ex
@@ -67,14 +67,14 @@ defmodule ColouredFlow.Runner.Enactment.WorkitemConsumption do
     end)
     |> Enum.reduce_while(place_markings, fn
       {place, to_consume_tokens}, acc when is_map_key(acc, place) ->
-        place_marking = Map.fetch!(acc, place)
+        %Marking{} = place_marking = Map.fetch!(acc, place)
 
         case MultiSet.safe_difference(place_marking.tokens, to_consume_tokens) do
           {:ok, remaining_tokens} when MultiSet.is_empty(remaining_tokens) ->
             {:cont, Map.delete(acc, place)}
 
           {:ok, remaining_tokens} ->
-            {:cont, Map.put(acc, place, %Marking{place_marking | tokens: remaining_tokens})}
+            {:cont, Map.put(acc, place, %{place_marking | tokens: remaining_tokens})}
 
           :error ->
             {:halt, {:error, {:unsufficient_tokens, place_marking}}}

--- a/lib/coloured_flow/validators/validators.ex
+++ b/lib/coloured_flow/validators/validators.ex
@@ -19,17 +19,17 @@ defmodule ColouredFlow.Validators do
   def run(%ColouredPetriNet{} = cpnet) do
     # credo:disable-for-next-line Credo.Check.Refactor.RedundantWithClauseResult
     with(
-      {:ok, cpnet} <- StructureValidator.validate(cpnet),
-      {:ok, cpnet} <- UniqueNameValidator.validate(cpnet),
-      {:ok, cpnet} <- ColourSetValidator.validate(cpnet),
+      {:ok, %ColouredPetriNet{} = cpnet} <- StructureValidator.validate(cpnet),
+      {:ok, %ColouredPetriNet{} = cpnet} <- UniqueNameValidator.validate(cpnet),
+      {:ok, %ColouredPetriNet{} = cpnet} <- ColourSetValidator.validate(cpnet),
       {:ok, constants} <- ConstantsValidator.validate(cpnet.constants, cpnet),
-      cpnet = %ColouredPetriNet{cpnet | constants: constants},
+      cpnet = %{cpnet | constants: constants},
       {:ok, variables} <- VariablesValidator.validate(cpnet.variables, cpnet),
-      cpnet = %ColouredPetriNet{cpnet | variables: variables},
-      {:ok, cpnet} <- ArcValidator.validate(cpnet),
-      {:ok, cpnet} <- GuardValidator.validate(cpnet),
-      {:ok, cpnet} <- ActionValidator.validate(cpnet),
-      {:ok, cpnet} <- TerminationCriteriaValidator.validate(cpnet)
+      cpnet = %{cpnet | variables: variables},
+      {:ok, %ColouredPetriNet{} = cpnet} <- ArcValidator.validate(cpnet),
+      {:ok, %ColouredPetriNet{} = cpnet} <- GuardValidator.validate(cpnet),
+      {:ok, %ColouredPetriNet{} = cpnet} <- ActionValidator.validate(cpnet),
+      {:ok, %ColouredPetriNet{} = cpnet} <- TerminationCriteriaValidator.validate(cpnet)
     ) do
       {:ok, cpnet}
     end


### PR DESCRIPTION
## Summary

Local Elixir 1.19.5 fails `mix compile --warnings-as-errors` on \`%X{var | field: ...}\` struct updates where \`var\` is bound from a \`dynamic()\` source. CI on 1.17.3 is unaffected, but local dev breaks. Also the \`MultiSet\` \`Inspect\` impl regresses on 1.19.5: \`Inspect.Algebra.concat/2\` no longer accepts the doc shape returned by \`Inspect.List.inspect/2\`.

Per the compiler hints, narrow each affected binding (\`%X{} = var\`) and switch updates to map-update syntax. Replace \`Inspect.List.inspect/2\` with \`to_doc/2\` in \`MultiSet\`'s \`Inspect\` impl.

## Sites changed

- \`expression.ex\` — 8 \`%Scope{...}\` updates in \`analyse_node/2\` (parameter-pattern fix in each clause).
- \`validators.ex\` — \`%ColouredPetriNet{...}\` updates in \`run/1\`'s \`with\`.
- \`enactment.ex\` — \`%Snapshot{...}\` in \`catchup_snapshot/2\` and \`%Workitem{...}\` updates in \`apply_calibration/1\` and \`start_workitems/2\`.
- \`workitem_consumption.ex\` — \`%Marking{...}\` update in \`consume_tokens/2\`.
- \`multi_set.ex\` — \`Inspect.List.inspect/2\` → \`to_doc/2\`.

Production behavior is unchanged — the new \`%X{} = var\` runtime guards preserve the same struct-enforcement semantics.

## Test plan

- [x] \`mix compile --warnings-as-errors\` zero warnings.
- [x] \`mix format --check-formatted\` clean.
- [x] \`mix credo --strict\` exit 0.
- [x] \`mix dialyzer\` clean (5 errors, all in \`.dialyzer_ignore.exs\`).
- [x] \`RESET_DB=1 mix test\` — 63 doctests, 316 tests, 0 failures.
- [ ] CI green on Elixir 1.17.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)