### PR TITLE
feat(dsl): declarative workflow DSL on top of Notation.* macros

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,30 @@
-locals_without_parens = [colset: 1, var: 1, val: 1, return: 1]
+locals_without_parens = [
+  colset: 1,
+  var: 1,
+  val: 1,
+  return: 1,
+  # ColouredFlow.DSL top-level
+  name: 1,
+  version: 1,
+  # ColouredFlow.DSL.Place
+  place: 2,
+  initial_marking: 2,
+  # ColouredFlow.DSL.Function
+  function: 1,
+  function: 2,
+  # ColouredFlow.DSL.Transition
+  transition: 2,
+  guard: 1,
+  action: 1,
+  # ColouredFlow.DSL.Arc
+  input: 2,
+  input: 3,
+  output: 2,
+  output: 3,
+  # ColouredFlow.DSL.Termination
+  termination: 1,
+  on_markings: 1
+]
 
 [
   inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}", "*.md"],

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,8 @@ The code splits into **static CPN structure**, **CPN semantics**, and the
 | `definition/`               | Pure data model. `ColouredPetriNet` holds `colour_sets`, `places`, `transitions`, `arcs`, `variables`, `constants`, `functions`, optional `termination_criteria`. |
 | `enactment/`                | Runtime values: `Marking` (tokens on a place), `BindingElement` (transition bound to input tokens), `Occurrence` (fired binding — the event-source event).        |
 | `multi_set.ex`              | Multiset token bag. Sigil: `~MS[{1, "a"}, {2, "b"}]`.                                                                                                             |
-| `notation/`                 | Elixir DSL: `colset/1`, `val/1`, `var/1`, `arc` macro.                                                                                                            |
+| `notation/`                 | Low-level building blocks reused by `dsl/`: `colset/1`, `val/1`, `var/1`, plus `arc`/expression helpers.                                                          |
+| `dsl/`                      | High-level declarative workflow DSL (`use ColouredFlow.DSL`). Composes `notation/` into a validated `ColouredPetriNet` at compile time. See `dsl/spec.md`.        |
 | `builder/`                  | Converts DSL input into a validated `ColouredPetriNet`.                                                                                                           |
 | `validators/`               | Static definition checks (colour sets, arc typechecks) + enactment-time invariants.                                                                               |
 | `expression/`               | CPN ML compiler/evaluator; builds guards and bindings for arc inscriptions.                                                                                       |
@@ -82,10 +83,10 @@ tree.
   picked via
   `Application.get_env(:coloured_flow, ColouredFlow.Runner.Storage)[:storage]`.
 
-  | Implementation     | Use                        | Location                                                    |
-  | ------------------ | -------------------------- | ----------------------------------------------------------- |
-  | `Storage.Default`  | production — Ecto/Postgres | `storage/schemas/`; migrations `storage/migrations/{V0,V1}` |
-  | `Storage.InMemory` | tests                      | `storage/in_memory.ex`                                      |
+  | Implementation     | Use                        | Location                                                     |
+  | ------------------ | -------------------------- | ------------------------------------------------------------ |
+  | `Storage.Default`  | production — Ecto/Postgres | `storage/schemas/`; migrations `storage/migrations/{V0..V3}` |
+  | `Storage.InMemory` | tests                      | `storage/in_memory.ex`                                       |
 
 - **Worklist** (`runner/worklist/`). `WorkitemStream.live_query` + `list_live`
   stream live workitems via cursor (see `TrafficLight` example's
@@ -97,5 +98,12 @@ tree.
 
 - Prefer `typed_structor` over plain `defstruct` + `@type t` for new data types
   — used pervasively.
-- DSL macros `colset`, `val`, `var`, `return` are registered as
-  `locals_without_parens` — don't add parens when the formatter complains.
+- DSL macros are registered in `.formatter.exs` `locals_without_parens` — don't
+  add parens when the formatter complains. Current set: `colset/1`, `var/1`,
+  `val/1`, `return/1` (notation); `name/1`, `version/1`, `place/2`,
+  `initial_marking/2`, `function/{1,2}`, `transition/2`, `guard/1`, `action/1`,
+  `input/{2,3}`, `output/{2,3}`, `termination/1`, `on_markings/1` (high-level
+  DSL).
+- Modules using `ColouredFlow.DSL` expose `cpnet/0` (the materialised
+  `%ColouredPetriNet{}`) and `__cpn__/1` reflection (`:name`, `:version`,
+  `:initial_markings`), modeled after `Ecto.Schema.__schema__/1`.

--- a/lib/coloured_flow/dsl.ex
+++ b/lib/coloured_flow/dsl.ex
@@ -66,6 +66,15 @@ defmodule ColouredFlow.DSL do
       Module.register_attribute(__MODULE__, :cf_name, accumulate: false)
       Module.register_attribute(__MODULE__, :cf_version, accumulate: false)
 
+      # Per-declaration metadata: accumulates `{name, file, line}` triples so
+      # `Builder` can map validator-driven errors back to the offending callsite.
+      Module.register_attribute(__MODULE__, :cf_colour_sets_meta, accumulate: true)
+      Module.register_attribute(__MODULE__, :cf_variables_meta, accumulate: true)
+      Module.register_attribute(__MODULE__, :cf_constants_meta, accumulate: true)
+      Module.register_attribute(__MODULE__, :cf_functions_meta, accumulate: true)
+      Module.register_attribute(__MODULE__, :cf_places_meta, accumulate: true)
+      Module.register_attribute(__MODULE__, :cf_transitions_meta, accumulate: true)
+
       @before_compile ColouredFlow.DSL.Builder
     end
   end
@@ -109,12 +118,15 @@ defmodule ColouredFlow.DSL do
   """
   defmacro colset(declaration) do
     {name, type} = ColouredFlow.Notation.Colset.__colset__(declaration)
+    caller_file = __CALLER__.file
+    caller_line = __CALLER__.line
 
     quote do
       @cf_colour_sets %ColourSet{
         name: unquote(name),
         type: unquote(type)
       }
+      @cf_colour_sets_meta {unquote(name), unquote(caller_file), unquote(caller_line)}
     end
   end
 
@@ -128,12 +140,15 @@ defmodule ColouredFlow.DSL do
   """
   defmacro var(declaration) do
     {name, colour_set} = ColouredFlow.Notation.Var.__var__(declaration)
+    caller_file = __CALLER__.file
+    caller_line = __CALLER__.line
 
     quote do
       @cf_variables %Variable{
         name: unquote(name),
         colour_set: unquote(colour_set)
       }
+      @cf_variables_meta {unquote(name), unquote(caller_file), unquote(caller_line)}
     end
   end
 
@@ -147,6 +162,8 @@ defmodule ColouredFlow.DSL do
   """
   defmacro val(declaration) do
     {name, colour_set, value} = ColouredFlow.Notation.Val.__val__(declaration)
+    caller_file = __CALLER__.file
+    caller_line = __CALLER__.line
 
     quote do
       @cf_constants %Constant{
@@ -154,6 +171,7 @@ defmodule ColouredFlow.DSL do
         colour_set: unquote(colour_set),
         value: unquote(value)
       }
+      @cf_constants_meta {unquote(name), unquote(caller_file), unquote(caller_line)}
     end
   end
 end

--- a/lib/coloured_flow/dsl.ex
+++ b/lib/coloured_flow/dsl.ex
@@ -1,0 +1,159 @@
+defmodule ColouredFlow.DSL do
+  @external_resource Path.expand("dsl/spec.md", __DIR__)
+
+  @moduledoc File.read!(@external_resource)
+
+  alias ColouredFlow.Definition.ColourSet
+  alias ColouredFlow.Definition.Constant
+  alias ColouredFlow.Definition.Variable
+
+  @doc false
+  defmacro __using__(_opts) do
+    quote do
+      import ColouredFlow.DSL,
+        only: [
+          name: 1,
+          version: 1,
+          colset: 1,
+          var: 1,
+          val: 1
+        ]
+
+      import ColouredFlow.DSL.Place,
+        only: [
+          place: 2,
+          initial_marking: 2
+        ]
+
+      import ColouredFlow.DSL.Function,
+        only: [
+          function: 1,
+          function: 2
+        ]
+
+      import ColouredFlow.DSL.Transition,
+        only: [
+          transition: 2,
+          guard: 1,
+          action: 1
+        ]
+
+      import ColouredFlow.DSL.Arc,
+        only: [
+          input: 2,
+          input: 3,
+          output: 2,
+          output: 3
+        ]
+
+      import ColouredFlow.DSL.Termination,
+        only: [
+          termination: 1,
+          on_markings: 1
+        ]
+
+      import ColouredFlow.MultiSet, only: [sigil_MS: 2, multi_set_coefficient: 2]
+
+      Module.register_attribute(__MODULE__, :cf_colour_sets, accumulate: true)
+      Module.register_attribute(__MODULE__, :cf_variables, accumulate: true)
+      Module.register_attribute(__MODULE__, :cf_constants, accumulate: true)
+      Module.register_attribute(__MODULE__, :cf_functions, accumulate: true)
+      Module.register_attribute(__MODULE__, :cf_places, accumulate: true)
+      Module.register_attribute(__MODULE__, :cf_initial_markings, accumulate: true)
+      Module.register_attribute(__MODULE__, :cf_transitions, accumulate: true)
+      Module.register_attribute(__MODULE__, :cf_arcs, accumulate: true)
+      Module.register_attribute(__MODULE__, :cf_termination_criteria, accumulate: true)
+      Module.register_attribute(__MODULE__, :cf_name, accumulate: false)
+      Module.register_attribute(__MODULE__, :cf_version, accumulate: false)
+
+      @before_compile ColouredFlow.DSL.Builder
+    end
+  end
+
+  @doc """
+  Set the human-readable workflow name. Compile-time only.
+
+  ## Examples
+
+      name "Traffic Light"
+  """
+  defmacro name(value) do
+    quote do
+      @cf_name unquote(value)
+    end
+  end
+
+  @doc """
+  Set the workflow version (any string the caller chooses; semver is
+  conventional).
+
+  ## Examples
+
+      version "1.0.0"
+  """
+  defmacro version(value) do
+    quote do
+      @cf_version unquote(value)
+    end
+  end
+
+  @doc """
+  Re-exported from `ColouredFlow.Notation.Colset`. Declares a colour set.
+
+  ## Examples
+
+      colset int()    :: integer()
+      colset bool()   :: boolean()
+      colset status() :: ok | err
+      colset point()  :: {integer(), integer()}
+  """
+  defmacro colset(declaration) do
+    {name, type} = ColouredFlow.Notation.Colset.__colset__(declaration)
+
+    quote do
+      @cf_colour_sets %ColourSet{
+        name: unquote(name),
+        type: unquote(type)
+      }
+    end
+  end
+
+  @doc """
+  Re-exported from `ColouredFlow.Notation.Var`. Declares a variable bound to a
+  colour set.
+
+  ## Examples
+
+      var x :: int()
+  """
+  defmacro var(declaration) do
+    {name, colour_set} = ColouredFlow.Notation.Var.__var__(declaration)
+
+    quote do
+      @cf_variables %Variable{
+        name: unquote(name),
+        colour_set: unquote(colour_set)
+      }
+    end
+  end
+
+  @doc """
+  Re-exported from `ColouredFlow.Notation.Val`. Declares a constant bound to a
+  colour set.
+
+  ## Examples
+
+      val pi :: float() = 3.14
+  """
+  defmacro val(declaration) do
+    {name, colour_set, value} = ColouredFlow.Notation.Val.__val__(declaration)
+
+    quote do
+      @cf_constants %Constant{
+        name: unquote(name),
+        colour_set: unquote(colour_set),
+        value: unquote(value)
+      }
+    end
+  end
+end

--- a/lib/coloured_flow/dsl/arc.ex
+++ b/lib/coloured_flow/dsl/arc.ex
@@ -100,8 +100,24 @@ defmodule ColouredFlow.DSL.Arc do
         {arg2 ++ opts_after_do, body}
 
       Keyword.has_key?(arg3, :do) ->
-        {body, _opts} = Keyword.pop!(arg3, :do)
-        {[], body}
+        raise CompileError,
+          description: """
+          Invalid `#{label}` arguments: options must come before the `do ... end` block.
+
+          The expression is the block body for multi-line arcs; any positional \
+          argument before the block (other than a keyword list of options) is \
+          ambiguous and would be silently dropped.
+
+          Got: #{Macro.to_string(arg2)} as the second argument before the `do` block.
+
+          Use one of:
+              #{label} :place, expression                    # single-line
+              #{label} :place, expression, label: "..."      # single-line, with options
+              #{label} :place, do: expression                # multi-line
+              #{label} :place, label: "..." do ... end       # multi-line, with options
+          """,
+          file: caller.file,
+          line: caller.line
 
       keyword?(arg3) ->
         {arg3, arg2}

--- a/lib/coloured_flow/dsl/arc.ex
+++ b/lib/coloured_flow/dsl/arc.ex
@@ -23,7 +23,7 @@ defmodule ColouredFlow.DSL.Arc do
       end
   """
   defmacro input(place, expression_or_opts, opts_or_block \\ []) do
-    build_arc(place, expression_or_opts, opts_or_block, :p_to_t, "input")
+    build_arc(place, expression_or_opts, opts_or_block, :p_to_t, "input", __CALLER__)
   end
 
   @doc """
@@ -40,7 +40,7 @@ defmodule ColouredFlow.DSL.Arc do
       end
   """
   defmacro output(place, expression_or_opts, opts_or_block \\ []) do
-    build_arc(place, expression_or_opts, opts_or_block, :t_to_p, "output")
+    build_arc(place, expression_or_opts, opts_or_block, :t_to_p, "output", __CALLER__)
   end
 
   @spec build_arc(
@@ -48,23 +48,29 @@ defmodule ColouredFlow.DSL.Arc do
           Macro.t(),
           Macro.t(),
           Arc.orientation(),
-          String.t()
+          String.t(),
+          Macro.Env.t()
         ) :: Macro.t()
-  defp build_arc(place, arg2, arg3, orientation, label) do
-    place_value = unquote_atom!(place, "#{label} place")
-    {opts, expr_ast} = decompose_args(arg2, arg3, label)
+  defp build_arc(place, arg2, arg3, orientation, label, caller) do
+    place_value = unquote_atom!(place, "#{label} place", caller)
+    {opts, expr_ast} = decompose_args(arg2, arg3, label, caller)
 
     arc_label = Keyword.get(opts, :label)
     expression = ExpressionHelper.build_arc_expression!(orientation, expr_ast)
 
     quote do
-      ColouredFlow.DSL.Transition.__push_arc__(__MODULE__, %Arc{
-        label: unquote(arc_label),
-        orientation: unquote(orientation),
-        transition: nil,
-        place: unquote(Atom.to_string(place_value)),
-        expression: unquote(Macro.escape(expression))
-      })
+      ColouredFlow.DSL.Transition.__push_arc__(
+        __MODULE__,
+        %Arc{
+          label: unquote(arc_label),
+          orientation: unquote(orientation),
+          transition: nil,
+          place: unquote(Atom.to_string(place_value)),
+          expression: unquote(Macro.escape(expression))
+        },
+        unquote(caller.file),
+        unquote(caller.line)
+      )
     end
   end
 
@@ -75,10 +81,10 @@ defmodule ColouredFlow.DSL.Arc do
   #   - (place, expression, opts_keyword)            -- arg3 is keyword (no :do)
   #   - (place, opts_keyword, do: expression)        -- arg2 is keyword, arg3 has :do
   #   - (place, do: expression)                      -- arg2 is keyword with :do, arg3 == []
-  @spec decompose_args(Macro.t(), Macro.t(), String.t()) :: {keyword(), Macro.t()}
-  defp decompose_args(arg2, arg3, label)
+  @spec decompose_args(Macro.t(), Macro.t(), String.t(), Macro.Env.t()) :: {keyword(), Macro.t()}
+  defp decompose_args(arg2, arg3, label, caller)
 
-  defp decompose_args(arg2, [], _label) do
+  defp decompose_args(arg2, [], _label, _caller) do
     if keyword?(arg2) and Keyword.has_key?(arg2, :do) do
       {body, opts} = Keyword.pop!(arg2, :do)
       {opts, body}
@@ -87,7 +93,7 @@ defmodule ColouredFlow.DSL.Arc do
     end
   end
 
-  defp decompose_args(arg2, arg3, label) when is_list(arg3) do
+  defp decompose_args(arg2, arg3, label, caller) when is_list(arg3) do
     cond do
       Keyword.has_key?(arg3, :do) and keyword?(arg2) ->
         {body, opts_after_do} = Keyword.pop!(arg3, :do)
@@ -101,13 +107,18 @@ defmodule ColouredFlow.DSL.Arc do
         {arg3, arg2}
 
       true ->
-        raise ArgumentError, "Invalid `#{label}` arguments: #{inspect(arg3)}"
+        raise CompileError,
+          description: "Invalid `#{label}` arguments: #{inspect(arg3)}",
+          file: caller.file,
+          line: caller.line
     end
   end
 
-  defp decompose_args(arg2, arg3, label) do
-    raise ArgumentError,
-          "Invalid `#{label}` arguments: arg2=#{inspect(arg2)}, arg3=#{inspect(arg3)}"
+  defp decompose_args(arg2, arg3, label, caller) do
+    raise CompileError,
+      description: "Invalid `#{label}` arguments: arg2=#{inspect(arg2)}, arg3=#{inspect(arg3)}",
+      file: caller.file,
+      line: caller.line
   end
 
   defp keyword?(list) when is_list(list) do
@@ -120,10 +131,13 @@ defmodule ColouredFlow.DSL.Arc do
 
   defp keyword?(_other), do: false
 
-  @spec unquote_atom!(Macro.t(), String.t()) :: atom()
-  defp unquote_atom!(value, _label) when is_atom(value), do: value
+  @spec unquote_atom!(Macro.t(), String.t(), Macro.Env.t()) :: atom()
+  defp unquote_atom!(value, _label, _caller) when is_atom(value), do: value
 
-  defp unquote_atom!(value, label) do
-    raise ArgumentError, "Expected #{label} to be an atom, got: #{Macro.to_string(value)}"
+  defp unquote_atom!(value, label, caller) do
+    raise CompileError,
+      description: "Expected #{label} to be an atom, got: #{Macro.to_string(value)}",
+      file: caller.file,
+      line: caller.line
   end
 end

--- a/lib/coloured_flow/dsl/arc.ex
+++ b/lib/coloured_flow/dsl/arc.ex
@@ -1,0 +1,129 @@
+defmodule ColouredFlow.DSL.Arc do
+  @moduledoc """
+  `input/2,3` and `output/2,3` macros. See `ColouredFlow.DSL` for context.
+
+  These macros are valid only inside a `transition do ... end` block.
+  """
+
+  alias ColouredFlow.DSL.ExpressionHelper
+
+  alias ColouredFlow.Definition.Arc
+
+  @doc """
+  Declare an incoming arc (place → transition). The expression must use the
+  `bind/1` keyword to consume tokens. Options: `:label`.
+
+  ## Examples
+
+      input :input, bind({1, x})
+      input :input, bind({1, x}), label: "in"
+
+      input :input, label: "in" do
+        if x > 0, do: bind({1, x}), else: bind({2, x})
+      end
+  """
+  defmacro input(place, expression_or_opts, opts_or_block \\ []) do
+    build_arc(place, expression_or_opts, opts_or_block, :p_to_t, "input")
+  end
+
+  @doc """
+  Declare an outgoing arc (transition → place). The expression evaluates to the
+  multiset of tokens produced. Options: `:label`.
+
+  ## Examples
+
+      output :output, {1, x}
+      output :output, {1, x}, label: "out"
+
+      output :output, label: "out" do
+        if x > 0, do: {1, x}, else: {0, x}
+      end
+  """
+  defmacro output(place, expression_or_opts, opts_or_block \\ []) do
+    build_arc(place, expression_or_opts, opts_or_block, :t_to_p, "output")
+  end
+
+  @spec build_arc(
+          Macro.t(),
+          Macro.t(),
+          Macro.t(),
+          Arc.orientation(),
+          String.t()
+        ) :: Macro.t()
+  defp build_arc(place, arg2, arg3, orientation, label) do
+    place_value = unquote_atom!(place, "#{label} place")
+    {opts, expr_ast} = decompose_args(arg2, arg3, label)
+
+    arc_label = Keyword.get(opts, :label)
+    expression = ExpressionHelper.build_arc_expression!(orientation, expr_ast)
+
+    quote do
+      ColouredFlow.DSL.Transition.__push_arc__(__MODULE__, %Arc{
+        label: unquote(arc_label),
+        orientation: unquote(orientation),
+        transition: nil,
+        place: unquote(Atom.to_string(place_value)),
+        expression: unquote(Macro.escape(expression))
+      })
+    end
+  end
+
+  # Decompose arc args into {opts_keyword, expression_ast}.
+  #
+  # Supported forms:
+  #   - (place, expression)                          -- arg3 == []
+  #   - (place, expression, opts_keyword)            -- arg3 is keyword (no :do)
+  #   - (place, opts_keyword, do: expression)        -- arg2 is keyword, arg3 has :do
+  #   - (place, do: expression)                      -- arg2 is keyword with :do, arg3 == []
+  @spec decompose_args(Macro.t(), Macro.t(), String.t()) :: {keyword(), Macro.t()}
+  defp decompose_args(arg2, arg3, label)
+
+  defp decompose_args(arg2, [], _label) do
+    if keyword?(arg2) and Keyword.has_key?(arg2, :do) do
+      {body, opts} = Keyword.pop!(arg2, :do)
+      {opts, body}
+    else
+      {[], arg2}
+    end
+  end
+
+  defp decompose_args(arg2, arg3, label) when is_list(arg3) do
+    cond do
+      Keyword.has_key?(arg3, :do) and keyword?(arg2) ->
+        {body, opts_after_do} = Keyword.pop!(arg3, :do)
+        {arg2 ++ opts_after_do, body}
+
+      Keyword.has_key?(arg3, :do) ->
+        {body, _opts} = Keyword.pop!(arg3, :do)
+        {[], body}
+
+      keyword?(arg3) ->
+        {arg3, arg2}
+
+      true ->
+        raise ArgumentError, "Invalid `#{label}` arguments: #{inspect(arg3)}"
+    end
+  end
+
+  defp decompose_args(arg2, arg3, label) do
+    raise ArgumentError,
+          "Invalid `#{label}` arguments: arg2=#{inspect(arg2)}, arg3=#{inspect(arg3)}"
+  end
+
+  defp keyword?(list) when is_list(list) do
+    list != [] and
+      Enum.all?(list, fn
+        {key, _value} when is_atom(key) -> true
+        _other -> false
+      end)
+  end
+
+  defp keyword?(_other), do: false
+
+  @spec unquote_atom!(Macro.t(), String.t()) :: atom()
+  defp unquote_atom!(value, _label) when is_atom(value), do: value
+
+  defp unquote_atom!(value, label) do
+    raise ArgumentError, "Expected #{label} to be an atom, got: #{Macro.to_string(value)}"
+  end
+end

--- a/lib/coloured_flow/dsl/builder.ex
+++ b/lib/coloured_flow/dsl/builder.ex
@@ -1,0 +1,148 @@
+defmodule ColouredFlow.DSL.Builder do
+  @moduledoc """
+  `@before_compile` hook for `ColouredFlow.DSL`. Materialises the accumulated
+  module attributes into a `%ColouredFlow.Definition.ColouredPetriNet{}`,
+  validates it, and injects a `cpnet/0` accessor.
+  """
+
+  alias ColouredFlow.Definition.ColourSet
+  alias ColouredFlow.Definition.ColourSet.Descr
+  alias ColouredFlow.Definition.ColouredPetriNet
+  alias ColouredFlow.Definition.Place
+  alias ColouredFlow.Definition.Procedure
+
+  @doc false
+  defmacro __before_compile__(env) do
+    cpnet = build_cpnet(env.module)
+    cpnet = resolve_function_results(cpnet)
+    # Compute action outputs from arc expressions, mirroring
+    # `ColouredFlow.Builder.build/1`. This both populates `action.outputs`
+    # and lets the arc validator allow free vars on outgoing arcs that are
+    # produced by the action.
+    cpnet = ColouredFlow.Builder.build(cpnet)
+
+    case ColouredFlow.Validators.run(cpnet) do
+      {:ok, validated} ->
+        quote do
+          @doc """
+          The `%ColouredFlow.Definition.ColouredPetriNet{}` materialised from the DSL
+          declarations in this module.
+          """
+          @spec cpnet() :: ColouredPetriNet.t()
+          def cpnet, do: unquote(Macro.escape(validated))
+
+          @doc """
+          The human-readable name of this workflow, or `nil` if unset.
+          """
+          @spec __cf_name__() :: String.t() | nil
+          def __cf_name__, do: unquote(Module.get_attribute(env.module, :cf_name))
+
+          @doc """
+          The version string of this workflow, or `nil` if unset.
+          """
+          @spec __cf_version__() :: String.t() | nil
+          def __cf_version__, do: unquote(Module.get_attribute(env.module, :cf_version))
+        end
+
+      {:error, exception} ->
+        raise CompileError,
+          description: """
+          ColouredFlow.DSL: invalid workflow definition.
+
+          #{Exception.message(exception)}
+          """,
+          file: env.file,
+          line: env.line
+    end
+  end
+
+  @spec build_cpnet(module()) :: ColouredPetriNet.t()
+  defp build_cpnet(module) do
+    %ColouredPetriNet{
+      colour_sets: pull(module, :cf_colour_sets),
+      places: build_places(module),
+      transitions: pull(module, :cf_transitions),
+      arcs: pull(module, :cf_arcs),
+      variables: pull(module, :cf_variables),
+      constants: pull(module, :cf_constants),
+      functions: pull(module, :cf_functions),
+      termination_criteria: pull_one(module, :cf_termination_criteria)
+    }
+  end
+
+  defp build_places(module) do
+    Enum.map(pull(module, :cf_places), fn %Place{} = place -> place end)
+  end
+
+  defp pull(module, attr) do
+    case Module.get_attribute(module, attr) do
+      nil -> []
+      list when is_list(list) -> Enum.reverse(list)
+    end
+  end
+
+  defp pull_one(module, attr) do
+    case Module.get_attribute(module, attr) do
+      nil -> nil
+      list when is_list(list) -> List.last(list)
+      other -> other
+    end
+  end
+
+  # Resolve user-defined colour-set names appearing in `Procedure.result` to
+  # their underlying primitive descr. The DSL stores `{:bool, []}` when the
+  # user writes `:: bool()`, which is not a valid `ColourSet.descr()`; the
+  # canonical form requires the leaf to be a built-in primitive.
+  @spec resolve_function_results(ColouredPetriNet.t()) :: ColouredPetriNet.t()
+  defp resolve_function_results(%ColouredPetriNet{} = cpnet) do
+    colour_sets = Map.new(cpnet.colour_sets, &{&1.name, &1.type})
+
+    functions =
+      Enum.map(cpnet.functions, fn %Procedure{} = procedure ->
+        %{procedure | result: resolve_descr(procedure.result, colour_sets)}
+      end)
+
+    %ColouredPetriNet{cpnet | functions: functions}
+  end
+
+  @doc false
+  @spec resolve_descr(ColourSet.descr(), %{ColourSet.name() => ColourSet.descr()}) ::
+          ColourSet.descr()
+  def resolve_descr(descr, colour_sets) do
+    resolve_step(Descr.match(descr), descr, colour_sets)
+  end
+
+  @primitive_types [:integer, :float, :boolean, :binary, :unit]
+
+  defp resolve_step({:built_in, type}, descr, _colour_sets) when type in @primitive_types,
+    do: descr
+
+  defp resolve_step({:built_in, :enum}, descr, _colour_sets), do: descr
+
+  defp resolve_step({:built_in, :tuple}, {:tuple, types}, colour_sets) do
+    {:tuple, Enum.map(types, &resolve_descr(&1, colour_sets))}
+  end
+
+  defp resolve_step({:built_in, :map}, {:map, types}, colour_sets) do
+    {:map, Map.new(types, fn {key, type} -> {key, resolve_descr(type, colour_sets)} end)}
+  end
+
+  defp resolve_step({:built_in, :list}, {:list, type}, colour_sets) do
+    {:list, resolve_descr(type, colour_sets)}
+  end
+
+  defp resolve_step({:built_in, :union}, {:union, types}, colour_sets) do
+    {:union, Map.new(types, fn {tag, type} -> {tag, resolve_descr(type, colour_sets)} end)}
+  end
+
+  defp resolve_step({:compound, name}, descr, colour_sets) do
+    case Map.fetch(colour_sets, name) do
+      # Leave unresolved names alone; the validator pipeline will surface
+      # the failure with a precise message.
+      :error -> descr
+      {:ok, underlying} -> resolve_descr(underlying, colour_sets)
+    end
+  end
+
+  defp resolve_step(:unknown, descr, _colour_sets), do: descr
+end

--- a/lib/coloured_flow/dsl/builder.ex
+++ b/lib/coloured_flow/dsl/builder.ex
@@ -12,6 +12,9 @@ defmodule ColouredFlow.DSL.Builder do
   alias ColouredFlow.Definition.Procedure
   alias ColouredFlow.Enactment.Marking
 
+  alias ColouredFlow.Validators.Exceptions.MissingColourSetError
+  alias ColouredFlow.Validators.Exceptions.UniqueNameViolationError
+
   @doc false
   defmacro __before_compile__(env) do
     cpnet = build_cpnet(env.module)
@@ -55,14 +58,153 @@ defmodule ColouredFlow.DSL.Builder do
         end
 
       {:error, exception} ->
+        {file, line} = locate_error(exception, env)
+
         raise CompileError,
           description: """
           ColouredFlow.DSL: invalid workflow definition.
 
           #{Exception.message(exception)}
           """,
-          file: env.file,
-          line: env.line
+          file: file,
+          line: line
+    end
+  end
+
+  # Map a validator-driven error back to the originating declaration's
+  # `{file, line}`. Falls back to the `defmodule` callsite when the offending
+  # declaration cannot be identified.
+  @spec locate_error(Exception.t(), Macro.Env.t()) :: {String.t(), non_neg_integer()}
+  defp locate_error(%UniqueNameViolationError{scope: scope, name: name}, env) do
+    locate_unique_violation(scope, name, env)
+  end
+
+  defp locate_error(%MissingColourSetError{colour_set: colour_set}, env) do
+    locate_missing_colour_set(colour_set, env)
+  end
+
+  defp locate_error(_other, env) do
+    {env.file, env.line}
+  end
+
+  # `UniqueNameValidator` halts on the *second* occurrence of a duplicate name.
+  # The metadata accumulator stores entries in reverse declaration order
+  # (most-recent first), so reverse to source order and pick the second
+  # occurrence — that's the duplicate the validator rejected. The validator
+  # uses `:variable_and_constant` to lump variables and constants together,
+  # despite that not appearing in the exception's declared scope type.
+  @unique_scope_attrs %{
+    colour_set: [:cf_colour_sets_meta],
+    place: [:cf_places_meta],
+    transition: [:cf_transitions_meta],
+    function: [:cf_functions_meta],
+    variable_and_constant: [:cf_variables_meta, :cf_constants_meta]
+  }
+
+  defp locate_unique_violation(scope, name, env) do
+    case Map.fetch(@unique_scope_attrs, scope) do
+      {:ok, attrs} ->
+        attrs
+        |> Enum.flat_map(&source_order_meta(env.module, &1))
+        |> locate_duplicate(name, env)
+
+      :error ->
+        {env.file, env.line}
+    end
+  end
+
+  # `MissingColourSetError` is raised by the places/functions/variables/
+  # constants validators when a referenced colour set is not declared. The
+  # exception carries the missing colour set name. We probe each declaration
+  # scope in the same order the validator pipeline does and return the first
+  # match.
+  defp locate_missing_colour_set(colour_set, env) do
+    locate_missing_in_places(colour_set, env) ||
+      locate_missing_in_functions(colour_set, env) ||
+      locate_missing_in_constants(colour_set, env) ||
+      locate_missing_in_variables(colour_set, env) ||
+      {env.file, env.line}
+  end
+
+  defp locate_missing_in_places(colour_set, env) do
+    env.module
+    |> zip_meta(:cf_places, :cf_places_meta)
+    |> Enum.find_value(fn
+      {%Place{colour_set: ^colour_set}, {_name, file, line}} -> {file, line}
+      _other -> nil
+    end)
+  end
+
+  defp locate_missing_in_functions(colour_set, env) do
+    env.module
+    |> zip_meta(:cf_functions, :cf_functions_meta)
+    |> Enum.find_value(fn
+      {%Procedure{result: result}, {_name, file, line}} ->
+        if descr_references?(result, colour_set), do: {file, line}, else: nil
+
+      _other ->
+        nil
+    end)
+  end
+
+  defp locate_missing_in_constants(colour_set, env) do
+    env.module
+    |> zip_meta(:cf_constants, :cf_constants_meta)
+    |> Enum.find_value(fn
+      {%{colour_set: ^colour_set}, {_name, file, line}} -> {file, line}
+      _other -> nil
+    end)
+  end
+
+  defp locate_missing_in_variables(colour_set, env) do
+    env.module
+    |> zip_meta(:cf_variables, :cf_variables_meta)
+    |> Enum.find_value(fn
+      {%{colour_set: ^colour_set}, {_name, file, line}} -> {file, line}
+      _other -> nil
+    end)
+  end
+
+  defp zip_meta(module, items_attr, meta_attr) do
+    items = source_order_meta(module, items_attr)
+    metas = source_order_meta(module, meta_attr)
+    Enum.zip(items, metas)
+  end
+
+  # Recursively check whether a `ColourSet.descr()` references the given
+  # colour-set name as a leaf node.
+  defp descr_references?({name, []}, target) when is_atom(name), do: name == target
+
+  defp descr_references?({:tuple, types}, target) when is_list(types) do
+    Enum.any?(types, &descr_references?(&1, target))
+  end
+
+  defp descr_references?({:list, type}, target), do: descr_references?(type, target)
+
+  defp descr_references?({:map, types}, target) when is_map(types) do
+    Enum.any?(types, fn {_key, type} -> descr_references?(type, target) end)
+  end
+
+  defp descr_references?({:union, types}, target) when is_map(types) do
+    Enum.any?(types, fn {_tag, type} -> descr_references?(type, target) end)
+  end
+
+  defp descr_references?(_other, _target), do: false
+
+  defp locate_duplicate(meta_list, name, env) do
+    meta_list
+    |> Enum.filter(fn {entry_name, _file, _line} -> entry_name == name end)
+    |> case do
+      [_first, {_name, file, line} | _rest] -> {file, line}
+      [{_name, file, line}] -> {file, line}
+      [] -> {env.file, env.line}
+    end
+  end
+
+  defp source_order_meta(module, attr) do
+    case Module.get_attribute(module, attr) do
+      nil -> []
+      list when is_list(list) -> Enum.reverse(list)
     end
   end
 
@@ -98,10 +240,14 @@ defmodule ColouredFlow.DSL.Builder do
     end
   end
 
+  # `Module.put_attribute/3` prepends in accumulate mode, so the head of the list
+  # is the most recent entry. This pulls that entry. Macros that should only
+  # appear once (e.g. `termination/1`) enforce uniqueness at macro-expansion
+  # time, so this list will contain at most one element.
   defp pull_one(module, attr) do
     case Module.get_attribute(module, attr) do
       nil -> nil
-      list when is_list(list) -> List.last(list)
+      list when is_list(list) -> List.first(list)
       other -> other
     end
   end

--- a/lib/coloured_flow/dsl/builder.ex
+++ b/lib/coloured_flow/dsl/builder.ex
@@ -42,11 +42,11 @@ defmodule ColouredFlow.DSL.Builder do
           @doc """
           Reflection helper exposing workflow metadata.
 
-          | key                  | value                                                          |
-          | -------------------- | -------------------------------------------------------------- |
-          | `:name`              | `String.t() \| nil` — `name "..."` declaration                  |
-          | `:version`           | `String.t() \| nil` — `version "..."` declaration               |
-          | `:initial_markings`  | `[%Marking{}]` — declared via `initial_marking/2`              |
+          | key                 | value                                             |
+          | ------------------- | ------------------------------------------------- |
+          | `:name`             | `String.t() \| nil` — `name "..."` declaration    |
+          | `:version`          | `String.t() \| nil` — `version "..."` declaration |
+          | `:initial_markings` | `[%Marking{}]` — declared via `initial_marking/2` |
           """
           @spec __cpn__(:name) :: String.t() | nil
           @spec __cpn__(:version) :: String.t() | nil

--- a/lib/coloured_flow/dsl/builder.ex
+++ b/lib/coloured_flow/dsl/builder.ex
@@ -10,6 +10,7 @@ defmodule ColouredFlow.DSL.Builder do
   alias ColouredFlow.Definition.ColouredPetriNet
   alias ColouredFlow.Definition.Place
   alias ColouredFlow.Definition.Procedure
+  alias ColouredFlow.Enactment.Marking
 
   @doc false
   defmacro __before_compile__(env) do
@@ -20,6 +21,7 @@ defmodule ColouredFlow.DSL.Builder do
     # and lets the arc validator allow free vars on outgoing arcs that are
     # produced by the action.
     cpnet = ColouredFlow.Builder.build(cpnet)
+    initial_markings = build_initial_markings(env.module)
 
     case ColouredFlow.Validators.run(cpnet) do
       {:ok, validated} ->
@@ -30,6 +32,14 @@ defmodule ColouredFlow.DSL.Builder do
           """
           @spec cpnet() :: ColouredPetriNet.t()
           def cpnet, do: unquote(Macro.escape(validated))
+
+          @doc """
+          The list of `%ColouredFlow.Enactment.Marking{}` structs declared via
+          `initial_marking/2`. Used by the Runner to seed an enactment; this is *not* part
+          of the static CPN definition (see `cpnet/0`).
+          """
+          @spec initial_markings() :: [Marking.t()]
+          def initial_markings, do: unquote(Macro.escape(initial_markings))
 
           @doc """
           The human-readable name of this workflow, or `nil` if unset.
@@ -54,6 +64,13 @@ defmodule ColouredFlow.DSL.Builder do
           file: env.file,
           line: env.line
     end
+  end
+
+  @spec build_initial_markings(module()) :: [Marking.t()]
+  defp build_initial_markings(module) do
+    module
+    |> pull(:cf_initial_markings)
+    |> Enum.map(fn {place, tokens} -> %Marking{place: place, tokens: tokens} end)
   end
 
   @spec build_cpnet(module()) :: ColouredPetriNet.t()

--- a/lib/coloured_flow/dsl/builder.ex
+++ b/lib/coloured_flow/dsl/builder.ex
@@ -28,6 +28,9 @@ defmodule ColouredFlow.DSL.Builder do
 
     case ColouredFlow.Validators.run(cpnet) do
       {:ok, validated} ->
+        name = Module.get_attribute(env.module, :cf_name)
+        version = Module.get_attribute(env.module, :cf_version)
+
         quote do
           @doc """
           The `%ColouredFlow.Definition.ColouredPetriNet{}` materialised from the DSL
@@ -37,24 +40,20 @@ defmodule ColouredFlow.DSL.Builder do
           def cpnet, do: unquote(Macro.escape(validated))
 
           @doc """
-          The list of `%ColouredFlow.Enactment.Marking{}` structs declared via
-          `initial_marking/2`. Used by the Runner to seed an enactment; this is *not* part
-          of the static CPN definition (see `cpnet/0`).
-          """
-          @spec initial_markings() :: [Marking.t()]
-          def initial_markings, do: unquote(Macro.escape(initial_markings))
+          Reflection helper exposing workflow metadata.
 
-          @doc """
-          The human-readable name of this workflow, or `nil` if unset.
+          | key                  | value                                                          |
+          | -------------------- | -------------------------------------------------------------- |
+          | `:name`              | `String.t() \| nil` — `name "..."` declaration                  |
+          | `:version`           | `String.t() \| nil` — `version "..."` declaration               |
+          | `:initial_markings`  | `[%Marking{}]` — declared via `initial_marking/2`              |
           """
-          @spec __cf_name__() :: String.t() | nil
-          def __cf_name__, do: unquote(Module.get_attribute(env.module, :cf_name))
-
-          @doc """
-          The version string of this workflow, or `nil` if unset.
-          """
-          @spec __cf_version__() :: String.t() | nil
-          def __cf_version__, do: unquote(Module.get_attribute(env.module, :cf_version))
+          @spec __cpn__(:name) :: String.t() | nil
+          @spec __cpn__(:version) :: String.t() | nil
+          @spec __cpn__(:initial_markings) :: [Marking.t()]
+          def __cpn__(:name), do: unquote(name)
+          def __cpn__(:version), do: unquote(version)
+          def __cpn__(:initial_markings), do: unquote(Macro.escape(initial_markings))
         end
 
       {:error, exception} ->

--- a/lib/coloured_flow/dsl/expression_helper.ex
+++ b/lib/coloured_flow/dsl/expression_helper.ex
@@ -1,0 +1,123 @@
+defmodule ColouredFlow.DSL.ExpressionHelper do
+  @moduledoc """
+  Helpers that convert an Elixir AST captured by a DSL macro into a
+  `ColouredFlow.Definition.Expression`.
+
+  See `ColouredFlow.DSL` for the full DSL spec.
+  """
+
+  alias ColouredFlow.Definition.Arc
+  alias ColouredFlow.Definition.Expression
+
+  @doc """
+  Build an `Expression` from an Elixir AST.
+
+  Stringifies the AST to populate `Expression.code` and reuses
+  `ColouredFlow.Definition.Expression.build/1` to extract free variables.
+
+  ## Examples
+
+      iex> ast = quote do: x + 1
+      iex> %ColouredFlow.Definition.Expression{vars: [:x]} =
+      ...>   ColouredFlow.DSL.ExpressionHelper.build_from_ast!(ast)
+  """
+  @spec build_from_ast!(Macro.t()) :: Expression.t()
+  def build_from_ast!(ast) do
+    case build_from_ast(ast) do
+      {:ok, expr} -> expr
+      {:error, reason} -> raise "failed to build expression: #{inspect(reason)}"
+    end
+  end
+
+  @doc """
+  Build an `Expression` from an Elixir AST. Returns `{:ok, expression}` or
+  `{:error, reason}`.
+  """
+  @spec build_from_ast(Macro.t()) ::
+          {:ok, Expression.t()} | {:error, ColouredFlow.Expression.compile_error()}
+  def build_from_ast(nil) do
+    {:ok, %Expression{}}
+  end
+
+  def build_from_ast(ast) do
+    code = ast_to_code(ast)
+    Expression.build(code)
+  end
+
+  @doc """
+  Build an arc `Expression` for the given orientation from an Elixir AST.
+
+  Equivalent to `ColouredFlow.Definition.Arc.build_expression/2` plus AST
+  stringification.
+
+  ## Examples
+
+      iex> ast = quote do: bind({1, x})
+      iex> %ColouredFlow.Definition.Expression{vars: [:x]} =
+      ...>   ColouredFlow.DSL.ExpressionHelper.build_arc_expression!(:p_to_t, ast)
+  """
+  @spec build_arc_expression!(Arc.orientation(), Macro.t()) :: Expression.t()
+  def build_arc_expression!(orientation, ast)
+      when orientation in [:p_to_t, :t_to_p] do
+    code = ast_to_code(ast)
+
+    case Arc.build_expression(orientation, code) do
+      {:ok, expr} -> expr
+      {:error, reason} -> raise "failed to build arc expression: #{inspect(reason)}"
+    end
+  end
+
+  @doc """
+  Returns a sorted list of free atom-vars referenced in the AST.
+
+  Free vars are determined by `ColouredFlow.Expression.compile/2` (so this is
+  consistent with how the rest of the engine extracts variables).
+
+  ## Examples
+
+      iex> ColouredFlow.DSL.ExpressionHelper.free_vars(quote do: x + y)
+      [:x, :y]
+
+      iex> ColouredFlow.DSL.ExpressionHelper.free_vars(quote do: 1 + 2)
+      []
+  """
+  @spec free_vars(Macro.t()) :: [atom()]
+  def free_vars(ast) do
+    case build_from_ast(ast) do
+      {:ok, %Expression{vars: vars}} -> vars
+      {:error, reason} -> raise "failed to compile expression: #{inspect(reason)}"
+    end
+  end
+
+  @doc """
+  Convert a `do` block to a single AST node.
+
+  When a `do ... end` block contains a single statement Elixir keeps the AST
+  as-is; multiple statements are wrapped in an `:__block__`.
+
+  ## Examples
+
+      iex> ColouredFlow.DSL.ExpressionHelper.block_to_ast(do: 1 + 1)
+      quote(do: 1 + 1)
+  """
+  @spec block_to_ast(Macro.t()) :: Macro.t() | nil
+  def block_to_ast(nil), do: nil
+
+  def block_to_ast(do: block), do: block
+
+  def block_to_ast(block) when is_list(block) do
+    case Keyword.fetch(block, :do) do
+      {:ok, body} -> body
+      :error -> raise ArgumentError, "expected a `do ... end` block, got: #{inspect(block)}"
+    end
+  end
+
+  def block_to_ast(other), do: other
+
+  @doc """
+  Convert an AST back to a code string suitable for `Expression.build/1`.
+  """
+  @spec ast_to_code(Macro.t()) :: binary()
+  def ast_to_code(ast) when is_nil(ast), do: ""
+  def ast_to_code(ast), do: Macro.to_string(ast)
+end

--- a/lib/coloured_flow/dsl/function.ex
+++ b/lib/coloured_flow/dsl/function.ex
@@ -51,6 +51,7 @@ defmodule ColouredFlow.DSL.Function do
         expression: unquote(Macro.escape(expression)),
         result: unquote(Macro.escape(result))
       }
+      @cf_functions_meta {unquote(name), unquote(caller_file), unquote(caller_line)}
     end
   end
 

--- a/lib/coloured_flow/dsl/function.ex
+++ b/lib/coloured_flow/dsl/function.ex
@@ -21,7 +21,9 @@ defmodule ColouredFlow.DSL.Function do
       end
   """
   defmacro function(head_with_type, body \\ nil) do
-    {name, args, result} = decompose_head(head_with_type)
+    caller_file = __CALLER__.file
+    caller_line = __CALLER__.line
+    {name, args, result} = decompose_head(head_with_type, __CALLER__)
     expr_ast = ExpressionHelper.block_to_ast(body)
     expression = ExpressionHelper.build_from_ast!(expr_ast)
 
@@ -39,7 +41,9 @@ defmodule ColouredFlow.DSL.Function do
         unquote(name_ast),
         unquote(args_ast),
         unquote(missing_ast),
-        unquote(extra_ast)
+        unquote(extra_ast),
+        unquote(caller_file),
+        unquote(caller_line)
       )
 
       @cf_functions %Procedure{
@@ -51,14 +55,17 @@ defmodule ColouredFlow.DSL.Function do
   end
 
   @doc false
-  @spec __validate_args__!(atom(), [atom()], [atom()], [atom()]) :: :ok
-  def __validate_args__!(name, args, missing, _extra) do
+  @spec __validate_args__!(atom(), [atom()], [atom()], [atom()], String.t(), non_neg_integer()) ::
+          :ok
+  def __validate_args__!(name, args, missing, _extra, file, line) do
     if missing != [] do
       raise CompileError,
         description: """
         Function `#{name}/#{length(args)}` declares argument(s) \
         #{inspect(missing)}, but they are not referenced in the body.
-        """
+        """,
+        file: file,
+        line: line
     end
 
     # Extra free variables are allowed (other vars/constants resolved at the
@@ -66,64 +73,41 @@ defmodule ColouredFlow.DSL.Function do
     :ok
   end
 
-  @spec decompose_head(Macro.t()) :: {atom(), [atom()], ColouredFlow.Definition.ColourSet.descr()}
-  defp decompose_head({:"::", _meta, [head, type_ast]}) do
-    {name, args} = decompose_call(head)
-    type_descr = decompose_type(type_ast)
+  @spec decompose_head(Macro.t(), Macro.Env.t()) ::
+          {atom(), [atom()], ColouredFlow.Definition.ColourSet.descr()}
+  defp decompose_head({:"::", _meta, [head, type_ast]}, caller) do
+    {name, args} = decompose_call(head, caller)
+    type_descr = ColouredFlow.Notation.Colset.__decompose_type__(type_ast)
     {name, args, type_descr}
   end
 
-  defp decompose_head(other) do
-    raise ArgumentError, """
-    Invalid function head, expected `name(arg1, arg2) :: type()`,
-    got: #{Macro.to_string(other)}
-    """
+  defp decompose_head(other, caller) do
+    raise CompileError,
+      description: """
+      Invalid function head, expected `name(arg1, arg2) :: type()`,
+      got: #{Macro.to_string(other)}
+      """,
+      file: caller.file,
+      line: caller.line
   end
 
-  defp decompose_call({name, _meta, args}) when is_atom(name) and is_list(args) do
+  defp decompose_call({name, _meta, args}, caller) when is_atom(name) and is_list(args) do
     arg_names =
       Enum.map(args, fn
         {arg, _meta, ctx} when is_atom(arg) and is_atom(ctx) ->
           arg
 
         other ->
-          raise ArgumentError,
-                "function argument must be a variable, got: #{Macro.to_string(other)}"
+          raise CompileError,
+            description: "function argument must be a variable, got: #{Macro.to_string(other)}",
+            file: caller.file,
+            line: caller.line
       end)
 
     {name, arg_names}
   end
 
-  defp decompose_call({name, _meta, ctx}) when is_atom(name) and is_atom(ctx) do
+  defp decompose_call({name, _meta, ctx}, _caller) when is_atom(name) and is_atom(ctx) do
     {name, []}
-  end
-
-  # Reuse Notation.Colset's type decomposer through a public-ish path. Falls
-  # back to a small local impl for the cases we need.
-  @spec decompose_type(Macro.t()) :: ColouredFlow.Definition.ColourSet.descr()
-  defp decompose_type({:{}, _meta, []}), do: {:unit, []}
-
-  defp decompose_type({type1, type2}) do
-    {:tuple, [decompose_type(type1), decompose_type(type2)]}
-  end
-
-  defp decompose_type({:{}, _meta, types}) do
-    {:tuple, Enum.map(types, &decompose_type/1)}
-  end
-
-  defp decompose_type({:%{}, _meta, fields}) do
-    map = Map.new(fields, fn {key, type} -> {key, decompose_type(type)} end)
-    {:map, map}
-  end
-
-  defp decompose_type({:list, _meta, [type]}) do
-    {:list, decompose_type(type)}
-  end
-
-  defp decompose_type(type) do
-    case Macro.decompose_call(type) do
-      {name, []} when is_atom(name) -> {name, []}
-      _other -> raise ArgumentError, "Invalid function return type: #{Macro.to_string(type)}"
-    end
   end
 end

--- a/lib/coloured_flow/dsl/function.ex
+++ b/lib/coloured_flow/dsl/function.ex
@@ -1,0 +1,129 @@
+defmodule ColouredFlow.DSL.Function do
+  @moduledoc """
+  `function/2` and `function/3` macros. See `ColouredFlow.DSL` for context.
+  """
+
+  alias ColouredFlow.DSL.ExpressionHelper
+
+  alias ColouredFlow.Definition.Procedure
+
+  @doc """
+  Declare a user-defined function (CPN procedure) usable in arc, guard, action,
+  and termination expressions. The arguments listed in the head must appear as
+  free variables in the body. The return type after `::` is the result colour set.
+
+  ## Examples
+
+      function is_even(x) :: bool(), do: Integer.mod(x, 2) === 0
+
+      function double(x) :: int() do
+        x * 2
+      end
+  """
+  defmacro function(head_with_type, body \\ nil) do
+    {name, args, result} = decompose_head(head_with_type)
+    expr_ast = ExpressionHelper.block_to_ast(body)
+    expression = ExpressionHelper.build_from_ast!(expr_ast)
+
+    free_set = MapSet.new(expression.vars)
+    declared = MapSet.new(args)
+
+    missing = declared |> MapSet.difference(free_set) |> MapSet.to_list() |> Enum.sort()
+    extra = free_set |> MapSet.difference(declared) |> MapSet.to_list() |> Enum.sort()
+
+    {missing_ast, extra_ast, args_ast, name_ast} =
+      {Macro.escape(missing), Macro.escape(extra), Macro.escape(args), Macro.escape(name)}
+
+    quote do
+      ColouredFlow.DSL.Function.__validate_args__!(
+        unquote(name_ast),
+        unquote(args_ast),
+        unquote(missing_ast),
+        unquote(extra_ast)
+      )
+
+      @cf_functions %Procedure{
+        name: unquote(name),
+        expression: unquote(Macro.escape(expression)),
+        result: unquote(Macro.escape(result))
+      }
+    end
+  end
+
+  @doc false
+  @spec __validate_args__!(atom(), [atom()], [atom()], [atom()]) :: :ok
+  def __validate_args__!(name, args, missing, _extra) do
+    if missing != [] do
+      raise CompileError,
+        description: """
+        Function `#{name}/#{length(args)}` declares argument(s) \
+        #{inspect(missing)}, but they are not referenced in the body.
+        """
+    end
+
+    # Extra free variables are allowed (other vars/constants resolved at the
+    # workflow level), so we don't reject them here.
+    :ok
+  end
+
+  @spec decompose_head(Macro.t()) :: {atom(), [atom()], ColouredFlow.Definition.ColourSet.descr()}
+  defp decompose_head({:"::", _meta, [head, type_ast]}) do
+    {name, args} = decompose_call(head)
+    type_descr = decompose_type(type_ast)
+    {name, args, type_descr}
+  end
+
+  defp decompose_head(other) do
+    raise ArgumentError, """
+    Invalid function head, expected `name(arg1, arg2) :: type()`,
+    got: #{Macro.to_string(other)}
+    """
+  end
+
+  defp decompose_call({name, _meta, args}) when is_atom(name) and is_list(args) do
+    arg_names =
+      Enum.map(args, fn
+        {arg, _meta, ctx} when is_atom(arg) and is_atom(ctx) ->
+          arg
+
+        other ->
+          raise ArgumentError,
+                "function argument must be a variable, got: #{Macro.to_string(other)}"
+      end)
+
+    {name, arg_names}
+  end
+
+  defp decompose_call({name, _meta, ctx}) when is_atom(name) and is_atom(ctx) do
+    {name, []}
+  end
+
+  # Reuse Notation.Colset's type decomposer through a public-ish path. Falls
+  # back to a small local impl for the cases we need.
+  @spec decompose_type(Macro.t()) :: ColouredFlow.Definition.ColourSet.descr()
+  defp decompose_type({:{}, _meta, []}), do: {:unit, []}
+
+  defp decompose_type({type1, type2}) do
+    {:tuple, [decompose_type(type1), decompose_type(type2)]}
+  end
+
+  defp decompose_type({:{}, _meta, types}) do
+    {:tuple, Enum.map(types, &decompose_type/1)}
+  end
+
+  defp decompose_type({:%{}, _meta, fields}) do
+    map = Map.new(fields, fn {key, type} -> {key, decompose_type(type)} end)
+    {:map, map}
+  end
+
+  defp decompose_type({:list, _meta, [type]}) do
+    {:list, decompose_type(type)}
+  end
+
+  defp decompose_type(type) do
+    case Macro.decompose_call(type) do
+      {name, []} when is_atom(name) -> {name, []}
+      _other -> raise ArgumentError, "Invalid function return type: #{Macro.to_string(type)}"
+    end
+  end
+end

--- a/lib/coloured_flow/dsl/place.ex
+++ b/lib/coloured_flow/dsl/place.ex
@@ -17,12 +17,16 @@ defmodule ColouredFlow.DSL.Place do
   defmacro place(name, colour_set) do
     name_value = unquote_atom!(name, "place name", __CALLER__)
     colour_set_value = unquote_atom!(colour_set, "place colour set", __CALLER__)
+    name_str = Atom.to_string(name_value)
+    caller_file = __CALLER__.file
+    caller_line = __CALLER__.line
 
     quote do
       @cf_places %Place{
-        name: unquote(Atom.to_string(name_value)),
+        name: unquote(name_str),
         colour_set: unquote(colour_set_value)
       }
+      @cf_places_meta {unquote(name_str), unquote(caller_file), unquote(caller_line)}
     end
   end
 

--- a/lib/coloured_flow/dsl/place.ex
+++ b/lib/coloured_flow/dsl/place.ex
@@ -1,0 +1,51 @@
+defmodule ColouredFlow.DSL.Place do
+  @moduledoc """
+  `place/2` and `initial_marking/2` macros. See `ColouredFlow.DSL` for context.
+  """
+
+  alias ColouredFlow.Definition.Place
+
+  @doc """
+  Declare a place. The first argument is the place name (atom; converted to a
+  string for the underlying `%Place{}`); the second is the colour set name (atom).
+
+  ## Examples
+
+      place :input, :int
+      place :output, :int
+  """
+  defmacro place(name, colour_set) do
+    name_value = unquote_atom!(name, "place name")
+    colour_set_value = unquote_atom!(colour_set, "place colour set")
+
+    quote do
+      @cf_places %Place{
+        name: unquote(Atom.to_string(name_value)),
+        colour_set: unquote(colour_set_value)
+      }
+    end
+  end
+
+  @doc """
+  Declare the initial marking for a place. Multiple `initial_marking/2` calls may
+  target different places; they are scattered freely between other declarations.
+
+  ## Examples
+
+      initial_marking :input, ~MS[1, 2, 3]
+  """
+  defmacro initial_marking(name, marking) do
+    name_value = unquote_atom!(name, "initial_marking place name")
+
+    quote do
+      @cf_initial_markings {unquote(Atom.to_string(name_value)), unquote(marking)}
+    end
+  end
+
+  @spec unquote_atom!(Macro.t(), String.t()) :: atom()
+  defp unquote_atom!(value, _label) when is_atom(value), do: value
+
+  defp unquote_atom!(value, label) do
+    raise ArgumentError, "Expected #{label} to be an atom, got: #{Macro.to_string(value)}"
+  end
+end

--- a/lib/coloured_flow/dsl/place.ex
+++ b/lib/coloured_flow/dsl/place.ex
@@ -15,8 +15,8 @@ defmodule ColouredFlow.DSL.Place do
       place :output, :int
   """
   defmacro place(name, colour_set) do
-    name_value = unquote_atom!(name, "place name")
-    colour_set_value = unquote_atom!(colour_set, "place colour set")
+    name_value = unquote_atom!(name, "place name", __CALLER__)
+    colour_set_value = unquote_atom!(colour_set, "place colour set", __CALLER__)
 
     quote do
       @cf_places %Place{
@@ -32,20 +32,23 @@ defmodule ColouredFlow.DSL.Place do
 
   ## Examples
 
-      initial_marking :input, ~MS[1, 2, 3]
+      initial_marking :input, ~MS[1 2 3]
   """
   defmacro initial_marking(name, marking) do
-    name_value = unquote_atom!(name, "initial_marking place name")
+    name_value = unquote_atom!(name, "initial_marking place name", __CALLER__)
 
     quote do
       @cf_initial_markings {unquote(Atom.to_string(name_value)), unquote(marking)}
     end
   end
 
-  @spec unquote_atom!(Macro.t(), String.t()) :: atom()
-  defp unquote_atom!(value, _label) when is_atom(value), do: value
+  @spec unquote_atom!(Macro.t(), String.t(), Macro.Env.t()) :: atom()
+  defp unquote_atom!(value, _label, _caller) when is_atom(value), do: value
 
-  defp unquote_atom!(value, label) do
-    raise ArgumentError, "Expected #{label} to be an atom, got: #{Macro.to_string(value)}"
+  defp unquote_atom!(value, label, caller) do
+    raise CompileError,
+      description: "Expected #{label} to be an atom, got: #{Macro.to_string(value)}",
+      file: caller.file,
+      line: caller.line
   end
 end

--- a/lib/coloured_flow/dsl/spec.md
+++ b/lib/coloured_flow/dsl/spec.md
@@ -1,0 +1,311 @@
+A declarative Elixir DSL for defining Coloured Petri Nets.
+
+This is the high-level workflow-assembly layer. The low-level building
+blocks (`colset/1`, `var/1`, `val/1`) live in `ColouredFlow.Notation.*` and
+are reused here. The DSL composes them into a complete
+`ColouredFlow.Definition.ColouredPetriNet` and validates it at compile
+time.
+
+## Synopsis
+
+    defmodule MyWorkflow do
+      use ColouredFlow.DSL
+
+      name "My Workflow"
+      version "1.0.0"
+
+      # types
+      colset int() :: integer()
+      colset bool() :: boolean()
+
+      # bindings
+      var x :: int()
+      var y :: int()
+      val pi :: float() = 3.14
+
+      # functions
+      function is_even(x) :: bool() do
+        Integer.mod(x, 2) === 0
+      end
+
+      # graph
+      place :input, :int
+      place :output, :int
+
+      initial_marking :input, ~MS[1, 2, 3]
+
+      transition :pass_through do
+        guard x > 0
+
+        input :input, bind({1, x}), label: "in"
+
+        output :output do
+          if is_even(x), do: {1, x}, else: {1, x + 1}
+        end
+
+        action do
+          log("fired with x=\#{x}")
+        end
+      end
+
+      # termination
+      termination do
+        on_markings do
+          match?(
+            %{"output" => out_ms} when multi_set_coefficient(out_ms, 1) >= 5,
+            markings
+          )
+        end
+      end
+    end
+
+    MyWorkflow.cpnet() #=> %ColouredFlow.Definition.ColouredPetriNet{...}
+
+## Module surface
+
+`use ColouredFlow.DSL` injects the macros listed below and registers an
+`@before_compile` hook that assembles a
+`%ColouredFlow.Definition.ColouredPetriNet{}` from the accumulated
+declarations and runs `ColouredFlow.Validators.run/1` against it. Any
+validator failure raises at compile time so misconfigured workflows never
+reach runtime.
+
+Compiled modules expose a single zero-arity helper:
+
+    MyWorkflow.cpnet() :: %ColouredFlow.Definition.ColouredPetriNet{}
+
+Higher-level integration (running an enactment, persisting it, etc.) is
+intentionally left to the existing `ColouredFlow.Runner.*` API. The DSL
+produces only the static definition.
+
+## Universal expression rule
+
+Every macro that accepts an expression follows the same rule:
+
+- **Single-line**: the expression is the last positional argument.
+- **Multi-line**: pass a `do ... end` block; the block body **is** the
+  expression. There is no `expr do ... end` wrapper anywhere.
+- **Options** (e.g., `label:`): keyword arguments only, placed before the
+  `do` block.
+
+```elixir
+guard x > 0                                  # single-line
+guard do x > 0 and y > 0 end                 # multi-line
+
+input :p, bind({1, x})                       # single-line, no label
+input :p, bind({1, x}), label: "in"          # single-line, with label
+
+input :p, label: "in" do                     # multi-line, with label
+  if x > 0, do: bind({1, x}), else: bind({2, x})
+end
+```
+
+## Reuse
+
+`colset/1`, `var/1`, and `val/1` are re-exported from
+`ColouredFlow.Notation.*` so existing notation users have one mental model.
+Everything else (`name`, `version`, `place`, `initial_marking`,
+`transition`, `input`, `output`, `guard`, `action`, `function`,
+`termination`, `on_markings`) is new and lives under
+`ColouredFlow.DSL.*`.
+
+## Top-level macros
+
+### `name/1`
+
+Set the human-readable workflow name. Compile-time only.
+
+    name "Traffic Light"
+
+### `version/1`
+
+Set the workflow version (any string the caller chooses; semver is
+conventional).
+
+    version "1.0.0"
+
+### `colset/1`
+
+Re-exported from `ColouredFlow.Notation.Colset`. Declares a colour set.
+
+    colset int()    :: integer()
+    colset bool()   :: boolean()
+    colset status() :: ok | err
+    colset point()  :: {integer(), integer()}
+
+### `var/1`
+
+Re-exported from `ColouredFlow.Notation.Var`. Declares a variable bound to
+a colour set.
+
+    var x :: int()
+
+### `val/1`
+
+Re-exported from `ColouredFlow.Notation.Val`. Declares a constant bound to
+a colour set.
+
+    val pi :: float() = 3.14
+
+### `place/2`
+
+Declare a place. The first argument is the place name (atom; converted to a
+string for the underlying `%Place{}`); the second is the colour set name
+(atom).
+
+    place :input, :int
+    place :output, :int
+
+### `initial_marking/2`
+
+Declare the initial marking for a place. Multiple `initial_marking/2`
+calls may target different places; they are scattered freely between
+other declarations.
+
+    initial_marking :input, ~MS[1, 2, 3]
+
+### `function/2` and `function/3`
+
+Declare a user-defined function (CPN procedure) usable in arc, guard,
+action, and termination expressions. The arguments listed in the head
+must appear as free variables in the body. The return type after `::` is
+the result colour set.
+
+    function is_even(x) :: bool(), do: Integer.mod(x, 2) === 0
+
+    function double(x) :: int() do
+      x * 2
+    end
+
+### `transition/2`
+
+Declare a transition. The block accepts `guard/1`, `action/1`, `input/2,3`
+and `output/2,3`.
+
+    transition :pass_through do
+      guard x > 0
+
+      input :input, bind({1, x})
+      output :output, {1, x * 2}
+
+      action do
+        :ok
+      end
+    end
+
+### `termination/1`
+
+Declare termination criteria. The block accepts criterion-specific
+sub-macros. Currently only `on_markings/1` is supported. Future criterion
+kinds (`on_time`, `on_workitem_count`, etc.) plug in here without
+changing call sites.
+
+    termination do
+      on_markings do
+        match?(
+          %{"output" => out_ms} when multi_set_coefficient(out_ms, 1) >= 5,
+          markings
+        )
+      end
+    end
+
+## Transition-scope macros
+
+### `guard/1`
+
+Boolean expression over bound variables. Optional. Returning a falsy
+value disables the transition for the current binding.
+
+    guard x > 0
+    guard do
+      x > 0 and is_even(x)
+    end
+
+### `action/1`
+
+Expression evaluated when the transition fires. Optional. Use for output
+bindings (when an outgoing arc references an unbound variable) and for
+side effects.
+
+    action :ok
+    action do
+      log("fired")
+      :ok
+    end
+
+### `input/2` and `input/3`
+
+Declare an incoming arc (place → transition). The expression must use the
+`bind/1` keyword to consume tokens. Options: `:label`.
+
+    input :input, bind({1, x})
+    input :input, bind({1, x}), label: "in"
+    input :input, label: "in" do
+      if x > 0, do: bind({1, x}), else: bind({2, x})
+    end
+
+### `output/2` and `output/3`
+
+Declare an outgoing arc (transition → place). The expression evaluates to
+the multiset of tokens produced. Options: `:label`.
+
+    output :output, {1, x}
+    output :output, {1, x}, label: "out"
+    output :output, label: "out" do
+      if x > 0, do: {1, x}, else: {0, x}
+    end
+
+## Termination-scope macros
+
+### `on_markings/1`
+
+Boolean expression over the special variable `markings` (a map of place
+name → token multiset). Returning a truthy value terminates the enactment
+with reason `:explicit`.
+
+    on_markings do
+      match?(
+        %{"output" => out_ms} when multi_set_coefficient(out_ms, 1) >= 5,
+        markings
+      )
+    end
+
+## Compile-time validation
+
+The `@before_compile` hook builds a `%ColouredPetriNet{}` from the
+accumulated declarations and runs the existing
+`ColouredFlow.Validators.run/1` pipeline:
+
+- colour-set declarations are well-formed,
+- place colour-set references resolve,
+- arc endpoints exist,
+- incoming arcs use `bind/1`,
+- free variables in expressions resolve to declared `var/1` (or function
+  arguments),
+- structural sanity (no orphan places, no duplicate names, etc.).
+
+Any failure raises a clear compile-time error pointing to the offending
+line.
+
+## File layout
+
+Macros are partitioned by concern; the entry module re-exports them via
+`__using__/1`.
+
+- `ColouredFlow.DSL`                       — entry, `__using__/1`, top-level macros
+- `ColouredFlow.DSL.Builder`               — `@before_compile` hook
+- `ColouredFlow.DSL.Place`                 — `place/2`, `initial_marking/2`
+- `ColouredFlow.DSL.Transition`            — `transition/2`, `guard/1`, `action/1`
+- `ColouredFlow.DSL.Arc`                   — `input/{2,3}`, `output/{2,3}`
+- `ColouredFlow.DSL.Function`              — `function/{2,3}`
+- `ColouredFlow.DSL.Termination`           — `termination/1`, `on_markings/1`
+- `ColouredFlow.DSL.ExpressionHelper`      — AST → `%Expression{}` conversion
+
+## Out of scope
+
+- Runner integration: spawning enactments, persisting flows. The DSL
+  produces a definition; how it is run is the caller's choice.
+- Visualisation / diagram generation. Could be layered on top of
+  `cpnet/0`.
+- Live editing / hot reload. Workflows are expected to be defined in
+  source and recompiled.

--- a/lib/coloured_flow/dsl/spec.md
+++ b/lib/coloured_flow/dsl/spec.md
@@ -32,7 +32,7 @@ time.
       place :input, :int
       place :output, :int
 
-      initial_marking :input, ~MS[1, 2, 3]
+      initial_marking :input, ~MS[1 2 3]
 
       transition :pass_through do
         guard x > 0
@@ -70,9 +70,14 @@ declarations and runs `ColouredFlow.Validators.run/1` against it. Any
 validator failure raises at compile time so misconfigured workflows never
 reach runtime.
 
-Compiled modules expose a single zero-arity helper:
+Compiled modules expose two zero-arity helpers:
 
-    MyWorkflow.cpnet() :: %ColouredFlow.Definition.ColouredPetriNet{}
+    MyWorkflow.cpnet()             :: %ColouredFlow.Definition.ColouredPetriNet{}
+    MyWorkflow.initial_markings()  :: [%ColouredFlow.Enactment.Marking{}]
+
+`cpnet/0` returns the static CPN definition. `initial_markings/0` returns
+the list of `%Marking{}` structs declared via `initial_marking/2` — Runner
+seed data, deliberately *not* part of `cpnet/0`.
 
 Higher-level integration (running an enactment, persisting it, etc.) is
 intentionally left to the existing `ColouredFlow.Runner.*` API. The DSL
@@ -162,7 +167,7 @@ Declare the initial marking for a place. Multiple `initial_marking/2`
 calls may target different places; they are scattered freely between
 other declarations.
 
-    initial_marking :input, ~MS[1, 2, 3]
+    initial_marking :input, ~MS[1 2 3]
 
 ### `function/2` and `function/3`
 

--- a/lib/coloured_flow/dsl/spec.md
+++ b/lib/coloured_flow/dsl/spec.md
@@ -52,19 +52,24 @@ runtime.
 
 ## Generated module surface
 
-A module that uses `ColouredFlow.DSL` exposes two zero-arity helpers:
+A module that uses `ColouredFlow.DSL` exposes:
 
-    MyWorkflow.cpnet()             :: %ColouredFlow.Definition.ColouredPetriNet{}
-    MyWorkflow.initial_markings()  :: [%ColouredFlow.Enactment.Marking{}]
+    MyWorkflow.cpnet()                      :: %ColouredFlow.Definition.ColouredPetriNet{}
+    MyWorkflow.__cpn__(:name)               :: String.t() | nil
+    MyWorkflow.__cpn__(:version)            :: String.t() | nil
+    MyWorkflow.__cpn__(:initial_markings)   :: [%ColouredFlow.Enactment.Marking{}]
 
-`cpnet/0` returns the static CPN — colour sets, variables, places,
-transitions, arcs, and termination criteria. It is the input the runner
-reuses across every enactment of the workflow.
+`cpnet/0` is the **main API**: it returns the static CPN — colour sets,
+variables, places, transitions, arcs, and termination criteria — that
+the runner reuses across every enactment of the workflow.
 
-`initial_markings/0` returns the list of `%Marking{}` declared via
-`initial_marking/2`. This is enactment-seed data, deliberately *not*
-folded into `cpnet/0`. Pass it to `Storage.insert_enactment/1` (or your
-own runner glue) when starting an enactment.
+`__cpn__/1` is a **reflection helper** for declaration metadata
+(modeled after `Ecto.Schema.__schema__/1`). Pass an atom key to read
+the corresponding piece of workflow metadata. `:initial_markings`
+returns the list of `%Marking{}` declared via `initial_marking/2`;
+this is enactment-seed data, deliberately *not* folded into `cpnet/0`.
+Pass it to `Storage.insert_enactment/1` (or your own runner glue) when
+starting an enactment.
 
 Higher-level integration — spawning enactments, persisting flows,
 visualisation — is left to the existing `ColouredFlow.Runner.*` API.

--- a/lib/coloured_flow/dsl/spec.md
+++ b/lib/coloured_flow/dsl/spec.md
@@ -1,10 +1,11 @@
 A declarative Elixir DSL for defining Coloured Petri Nets.
 
-This is the high-level workflow-assembly layer. The low-level building
-blocks (`colset/1`, `var/1`, `val/1`) live in `ColouredFlow.Notation.*` and
-are reused here. The DSL composes them into a complete
-`ColouredFlow.Definition.ColouredPetriNet` and validates it at compile
-time.
+This is the high-level workflow-assembly layer on top of
+`ColouredFlow.Notation.*`. The DSL composes colour sets, variables,
+constants, places, transitions, arcs, functions, and termination criteria
+into a complete `ColouredFlow.Definition.ColouredPetriNet` and validates
+it at compile time. Any issue raises during `mix compile`, never at
+runtime.
 
 ## Synopsis
 
@@ -14,21 +15,16 @@ time.
       name "My Workflow"
       version "1.0.0"
 
-      # types
       colset int() :: integer()
       colset bool() :: boolean()
 
-      # bindings
       var x :: int()
-      var y :: int()
       val pi :: float() = 3.14
 
-      # functions
       function is_even(x) :: bool() do
         Integer.mod(x, 2) === 0
       end
 
-      # graph
       place :input, :int
       place :output, :int
 
@@ -42,13 +38,8 @@ time.
         output :output do
           if is_even(x), do: {1, x}, else: {1, x + 1}
         end
-
-        action do
-          log("fired with x=\#{x}")
-        end
       end
 
-      # termination
       termination do
         on_markings do
           match?(
@@ -59,73 +50,58 @@ time.
       end
     end
 
-    MyWorkflow.cpnet() #=> %ColouredFlow.Definition.ColouredPetriNet{...}
+## Generated module surface
 
-## Module surface
-
-`use ColouredFlow.DSL` injects the macros listed below and registers an
-`@before_compile` hook that assembles a
-`%ColouredFlow.Definition.ColouredPetriNet{}` from the accumulated
-declarations and runs `ColouredFlow.Validators.run/1` against it. Any
-validator failure raises at compile time so misconfigured workflows never
-reach runtime.
-
-Compiled modules expose two zero-arity helpers:
+A module that uses `ColouredFlow.DSL` exposes two zero-arity helpers:
 
     MyWorkflow.cpnet()             :: %ColouredFlow.Definition.ColouredPetriNet{}
     MyWorkflow.initial_markings()  :: [%ColouredFlow.Enactment.Marking{}]
 
-`cpnet/0` returns the static CPN definition. `initial_markings/0` returns
-the list of `%Marking{}` structs declared via `initial_marking/2` — Runner
-seed data, deliberately *not* part of `cpnet/0`.
+`cpnet/0` returns the static CPN — colour sets, variables, places,
+transitions, arcs, and termination criteria. It is the input the runner
+reuses across every enactment of the workflow.
 
-Higher-level integration (running an enactment, persisting it, etc.) is
-intentionally left to the existing `ColouredFlow.Runner.*` API. The DSL
-produces only the static definition.
+`initial_markings/0` returns the list of `%Marking{}` declared via
+`initial_marking/2`. This is enactment-seed data, deliberately *not*
+folded into `cpnet/0`. Pass it to `Storage.insert_enactment/1` (or your
+own runner glue) when starting an enactment.
+
+Higher-level integration — spawning enactments, persisting flows,
+visualisation — is left to the existing `ColouredFlow.Runner.*` API.
 
 ## Universal expression rule
 
-Every macro that accepts an expression follows the same rule:
+Every macro that accepts an expression follows the same shape:
 
-- **Single-line**: the expression is the last positional argument.
-- **Multi-line**: pass a `do ... end` block; the block body **is** the
-  expression. There is no `expr do ... end` wrapper anywhere.
-- **Options** (e.g., `label:`): keyword arguments only, placed before the
-  `do` block.
+  - **Single-line**: the expression is the last positional argument.
+  - **Multi-line**: pass a `do ... end` block; the block body **is** the
+    expression. There is no `expr do ... end` wrapper.
+  - **Options** (e.g., `label:`): keyword arguments only, before the `do`
+    block.
 
 ```elixir
-guard x > 0                                  # single-line
-guard do x > 0 and y > 0 end                 # multi-line
+guard x > 0                                 # single-line
+guard do x > 0 and y > 0 end                # multi-line
 
-input :p, bind({1, x})                       # single-line, no label
-input :p, bind({1, x}), label: "in"          # single-line, with label
+input :p, bind({1, x})                      # single-line, no label
+input :p, bind({1, x}), label: "in"         # single-line, with label
 
-input :p, label: "in" do                     # multi-line, with label
+input :p, label: "in" do                    # multi-line, with label
   if x > 0, do: bind({1, x}), else: bind({2, x})
 end
 ```
-
-## Reuse
-
-`colset/1`, `var/1`, and `val/1` are re-exported from
-`ColouredFlow.Notation.*` so existing notation users have one mental model.
-Everything else (`name`, `version`, `place`, `initial_marking`,
-`transition`, `input`, `output`, `guard`, `action`, `function`,
-`termination`, `on_markings`) is new and lives under
-`ColouredFlow.DSL.*`.
 
 ## Top-level macros
 
 ### `name/1`
 
-Set the human-readable workflow name. Compile-time only.
+Set the human-readable workflow name.
 
     name "Traffic Light"
 
 ### `version/1`
 
-Set the workflow version (any string the caller chooses; semver is
-conventional).
+Set the workflow version (free-form string; semver is conventional).
 
     version "1.0.0"
 
@@ -140,41 +116,42 @@ Re-exported from `ColouredFlow.Notation.Colset`. Declares a colour set.
 
 ### `var/1`
 
-Re-exported from `ColouredFlow.Notation.Var`. Declares a variable bound to
-a colour set.
+Re-exported from `ColouredFlow.Notation.Var`. Declares a variable bound
+to a colour set.
 
     var x :: int()
 
 ### `val/1`
 
-Re-exported from `ColouredFlow.Notation.Val`. Declares a constant bound to
-a colour set.
+Re-exported from `ColouredFlow.Notation.Val`. Declares a constant bound
+to a colour set.
 
     val pi :: float() = 3.14
 
 ### `place/2`
 
-Declare a place. The first argument is the place name (atom; converted to a
-string for the underlying `%Place{}`); the second is the colour set name
-(atom).
+Declare a place. Place names are atoms; the underlying `%Place{}` stores
+them as strings. The colour set name is also an atom and must be a
+declared `colset`.
 
     place :input, :int
     place :output, :int
 
 ### `initial_marking/2`
 
-Declare the initial marking for a place. Multiple `initial_marking/2`
-calls may target different places; they are scattered freely between
-other declarations.
+Declare an initial marking for a place. Multiple `initial_marking/2`
+calls accumulate in declaration order and are exposed via
+`initial_markings/0` on the host module. The cpnet definition itself is
+not affected.
 
     initial_marking :input, ~MS[1 2 3]
 
 ### `function/2` and `function/3`
 
 Declare a user-defined function (CPN procedure) usable in arc, guard,
-action, and termination expressions. The arguments listed in the head
-must appear as free variables in the body. The return type after `::` is
-the result colour set.
+action, and termination expressions. Arguments listed in the head must
+appear as free variables in the body; the result type after `::` is the
+result colour set.
 
     function is_even(x) :: bool(), do: Integer.mod(x, 2) === 0
 
@@ -184,8 +161,8 @@ the result colour set.
 
 ### `transition/2`
 
-Declare a transition. The block accepts `guard/1`, `action/1`, `input/2,3`
-and `output/2,3`.
+Declare a transition. The block accepts `guard/1`, `action/1`,
+`input/2,3`, and `output/2,3`.
 
     transition :pass_through do
       guard x > 0
@@ -201,9 +178,9 @@ and `output/2,3`.
 ### `termination/1`
 
 Declare termination criteria. The block accepts criterion-specific
-sub-macros. Currently only `on_markings/1` is supported. Future criterion
-kinds (`on_time`, `on_workitem_count`, etc.) plug in here without
-changing call sites.
+sub-macros. Currently `on_markings/1` is the only kind. Future kinds
+(`on_time`, `on_workitem_count`, …) plug in here without changing call
+sites.
 
     termination do
       on_markings do
@@ -218,8 +195,9 @@ changing call sites.
 
 ### `guard/1`
 
-Boolean expression over bound variables. Optional. Returning a falsy
-value disables the transition for the current binding.
+A boolean expression over bound variables. Optional. A falsy result
+disables the transition for the current binding. Declaring `guard` more
+than once in a transition is a compile-time error.
 
     guard x > 0
     guard do
@@ -228,9 +206,10 @@ value disables the transition for the current binding.
 
 ### `action/1`
 
-Expression evaluated when the transition fires. Optional. Use for output
-bindings (when an outgoing arc references an unbound variable) and for
-side effects.
+Expression evaluated when the transition fires. Optional. Use it to
+provide bindings for outgoing arcs that reference variables not bound by
+any incoming arc. Declaring `action` more than once in a transition is a
+compile-time error.
 
     action :ok
     action do
@@ -240,8 +219,8 @@ side effects.
 
 ### `input/2` and `input/3`
 
-Declare an incoming arc (place → transition). The expression must use the
-`bind/1` keyword to consume tokens. Options: `:label`.
+Declare an incoming arc (place → transition). The expression must use
+`bind/1` to consume tokens. Options: `:label`.
 
     input :input, bind({1, x})
     input :input, bind({1, x}), label: "in"
@@ -251,8 +230,8 @@ Declare an incoming arc (place → transition). The expression must use the
 
 ### `output/2` and `output/3`
 
-Declare an outgoing arc (transition → place). The expression evaluates to
-the multiset of tokens produced. Options: `:label`.
+Declare an outgoing arc (transition → place). The expression evaluates
+to the multiset of tokens produced. Options: `:label`.
 
     output :output, {1, x}
     output :output, {1, x}, label: "out"
@@ -264,9 +243,10 @@ the multiset of tokens produced. Options: `:label`.
 
 ### `on_markings/1`
 
-Boolean expression over the special variable `markings` (a map of place
-name → token multiset). Returning a truthy value terminates the enactment
-with reason `:explicit`.
+Boolean expression over the special variable `markings` — a map of place
+name (string) to token multiset. A truthy result terminates the
+enactment with reason `:explicit`. Declaring `on_markings` more than
+once is a compile-time error.
 
     on_markings do
       match?(
@@ -278,39 +258,18 @@ with reason `:explicit`.
 ## Compile-time validation
 
 The `@before_compile` hook builds a `%ColouredPetriNet{}` from the
-accumulated declarations and runs the existing
-`ColouredFlow.Validators.run/1` pipeline:
+accumulated declarations, runs `ColouredFlow.Builder.build/1` (which
+populates `action.outputs` from arc/guard analysis), and runs
+`ColouredFlow.Validators.run/1`:
 
-- colour-set declarations are well-formed,
-- place colour-set references resolve,
-- arc endpoints exist,
-- incoming arcs use `bind/1`,
-- free variables in expressions resolve to declared `var/1` (or function
-  arguments),
-- structural sanity (no orphan places, no duplicate names, etc.).
+  - colour set declarations are well-formed,
+  - place / variable / constant colour-set references resolve,
+  - arc endpoints exist,
+  - incoming arcs use `bind/1`,
+  - free variables in expressions resolve to `var/1` (or function args),
+  - guard variables are bound by the same transition's incoming arcs,
+  - function names are unique and result descrs are fully resolved,
+  - termination criteria reference only `markings`.
 
-Any failure raises a clear compile-time error pointing to the offending
-line.
-
-## File layout
-
-Macros are partitioned by concern; the entry module re-exports them via
-`__using__/1`.
-
-- `ColouredFlow.DSL`                       — entry, `__using__/1`, top-level macros
-- `ColouredFlow.DSL.Builder`               — `@before_compile` hook
-- `ColouredFlow.DSL.Place`                 — `place/2`, `initial_marking/2`
-- `ColouredFlow.DSL.Transition`            — `transition/2`, `guard/1`, `action/1`
-- `ColouredFlow.DSL.Arc`                   — `input/{2,3}`, `output/{2,3}`
-- `ColouredFlow.DSL.Function`              — `function/{2,3}`
-- `ColouredFlow.DSL.Termination`           — `termination/1`, `on_markings/1`
-- `ColouredFlow.DSL.ExpressionHelper`      — AST → `%Expression{}` conversion
-
-## Out of scope
-
-- Runner integration: spawning enactments, persisting flows. The DSL
-  produces a definition; how it is run is the caller's choice.
-- Visualisation / diagram generation. Could be layered on top of
-  `cpnet/0`.
-- Live editing / hot reload. Workflows are expected to be defined in
-  source and recompiled.
+Any failure raises a `CompileError` pointing to the offending macro
+call.

--- a/lib/coloured_flow/dsl/termination.ex
+++ b/lib/coloured_flow/dsl/termination.ex
@@ -27,6 +27,9 @@ defmodule ColouredFlow.DSL.Termination do
       end
   """
   defmacro termination(opts \\ []) do
+    caller_file = __CALLER__.file
+    caller_line = __CALLER__.line
+
     block =
       case opts do
         list when is_list(list) -> Keyword.get(list, :do)
@@ -34,12 +37,18 @@ defmodule ColouredFlow.DSL.Termination do
       end
 
     if is_nil(block) do
-      raise ArgumentError,
-            "termination/1 requires a `do ... end` block, got: #{inspect(opts)}"
+      raise CompileError,
+        description: "termination/1 requires a `do ... end` block, got: #{inspect(opts)}",
+        file: caller_file,
+        line: caller_line
     end
 
     quote do
-      ColouredFlow.DSL.Termination.__open_termination__!(__MODULE__)
+      ColouredFlow.DSL.Termination.__open_termination__!(
+        __MODULE__,
+        unquote(caller_file),
+        unquote(caller_line)
+      )
 
       unquote(block)
 
@@ -60,6 +69,8 @@ defmodule ColouredFlow.DSL.Termination do
       end
   """
   defmacro on_markings(expression) do
+    caller_file = __CALLER__.file
+    caller_line = __CALLER__.line
     expr_ast = ExpressionHelper.block_to_ast(expression)
     expression = ExpressionHelper.build_from_ast!(expr_ast)
     markings = %Markings{expression: expression}
@@ -67,19 +78,21 @@ defmodule ColouredFlow.DSL.Termination do
     quote do
       ColouredFlow.DSL.Termination.__set_markings__!(
         __MODULE__,
-        unquote(Macro.escape(markings))
+        unquote(Macro.escape(markings)),
+        unquote(caller_file),
+        unquote(caller_line)
       )
     end
   end
 
   @doc false
-  @spec __open_termination__!(module()) :: :ok
-  def __open_termination__!(module) do
+  @spec __open_termination__!(module(), String.t(), non_neg_integer()) :: :ok
+  def __open_termination__!(module, file, line) do
     if Module.get_attribute(module, @scope_attr) do
       raise CompileError,
         description: "termination/1 cannot be nested",
-        file: source_file(module),
-        line: 0
+        file: file,
+        line: line
     end
 
     Module.put_attribute(module, @scope_attr, %{markings: nil})
@@ -98,27 +111,31 @@ defmodule ColouredFlow.DSL.Termination do
         line: 0
     end
 
-    if scope.markings || true do
-      criteria = %TerminationCriteria{markings: scope.markings}
-      Module.put_attribute(module, :cf_termination_criteria, criteria)
-    end
+    criteria = %TerminationCriteria{markings: scope.markings}
+    Module.put_attribute(module, :cf_termination_criteria, criteria)
 
     Module.delete_attribute(module, @scope_attr)
     :ok
   end
 
   @doc false
-  @spec __set_markings__!(module(), Markings.t()) :: :ok
-  def __set_markings__!(module, %Markings{} = markings) do
+  @spec __set_markings__!(module(), Markings.t(), String.t(), non_neg_integer()) :: :ok
+  def __set_markings__!(module, %Markings{} = markings, file, line) do
     case Module.get_attribute(module, @scope_attr) do
       nil ->
         raise CompileError,
           description: "on_markings may only be used inside a `termination do ... end` block",
-          file: source_file(module),
-          line: 0
+          file: file,
+          line: line
 
-      scope ->
+      %{markings: nil} = scope ->
         Module.put_attribute(module, @scope_attr, %{scope | markings: markings})
+
+      %{markings: _existing} ->
+        raise CompileError,
+          description: "on_markings already declared in this termination",
+          file: file,
+          line: line
     end
 
     :ok

--- a/lib/coloured_flow/dsl/termination.ex
+++ b/lib/coloured_flow/dsl/termination.ex
@@ -1,0 +1,135 @@
+defmodule ColouredFlow.DSL.Termination do
+  @moduledoc """
+  `termination/1` and `on_markings/1` macros. See `ColouredFlow.DSL` for context.
+
+  Currently only `on_markings/1` is supported. Future criterion kinds plug in here
+  without changing call sites.
+  """
+
+  alias ColouredFlow.DSL.ExpressionHelper
+
+  alias ColouredFlow.Definition.TerminationCriteria
+  alias ColouredFlow.Definition.TerminationCriteria.Markings
+
+  @scope_attr :__cf_termination_scope__
+
+  @doc """
+  Declare termination criteria. The block accepts criterion-specific sub-macros.
+  Currently only `on_markings/1` is supported.
+
+  ## Examples
+
+      termination do
+        on_markings do
+          match?(%{"output" => out}, markings) and
+            multi_set_coefficient(out, 1) >= 5
+        end
+      end
+  """
+  defmacro termination(opts \\ []) do
+    block =
+      case opts do
+        list when is_list(list) -> Keyword.get(list, :do)
+        _other -> nil
+      end
+
+    if is_nil(block) do
+      raise ArgumentError,
+            "termination/1 requires a `do ... end` block, got: #{inspect(opts)}"
+    end
+
+    quote do
+      ColouredFlow.DSL.Termination.__open_termination__!(__MODULE__)
+
+      unquote(block)
+
+      ColouredFlow.DSL.Termination.__close_termination__!(__MODULE__)
+    end
+  end
+
+  @doc """
+  Boolean expression over the special variable `markings` (a map of place name →
+  token multiset). Returning a truthy value terminates the enactment with reason
+  `:explicit`.
+
+  ## Examples
+
+      on_markings do
+        match?(%{"output" => out}, markings) and
+          multi_set_coefficient(out, 1) >= 5
+      end
+  """
+  defmacro on_markings(expression) do
+    expr_ast = ExpressionHelper.block_to_ast(expression)
+    expression = ExpressionHelper.build_from_ast!(expr_ast)
+    markings = %Markings{expression: expression}
+
+    quote do
+      ColouredFlow.DSL.Termination.__set_markings__!(
+        __MODULE__,
+        unquote(Macro.escape(markings))
+      )
+    end
+  end
+
+  @doc false
+  @spec __open_termination__!(module()) :: :ok
+  def __open_termination__!(module) do
+    if Module.get_attribute(module, @scope_attr) do
+      raise CompileError,
+        description: "termination/1 cannot be nested",
+        file: source_file(module),
+        line: 0
+    end
+
+    Module.put_attribute(module, @scope_attr, %{markings: nil})
+    :ok
+  end
+
+  @doc false
+  @spec __close_termination__!(module()) :: :ok
+  def __close_termination__!(module) do
+    scope = Module.get_attribute(module, @scope_attr)
+
+    if is_nil(scope) do
+      raise CompileError,
+        description: "internal error: closing termination that wasn't opened",
+        file: source_file(module),
+        line: 0
+    end
+
+    if scope.markings || true do
+      criteria = %TerminationCriteria{markings: scope.markings}
+      Module.put_attribute(module, :cf_termination_criteria, criteria)
+    end
+
+    Module.delete_attribute(module, @scope_attr)
+    :ok
+  end
+
+  @doc false
+  @spec __set_markings__!(module(), Markings.t()) :: :ok
+  def __set_markings__!(module, %Markings{} = markings) do
+    case Module.get_attribute(module, @scope_attr) do
+      nil ->
+        raise CompileError,
+          description: "on_markings may only be used inside a `termination do ... end` block",
+          file: source_file(module),
+          line: 0
+
+      scope ->
+        Module.put_attribute(module, @scope_attr, %{scope | markings: markings})
+    end
+
+    :ok
+  end
+
+  defp source_file(module) do
+    case Module.get_attribute(module, :file) do
+      nil -> "nofile"
+      src -> to_string(src)
+    end
+  rescue
+    _error -> "nofile"
+  end
+end

--- a/lib/coloured_flow/dsl/termination.ex
+++ b/lib/coloured_flow/dsl/termination.ex
@@ -44,6 +44,12 @@ defmodule ColouredFlow.DSL.Termination do
     end
 
     quote do
+      ColouredFlow.DSL.Termination.__check_unique_termination__!(
+        __MODULE__,
+        unquote(caller_file),
+        unquote(caller_line)
+      )
+
       ColouredFlow.DSL.Termination.__open_termination__!(
         __MODULE__,
         unquote(caller_file),
@@ -82,6 +88,22 @@ defmodule ColouredFlow.DSL.Termination do
         unquote(caller_file),
         unquote(caller_line)
       )
+    end
+  end
+
+  @doc false
+  @spec __check_unique_termination__!(module(), String.t(), non_neg_integer()) :: :ok
+  def __check_unique_termination__!(module, file, line) do
+    case Module.get_attribute(module, :cf_termination_criteria) do
+      [] ->
+        :ok
+
+      list when is_list(list) ->
+        raise CompileError,
+          description:
+            "termination/1 already declared in this workflow; only a single termination block is allowed",
+          file: file,
+          line: line
     end
   end
 

--- a/lib/coloured_flow/dsl/transition.ex
+++ b/lib/coloured_flow/dsl/transition.ex
@@ -64,6 +64,8 @@ defmodule ColouredFlow.DSL.Transition do
       unquote(block)
 
       ColouredFlow.DSL.Transition.__close_transition__!(__MODULE__)
+
+      @cf_transitions_meta {unquote(name_str), unquote(caller_file), unquote(caller_line)}
     end
   end
 

--- a/lib/coloured_flow/dsl/transition.ex
+++ b/lib/coloured_flow/dsl/transition.ex
@@ -1,0 +1,228 @@
+defmodule ColouredFlow.DSL.Transition do
+  @moduledoc """
+  `transition/2`, `guard/1`, `action/1` macros. See `ColouredFlow.DSL` for
+  context.
+
+  Internally this module uses the module attribute `@__cf_transition_scope__` on
+  the calling module to track the current open transition while expanding the
+  block body. The scope is a map of `%{name, arcs, guard, action}`.
+  """
+
+  alias ColouredFlow.DSL.ExpressionHelper
+
+  alias ColouredFlow.Definition.Action
+  alias ColouredFlow.Definition.Arc
+  alias ColouredFlow.Definition.Expression
+  alias ColouredFlow.Definition.Transition
+
+  @scope_attr :__cf_transition_scope__
+
+  @doc """
+  Declare a transition. The block accepts `guard/1`, `action/1`, `input/2,3` and
+  `output/2,3`.
+
+  ## Examples
+
+      transition :pass_through do
+        guard x > 0
+
+        input :input, bind({1, x})
+        output :output, {1, x * 2}
+
+        action do
+          :ok
+        end
+      end
+  """
+  defmacro transition(name, opts \\ []) do
+    name_value = unquote_atom!(name, "transition name")
+    name_str = Atom.to_string(name_value)
+
+    block =
+      case opts do
+        list when is_list(list) -> Keyword.get(list, :do)
+        _other -> nil
+      end
+
+    if is_nil(block) do
+      raise ArgumentError,
+            "transition/2 requires a `do ... end` block, got: #{inspect(opts)}"
+    end
+
+    quote do
+      ColouredFlow.DSL.Transition.__open_transition__!(__MODULE__, unquote(name_str))
+
+      unquote(block)
+
+      ColouredFlow.DSL.Transition.__close_transition__!(__MODULE__)
+    end
+  end
+
+  @doc """
+  Boolean expression over bound variables. Optional. Returning a falsy value
+  disables the transition for the current binding.
+
+  ## Examples
+
+      guard x > 0
+      guard do
+        x > 0 and is_even(x)
+      end
+  """
+  defmacro guard(expression) do
+    expr_ast = ExpressionHelper.block_to_ast(expression)
+    expr = ExpressionHelper.build_from_ast!(expr_ast)
+
+    quote do
+      ColouredFlow.DSL.Transition.__set_guard__!(__MODULE__, unquote(Macro.escape(expr)))
+    end
+  end
+
+  @doc """
+  Expression evaluated when the transition fires. Optional. Use for output
+  bindings (when an outgoing arc references an unbound variable) and for side
+  effects.
+
+  ## Examples
+
+      action :ok
+      action do
+        log("fired")
+        :ok
+      end
+  """
+  defmacro action(expression) do
+    expr_ast = ExpressionHelper.block_to_ast(expression)
+    code = ExpressionHelper.ast_to_code(expr_ast)
+
+    quote do
+      ColouredFlow.DSL.Transition.__set_action__!(__MODULE__, unquote(code))
+    end
+  end
+
+  @doc false
+  @spec __open_transition__!(module(), String.t()) :: :ok
+  def __open_transition__!(module, name) when is_atom(module) and is_binary(name) do
+    if Module.get_attribute(module, @scope_attr) do
+      raise CompileError,
+        description: "transition/2 cannot be nested",
+        file: source_file(module),
+        line: 0
+    end
+
+    Module.put_attribute(module, @scope_attr, %{
+      name: name,
+      arcs: [],
+      guard: nil,
+      action: nil
+    })
+
+    :ok
+  end
+
+  @doc false
+  @spec __close_transition__!(module()) :: :ok
+  def __close_transition__!(module) do
+    scope = Module.get_attribute(module, @scope_attr)
+
+    if is_nil(scope) do
+      raise CompileError,
+        description: "internal error: closing transition that wasn't opened",
+        file: source_file(module),
+        line: 0
+    end
+
+    arcs =
+      scope.arcs
+      |> Enum.reverse()
+      |> Enum.map(fn %Arc{} = arc -> %Arc{arc | transition: scope.name} end)
+
+    transition = %Transition{
+      name: scope.name,
+      guard: scope.guard,
+      action: build_action(scope.action)
+    }
+
+    Module.put_attribute(module, :cf_transitions, transition)
+
+    Enum.each(arcs, fn arc ->
+      Module.put_attribute(module, :cf_arcs, arc)
+    end)
+
+    Module.delete_attribute(module, @scope_attr)
+    :ok
+  end
+
+  @doc false
+  @spec __push_arc__(module(), Arc.t()) :: :ok
+  def __push_arc__(module, %Arc{} = arc) do
+    case Module.get_attribute(module, @scope_attr) do
+      nil ->
+        raise CompileError,
+          description: "input/output may only be used inside a `transition do ... end` block",
+          file: source_file(module),
+          line: 0
+
+      scope ->
+        Module.put_attribute(module, @scope_attr, %{scope | arcs: [arc | scope.arcs]})
+    end
+
+    :ok
+  end
+
+  @doc false
+  @spec __set_guard__!(module(), Expression.t()) :: :ok
+  def __set_guard__!(module, guard) do
+    case Module.get_attribute(module, @scope_attr) do
+      nil ->
+        raise CompileError,
+          description: "guard may only be used inside a `transition do ... end` block",
+          file: source_file(module),
+          line: 0
+
+      scope ->
+        Module.put_attribute(module, @scope_attr, %{scope | guard: guard})
+    end
+
+    :ok
+  end
+
+  @doc false
+  @spec __set_action__!(module(), String.t()) :: :ok
+  def __set_action__!(module, code) do
+    case Module.get_attribute(module, @scope_attr) do
+      nil ->
+        raise CompileError,
+          description: "action may only be used inside a `transition do ... end` block",
+          file: source_file(module),
+          line: 0
+
+      scope ->
+        Module.put_attribute(module, @scope_attr, %{scope | action: code})
+    end
+
+    :ok
+  end
+
+  defp build_action(nil), do: %Action{payload: nil, outputs: []}
+
+  defp build_action(code) when is_binary(code) do
+    %Action{payload: code, outputs: []}
+  end
+
+  @spec unquote_atom!(Macro.t(), String.t()) :: atom()
+  defp unquote_atom!(value, _label) when is_atom(value), do: value
+
+  defp unquote_atom!(value, label) do
+    raise ArgumentError, "Expected #{label} to be an atom, got: #{Macro.to_string(value)}"
+  end
+
+  defp source_file(module) do
+    case Module.get_attribute(module, :file) do
+      nil -> "nofile"
+      src -> to_string(src)
+    end
+  rescue
+    _error -> "nofile"
+  end
+end

--- a/lib/coloured_flow/dsl/transition.ex
+++ b/lib/coloured_flow/dsl/transition.ex
@@ -35,7 +35,9 @@ defmodule ColouredFlow.DSL.Transition do
       end
   """
   defmacro transition(name, opts \\ []) do
-    name_value = unquote_atom!(name, "transition name")
+    caller_file = __CALLER__.file
+    caller_line = __CALLER__.line
+    name_value = unquote_atom!(name, "transition name", __CALLER__)
     name_str = Atom.to_string(name_value)
 
     block =
@@ -45,12 +47,19 @@ defmodule ColouredFlow.DSL.Transition do
       end
 
     if is_nil(block) do
-      raise ArgumentError,
-            "transition/2 requires a `do ... end` block, got: #{inspect(opts)}"
+      raise CompileError,
+        description: "transition/2 requires a `do ... end` block, got: #{inspect(opts)}",
+        file: caller_file,
+        line: caller_line
     end
 
     quote do
-      ColouredFlow.DSL.Transition.__open_transition__!(__MODULE__, unquote(name_str))
+      ColouredFlow.DSL.Transition.__open_transition__!(
+        __MODULE__,
+        unquote(name_str),
+        unquote(caller_file),
+        unquote(caller_line)
+      )
 
       unquote(block)
 
@@ -70,11 +79,18 @@ defmodule ColouredFlow.DSL.Transition do
       end
   """
   defmacro guard(expression) do
+    caller_file = __CALLER__.file
+    caller_line = __CALLER__.line
     expr_ast = ExpressionHelper.block_to_ast(expression)
     expr = ExpressionHelper.build_from_ast!(expr_ast)
 
     quote do
-      ColouredFlow.DSL.Transition.__set_guard__!(__MODULE__, unquote(Macro.escape(expr)))
+      ColouredFlow.DSL.Transition.__set_guard__!(
+        __MODULE__,
+        unquote(Macro.escape(expr)),
+        unquote(caller_file),
+        unquote(caller_line)
+      )
     end
   end
 
@@ -92,22 +108,29 @@ defmodule ColouredFlow.DSL.Transition do
       end
   """
   defmacro action(expression) do
+    caller_file = __CALLER__.file
+    caller_line = __CALLER__.line
     expr_ast = ExpressionHelper.block_to_ast(expression)
     code = ExpressionHelper.ast_to_code(expr_ast)
 
     quote do
-      ColouredFlow.DSL.Transition.__set_action__!(__MODULE__, unquote(code))
+      ColouredFlow.DSL.Transition.__set_action__!(
+        __MODULE__,
+        unquote(code),
+        unquote(caller_file),
+        unquote(caller_line)
+      )
     end
   end
 
   @doc false
-  @spec __open_transition__!(module(), String.t()) :: :ok
-  def __open_transition__!(module, name) when is_atom(module) and is_binary(name) do
+  @spec __open_transition__!(module(), String.t(), String.t(), non_neg_integer()) :: :ok
+  def __open_transition__!(module, name, file, line) when is_atom(module) and is_binary(name) do
     if Module.get_attribute(module, @scope_attr) do
       raise CompileError,
         description: "transition/2 cannot be nested",
-        file: source_file(module),
-        line: 0
+        file: file,
+        line: line
     end
 
     Module.put_attribute(module, @scope_attr, %{
@@ -154,14 +177,14 @@ defmodule ColouredFlow.DSL.Transition do
   end
 
   @doc false
-  @spec __push_arc__(module(), Arc.t()) :: :ok
-  def __push_arc__(module, %Arc{} = arc) do
+  @spec __push_arc__(module(), Arc.t(), String.t(), non_neg_integer()) :: :ok
+  def __push_arc__(module, %Arc{} = arc, file, line) do
     case Module.get_attribute(module, @scope_attr) do
       nil ->
         raise CompileError,
           description: "input/output may only be used inside a `transition do ... end` block",
-          file: source_file(module),
-          line: 0
+          file: file,
+          line: line
 
       scope ->
         Module.put_attribute(module, @scope_attr, %{scope | arcs: [arc | scope.arcs]})
@@ -171,34 +194,46 @@ defmodule ColouredFlow.DSL.Transition do
   end
 
   @doc false
-  @spec __set_guard__!(module(), Expression.t()) :: :ok
-  def __set_guard__!(module, guard) do
+  @spec __set_guard__!(module(), Expression.t(), String.t(), non_neg_integer()) :: :ok
+  def __set_guard__!(module, guard, file, line) do
     case Module.get_attribute(module, @scope_attr) do
       nil ->
         raise CompileError,
           description: "guard may only be used inside a `transition do ... end` block",
-          file: source_file(module),
-          line: 0
+          file: file,
+          line: line
 
-      scope ->
+      %{guard: nil} = scope ->
         Module.put_attribute(module, @scope_attr, %{scope | guard: guard})
+
+      %{guard: _existing} ->
+        raise CompileError,
+          description: "guard already declared in this transition",
+          file: file,
+          line: line
     end
 
     :ok
   end
 
   @doc false
-  @spec __set_action__!(module(), String.t()) :: :ok
-  def __set_action__!(module, code) do
+  @spec __set_action__!(module(), String.t(), String.t(), non_neg_integer()) :: :ok
+  def __set_action__!(module, code, file, line) do
     case Module.get_attribute(module, @scope_attr) do
       nil ->
         raise CompileError,
           description: "action may only be used inside a `transition do ... end` block",
-          file: source_file(module),
-          line: 0
+          file: file,
+          line: line
 
-      scope ->
+      %{action: nil} = scope ->
         Module.put_attribute(module, @scope_attr, %{scope | action: code})
+
+      %{action: _existing} ->
+        raise CompileError,
+          description: "action already declared in this transition",
+          file: file,
+          line: line
     end
 
     :ok
@@ -210,11 +245,14 @@ defmodule ColouredFlow.DSL.Transition do
     %Action{payload: code, outputs: []}
   end
 
-  @spec unquote_atom!(Macro.t(), String.t()) :: atom()
-  defp unquote_atom!(value, _label) when is_atom(value), do: value
+  @spec unquote_atom!(Macro.t(), String.t(), Macro.Env.t()) :: atom()
+  defp unquote_atom!(value, _label, _caller) when is_atom(value), do: value
 
-  defp unquote_atom!(value, label) do
-    raise ArgumentError, "Expected #{label} to be an atom, got: #{Macro.to_string(value)}"
+  defp unquote_atom!(value, label, caller) do
+    raise CompileError,
+      description: "Expected #{label} to be an atom, got: #{Macro.to_string(value)}",
+      file: caller.file,
+      line: caller.line
   end
 
   defp source_file(module) do

--- a/lib/coloured_flow/notation/colset.ex
+++ b/lib/coloured_flow/notation/colset.ex
@@ -29,7 +29,7 @@ defmodule ColouredFlow.Notation.Colset do
   @spec __colset__(Macro.t()) :: {name :: Macro.t(), type :: Macro.t()}
   def __colset__({:"::", _meta, [name, type]}) do
     name = name |> decompose_name() |> Macro.escape()
-    type = type |> decompose_type() |> Macro.escape()
+    type = type |> __decompose_type__() |> Macro.escape()
 
     {name, type}
   end
@@ -40,6 +40,19 @@ defmodule ColouredFlow.Notation.Colset do
     See the documentation for valid colour set declarations at `ColouredFlow.Definition.ColourSet`.
     """
   end
+
+  @doc """
+  Decompose a colour-set type AST into a
+  `t:ColouredFlow.Definition.ColourSet.descr/0`.
+
+  Public-ish helper (matches the `__colset__/1` convention) so other DSL modules —
+  notably `ColouredFlow.DSL.Function` — can reuse the same parser without
+  duplicating clauses. Names that resolve to user-defined colour sets stay in
+  `{name, []}` form; callers needing primitive descrs must resolve them separately
+  (see `ColouredFlow.DSL.Builder.resolve_descr/2`).
+  """
+  @spec __decompose_type__(Macro.t()) :: ColourSet.descr()
+  def __decompose_type__(type), do: decompose_type(type)
 
   @name_example """
   Valid examples:

--- a/lib/coloured_flow/validators/definition/functions_validator.ex
+++ b/lib/coloured_flow/validators/definition/functions_validator.ex
@@ -1,0 +1,104 @@
+defmodule ColouredFlow.Validators.Definition.FunctionsValidator do
+  @moduledoc """
+  This validator ensures that procedures (a.k.a. functions) within a ColouredFlow
+  definition are valid.
+
+  It validates these aspects of a procedure:
+
+  1. Procedure names are unique within the net.
+  2. The `result` descr of each procedure is fully resolved: every leaf terminates
+     at a primitive type, or at a colour set declared in `cpnet.colour_sets`. No
+     leaf may reference an unresolved user-defined name.
+  """
+
+  alias ColouredFlow.Definition.ColourSet
+  alias ColouredFlow.Definition.ColouredPetriNet
+  alias ColouredFlow.Definition.Procedure
+  alias ColouredFlow.Validators.Exceptions.MissingColourSetError
+  alias ColouredFlow.Validators.Exceptions.UniqueNameViolationError
+
+  @spec validate(ColouredPetriNet.t()) ::
+          {:ok, ColouredPetriNet.t()}
+          | {:error, UniqueNameViolationError.t() | MissingColourSetError.t()}
+  def validate(%ColouredPetriNet{functions: []} = cpnet), do: {:ok, cpnet}
+
+  def validate(%ColouredPetriNet{} = cpnet) do
+    declared_colour_sets = MapSet.new(cpnet.colour_sets, & &1.name)
+
+    with :ok <- validate_unique_names(cpnet.functions),
+         :ok <- validate_results_resolved(cpnet.functions, declared_colour_sets) do
+      {:ok, cpnet}
+    end
+  end
+
+  @spec validate_unique_names([Procedure.t()]) ::
+          :ok | {:error, UniqueNameViolationError.t()}
+  defp validate_unique_names(functions) do
+    functions
+    |> Enum.reduce_while(MapSet.new(), fn %Procedure{name: name}, seen ->
+      if MapSet.member?(seen, name) do
+        {:halt, {:error, UniqueNameViolationError.exception(scope: :function, name: name)}}
+      else
+        {:cont, MapSet.put(seen, name)}
+      end
+    end)
+    |> case do
+      {:error, _exception} = error -> error
+      _seen -> :ok
+    end
+  end
+
+  @spec validate_results_resolved([Procedure.t()], MapSet.t(ColourSet.name())) ::
+          :ok | {:error, MissingColourSetError.t()}
+  defp validate_results_resolved(functions, declared_colour_sets) do
+    Enum.reduce_while(functions, :ok, fn %Procedure{} = procedure, :ok ->
+      case find_unresolved_descr(procedure.result, declared_colour_sets) do
+        nil ->
+          {:cont, :ok}
+
+        unresolved_name ->
+          {:halt, {:error, missing_colour_set_error(procedure, unresolved_name)}}
+      end
+    end)
+  end
+
+  @spec find_unresolved_descr(ColourSet.descr(), MapSet.t(ColourSet.name())) ::
+          ColourSet.name() | nil
+  defp find_unresolved_descr(descr, declared)
+
+  defp find_unresolved_descr({:integer, []}, _declared), do: nil
+  defp find_unresolved_descr({:float, []}, _declared), do: nil
+  defp find_unresolved_descr({:boolean, []}, _declared), do: nil
+  defp find_unresolved_descr({:binary, []}, _declared), do: nil
+  defp find_unresolved_descr({:unit, []}, _declared), do: nil
+
+  defp find_unresolved_descr({:tuple, types}, declared) when is_list(types) do
+    Enum.find_value(types, &find_unresolved_descr(&1, declared))
+  end
+
+  defp find_unresolved_descr({:map, types}, declared) when is_map(types) do
+    Enum.find_value(types, fn {_key, descr} -> find_unresolved_descr(descr, declared) end)
+  end
+
+  defp find_unresolved_descr({:enum, items}, _declared) when is_list(items), do: nil
+
+  defp find_unresolved_descr({:union, types}, declared) when is_map(types) do
+    Enum.find_value(types, fn {_tag, descr} -> find_unresolved_descr(descr, declared) end)
+  end
+
+  defp find_unresolved_descr({:list, type}, declared), do: find_unresolved_descr(type, declared)
+
+  defp find_unresolved_descr({name, []}, declared) when is_atom(name) do
+    if MapSet.member?(declared, name), do: nil, else: name
+  end
+
+  @spec missing_colour_set_error(Procedure.t(), ColourSet.name()) :: MissingColourSetError.t()
+  defp missing_colour_set_error(%Procedure{} = procedure, unresolved_name) do
+    MissingColourSetError.exception(
+      colour_set: unresolved_name,
+      message: """
+      procedure #{inspect(procedure.name)} declares a result that references the unknown colour set #{inspect(unresolved_name)}
+      """
+    )
+  end
+end

--- a/lib/coloured_flow/validators/definition/guard_validator.ex
+++ b/lib/coloured_flow/validators/definition/guard_validator.ex
@@ -33,9 +33,13 @@ defmodule ColouredFlow.Validators.Definition.GuardValidator do
     :ok
   end
 
-  defp validate_guard(%Transition{guard: %Expression{} = guard}, %ColouredPetriNet{} = cpnet) do
+  defp validate_guard(
+         %Transition{guard: %Expression{} = guard} = transition,
+         %ColouredPetriNet{} = cpnet
+       ) do
     bound_vars =
       cpnet.arcs
+      |> Enum.filter(&(&1.transition == transition.name))
       |> Enum.flat_map(fn
         %Arc{orientation: :p_to_t} = arc -> arc.expression.vars
         %Arc{} -> []

--- a/lib/coloured_flow/validators/definition/places_validator.ex
+++ b/lib/coloured_flow/validators/definition/places_validator.ex
@@ -1,0 +1,41 @@
+defmodule ColouredFlow.Validators.Definition.PlacesValidator do
+  @moduledoc """
+  The places validator ensures that each place in a ColouredFlow definition
+  references a declared colour set.
+  """
+
+  alias ColouredFlow.Definition.ColouredPetriNet
+  alias ColouredFlow.Definition.Place
+  alias ColouredFlow.Validators.Exceptions.MissingColourSetError
+
+  @doc """
+  Validate that every `%Place{}` in `cpnet.places` references a colour set present
+  in `cpnet.colour_sets`. Returns `{:ok, cpnet}` on success, or
+  `{:error, MissingColourSetError.t()}` for the first offending place.
+  """
+  @spec validate(ColouredPetriNet.t()) ::
+          {:ok, ColouredPetriNet.t()} | {:error, MissingColourSetError.t()}
+  def validate(%ColouredPetriNet{} = cpnet) do
+    colour_sets = MapSet.new(cpnet.colour_sets, & &1.name)
+
+    cpnet.places
+    |> Enum.find(fn %Place{} = place ->
+      not MapSet.member?(colour_sets, place.colour_set)
+    end)
+    |> case do
+      nil ->
+        {:ok, cpnet}
+
+      %Place{} = place ->
+        {
+          :error,
+          MissingColourSetError.exception(
+            colour_set: place.colour_set,
+            message: """
+            place #{inspect(place.name)} references unknown colour set #{inspect(place.colour_set)}
+            """
+          )
+        }
+    end
+  end
+end

--- a/lib/coloured_flow/validators/exceptions/unique_name_violation_error.ex
+++ b/lib/coloured_flow/validators/exceptions/unique_name_violation_error.ex
@@ -7,7 +7,7 @@ defmodule ColouredFlow.Validators.Exceptions.UniqueNameViolationError do
   use TypedStructor
 
   typed_structor definer: :defexception, enforce: true do
-    field :scope, :colour_set | :variable | :place | :transition
+    field :scope, :colour_set | :variable | :place | :transition | :function
     field :name, String.t() | atom()
   end
 

--- a/lib/coloured_flow/validators/validators.ex
+++ b/lib/coloured_flow/validators/validators.ex
@@ -10,6 +10,7 @@ defmodule ColouredFlow.Validators do
   alias ColouredFlow.Validators.Definition.ColourSetValidator
   alias ColouredFlow.Validators.Definition.ConstantsValidator
   alias ColouredFlow.Validators.Definition.GuardValidator
+  alias ColouredFlow.Validators.Definition.PlacesValidator
   alias ColouredFlow.Validators.Definition.StructureValidator
   alias ColouredFlow.Validators.Definition.TerminationCriteriaValidator
   alias ColouredFlow.Validators.Definition.UniqueNameValidator
@@ -22,6 +23,7 @@ defmodule ColouredFlow.Validators do
       {:ok, %ColouredPetriNet{} = cpnet} <- StructureValidator.validate(cpnet),
       {:ok, %ColouredPetriNet{} = cpnet} <- UniqueNameValidator.validate(cpnet),
       {:ok, %ColouredPetriNet{} = cpnet} <- ColourSetValidator.validate(cpnet),
+      {:ok, %ColouredPetriNet{} = cpnet} <- PlacesValidator.validate(cpnet),
       {:ok, constants} <- ConstantsValidator.validate(cpnet.constants, cpnet),
       cpnet = %{cpnet | constants: constants},
       {:ok, variables} <- VariablesValidator.validate(cpnet.variables, cpnet),

--- a/lib/coloured_flow/validators/validators.ex
+++ b/lib/coloured_flow/validators/validators.ex
@@ -9,6 +9,7 @@ defmodule ColouredFlow.Validators do
   alias ColouredFlow.Validators.Definition.ArcValidator
   alias ColouredFlow.Validators.Definition.ColourSetValidator
   alias ColouredFlow.Validators.Definition.ConstantsValidator
+  alias ColouredFlow.Validators.Definition.FunctionsValidator
   alias ColouredFlow.Validators.Definition.GuardValidator
   alias ColouredFlow.Validators.Definition.PlacesValidator
   alias ColouredFlow.Validators.Definition.StructureValidator
@@ -24,6 +25,7 @@ defmodule ColouredFlow.Validators do
       {:ok, %ColouredPetriNet{} = cpnet} <- UniqueNameValidator.validate(cpnet),
       {:ok, %ColouredPetriNet{} = cpnet} <- ColourSetValidator.validate(cpnet),
       {:ok, %ColouredPetriNet{} = cpnet} <- PlacesValidator.validate(cpnet),
+      {:ok, %ColouredPetriNet{} = cpnet} <- FunctionsValidator.validate(cpnet),
       {:ok, constants} <- ConstantsValidator.validate(cpnet.constants, cpnet),
       cpnet = %{cpnet | constants: constants},
       {:ok, variables} <- VariablesValidator.validate(cpnet.variables, cpnet),

--- a/test/coloured_flow/definition/presentation_test.exs
+++ b/test/coloured_flow/definition/presentation_test.exs
@@ -62,13 +62,13 @@ defmodule ColouredFlow.Definition.PresentationTest do
           a --bind {1, {n, d}}--> transmit_packet
           send_packet --{1, {n, d}}--> a
           b --bind {1, {n, d}}--> receive_packet
-          transmit_packet --if success do: {1, {n, d}}, else: {0, {n, d}}--> b
+          transmit_packet --if success, do: {1, {n, d}}, else: {0, {n, d}}--> b
           c --bind {1, n}--> transmit_ack
           receive_packet --if n == k, do: {1, k + 1}, else: {1, k}--> c
           d --bind {1, n}--> receive_ack
-          transmit_ack --if success do: {1, n}, else: {0, n}--> d
+          transmit_ack --if success, do: {1, n}, else: {0, n}--> d
           data_recevied --bind {1, data}--> receive_packet
-          receive_packet --if n == k do: {1, data <> d}, else: {1, data}--> data_recevied
+          receive_packet --if n == k, do: {1, data <> d}, else: {1, data}--> data_recevied
           next_rec --bind {1, k}--> receive_packet
           receive_packet --if n == k, do: {1, k + 1}, else: {1, k}--> next_rec
           next_send --bind {1, k}--> receive_ack

--- a/test/coloured_flow/dsl/arc_test.exs
+++ b/test/coloured_flow/dsl/arc_test.exs
@@ -163,5 +163,39 @@ defmodule ColouredFlow.DSL.ArcTest do
         end
       end
     end
+
+    test "rejects do block when arg2 is not a keyword list of options" do
+      source = """
+      defmodule ColouredFlow.DSL.ArcTest.ArcExprBeforeDo do
+        use ColouredFlow.DSL
+
+        name "ArcExprBeforeDo"
+
+        colset int() :: integer()
+
+        var x :: int()
+
+        place :input, :int
+        place :output, :int
+
+        transition :t do
+          input :input, bind({1, x}) do
+            bind({2, x})
+          end
+
+          output :output, {1, x}
+        end
+      end
+      """
+
+      error =
+        assert_raise CompileError, ~r/options.+before.+do/i, fn ->
+          Code.compile_string(source, "arc_expr_before_do.exs")
+        end
+
+      assert error.file == "arc_expr_before_do.exs"
+      # Points at the offending `input :input, bind({1, x}) do ... end` (line 14, 1-indexed).
+      assert error.line == 14
+    end
   end
 end

--- a/test/coloured_flow/dsl/arc_test.exs
+++ b/test/coloured_flow/dsl/arc_test.exs
@@ -1,0 +1,167 @@
+defmodule ColouredFlow.DSL.ArcTest do
+  use ExUnit.Case, async: true
+
+  alias ColouredFlow.Definition.Arc
+
+  describe "input/2" do
+    test "creates a :p_to_t arc with single-line bind" do
+      defmodule InputBare do
+        use ColouredFlow.DSL
+
+        name("InputBare")
+
+        colset int() :: integer()
+
+        var x :: int()
+
+        place(:input, :int)
+        place(:output, :int)
+
+        transition :t do
+          input(:input, bind({1, x}))
+          output(:output, {1, x})
+        end
+      end
+
+      cpnet = InputBare.cpnet()
+      assert [in_arc, out_arc] = cpnet.arcs
+      assert %Arc{orientation: :p_to_t, place: "input", transition: "t"} = in_arc
+      assert in_arc.label == nil
+      assert in_arc.expression.code =~ "bind"
+      assert in_arc.expression.vars == [:x]
+
+      assert %Arc{orientation: :t_to_p, place: "output", transition: "t"} = out_arc
+    end
+  end
+
+  describe "input/3 with label" do
+    test "stores the label" do
+      defmodule InputLabel do
+        use ColouredFlow.DSL
+
+        name("InputLabel")
+
+        colset int() :: integer()
+
+        var x :: int()
+
+        place(:input, :int)
+        place(:output, :int)
+
+        transition :t do
+          input(:input, bind({1, x}), label: "in")
+          output(:output, {1, x}, label: "out")
+        end
+      end
+
+      cpnet = InputLabel.cpnet()
+      [in_arc, out_arc] = cpnet.arcs
+
+      assert in_arc.label == "in"
+      assert out_arc.label == "out"
+    end
+  end
+
+  describe "input/2 with do block" do
+    test "uses block body as the expression, supports label option" do
+      defmodule InputBlock do
+        use ColouredFlow.DSL
+
+        name("InputBlock")
+
+        colset int() :: integer()
+
+        var x :: int()
+
+        place(:input, :int)
+        place(:output, :int)
+
+        transition :t do
+          input :input, label: "in" do
+            if x > 0, do: bind({1, x}), else: bind({0, x})
+          end
+
+          output :output, label: "out" do
+            if x > 0, do: {1, x}, else: {0, x}
+          end
+        end
+      end
+
+      cpnet = InputBlock.cpnet()
+      [in_arc, out_arc] = cpnet.arcs
+
+      assert in_arc.label == "in"
+      assert in_arc.expression.code =~ "bind"
+      assert out_arc.label == "out"
+    end
+  end
+
+  describe "validation" do
+    test "rejects p_to_t arc without bind" do
+      assert_raise RuntimeError, ~r/missing `bind`/, fn ->
+        defmodule MissingBind do
+          use ColouredFlow.DSL
+
+          name "MissingBind"
+
+          colset int() :: integer()
+
+          var x :: int()
+
+          place :input, :int
+          place :output, :int
+
+          transition :t do
+            input :input, {1, x}
+            output :output, {1, x}
+          end
+        end
+      end
+    end
+
+    test "rejects arc referencing unknown place" do
+      # The general StructureValidator surfaces unknown arc endpoints under
+      # the `:missing_nodes` reason ("Places: [\"ghost\"]").
+      assert_raise CompileError, ~r/missing.+ghost/is, fn ->
+        defmodule UnknownArcPlace do
+          use ColouredFlow.DSL
+
+          name "UnknownArcPlace"
+
+          colset int() :: integer()
+
+          var x :: int()
+
+          place :input, :int
+          place :output, :int
+
+          transition :t do
+            input :ghost, bind({1, x})
+            output :output, {1, x}
+          end
+        end
+      end
+    end
+
+    test "rejects free var not declared as var/1 or constant" do
+      assert_raise CompileError, ~r/unbound|unknown_vars|incoming/i, fn ->
+        defmodule UnboundVar do
+          use ColouredFlow.DSL
+
+          name "UnboundVar"
+
+          colset int() :: integer()
+
+          # x is not declared as var
+          place :input, :int
+          place :output, :int
+
+          transition :t do
+            input :input, bind({1, x})
+            output :output, {1, x}
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/coloured_flow/dsl/arc_test.exs
+++ b/test/coloured_flow/dsl/arc_test.exs
@@ -8,18 +8,18 @@ defmodule ColouredFlow.DSL.ArcTest do
       defmodule InputBare do
         use ColouredFlow.DSL
 
-        name("InputBare")
+        name "InputBare"
 
         colset int() :: integer()
 
         var x :: int()
 
-        place(:input, :int)
-        place(:output, :int)
+        place :input, :int
+        place :output, :int
 
         transition :t do
-          input(:input, bind({1, x}))
-          output(:output, {1, x})
+          input :input, bind({1, x})
+          output :output, {1, x}
         end
       end
 
@@ -39,18 +39,18 @@ defmodule ColouredFlow.DSL.ArcTest do
       defmodule InputLabel do
         use ColouredFlow.DSL
 
-        name("InputLabel")
+        name "InputLabel"
 
         colset int() :: integer()
 
         var x :: int()
 
-        place(:input, :int)
-        place(:output, :int)
+        place :input, :int
+        place :output, :int
 
         transition :t do
-          input(:input, bind({1, x}), label: "in")
-          output(:output, {1, x}, label: "out")
+          input :input, bind({1, x}), label: "in"
+          output :output, {1, x}, label: "out"
         end
       end
 
@@ -67,14 +67,14 @@ defmodule ColouredFlow.DSL.ArcTest do
       defmodule InputBlock do
         use ColouredFlow.DSL
 
-        name("InputBlock")
+        name "InputBlock"
 
         colset int() :: integer()
 
         var x :: int()
 
-        place(:input, :int)
-        place(:output, :int)
+        place :input, :int
+        place :output, :int
 
         transition :t do
           input :input, label: "in" do

--- a/test/coloured_flow/dsl/builder_test.exs
+++ b/test/coloured_flow/dsl/builder_test.exs
@@ -1,0 +1,107 @@
+defmodule ColouredFlow.DSL.BuilderTest do
+  use ExUnit.Case, async: true
+
+  describe "validator-driven errors point to the offending declaration" do
+    test "place referencing an unknown colour set points at the place call site" do
+      source = """
+      defmodule ColouredFlow.DSL.BuilderTest.PlaceUnknownColset do
+        use ColouredFlow.DSL
+
+        name "PlaceUnknownColset"
+
+        colset int() :: integer()
+
+        var x :: int()
+
+        place :input, :int
+        place :output, :ghost
+
+        transition :t do
+          input :input, bind({1, x})
+          output :output, {1, x}
+        end
+      end
+      """
+
+      error =
+        assert_raise CompileError, ~r/colour set|undefined|unknown/i, fn ->
+          Code.compile_string(source, "place_unknown_colset.exs")
+        end
+
+      assert error.file == "place_unknown_colset.exs"
+      # Points at `place :output, :ghost` (line 11, 1-indexed).
+      assert error.line == 11
+    end
+
+    test "duplicate function name points at the second declaration" do
+      source = """
+      defmodule ColouredFlow.DSL.BuilderTest.DuplicateFunction do
+        use ColouredFlow.DSL
+
+        name "DuplicateFunction"
+
+        colset int() :: integer()
+
+        function double(x) :: int() do
+          x * 2
+        end
+
+        function double(x) :: int() do
+          x * 3
+        end
+
+        var x :: int()
+
+        place :input, :int
+        place :output, :int
+
+        transition :t do
+          input :input, bind({1, x})
+          output :output, {1, x}
+        end
+      end
+      """
+
+      error =
+        assert_raise CompileError, ~r/unique|duplicate|already/i, fn ->
+          Code.compile_string(source, "duplicate_function.exs")
+        end
+
+      assert error.file == "duplicate_function.exs"
+      # Points at the second `function double(x)` (line 12, 1-indexed).
+      assert error.line == 12
+    end
+
+    test "duplicate colset name points at the second declaration" do
+      source = """
+      defmodule ColouredFlow.DSL.BuilderTest.DuplicateColset do
+        use ColouredFlow.DSL
+
+        name "DuplicateColset"
+
+        colset int() :: integer()
+        colset int() :: integer()
+
+        var x :: int()
+
+        place :input, :int
+        place :output, :int
+
+        transition :t do
+          input :input, bind({1, x})
+          output :output, {1, x}
+        end
+      end
+      """
+
+      error =
+        assert_raise CompileError, ~r/unique|duplicate|already/i, fn ->
+          Code.compile_string(source, "duplicate_colset.exs")
+        end
+
+      assert error.file == "duplicate_colset.exs"
+      # Points at the second `colset int()` (line 7, 1-indexed).
+      assert error.line == 7
+    end
+  end
+end

--- a/test/coloured_flow/dsl/cpnet_examples_test.exs
+++ b/test/coloured_flow/dsl/cpnet_examples_test.exs
@@ -15,12 +15,12 @@ defmodule ColouredFlow.DSL.CpnetExamplesTest do
 
     var x :: int()
 
-    place(:input, :int)
-    place(:output, :int)
+    place :input, :int
+    place :output, :int
 
     transition :pass_through do
-      input(:input, bind({1, x}), label: "in")
-      output(:output, {1, x}, label: "out")
+      input :input, bind({1, x}), label: "in"
+      output :output, {1, x}, label: "out"
     end
   end
 
@@ -31,24 +31,24 @@ defmodule ColouredFlow.DSL.CpnetExamplesTest do
 
     var x :: int()
 
-    place(:input, :int)
-    place(:place, :int)
-    place(:output_1, :int)
-    place(:output_2, :int)
+    place :input, :int
+    place :place, :int
+    place :output_1, :int
+    place :output_2, :int
 
     transition :pass_through do
-      input(:input, bind({1, x}))
-      output(:place, {1, x})
+      input :input, bind({1, x})
+      output :place, {1, x}
     end
 
     transition :deferred_choice_1 do
-      input(:place, bind({1, x}))
-      output(:output_1, {1, x})
+      input :place, bind({1, x})
+      output :output_1, {1, x}
     end
 
     transition :deferred_choice_2 do
-      input(:place, bind({1, x}))
-      output(:output_2, {1, x})
+      input :place, bind({1, x})
+      output :output_2, {1, x}
     end
   end
 
@@ -59,26 +59,26 @@ defmodule ColouredFlow.DSL.CpnetExamplesTest do
 
     var x :: int()
 
-    place(:input, :int)
-    place(:place_1, :int)
-    place(:place_2, :int)
-    place(:output_1, :int)
-    place(:output_2, :int)
+    place :input, :int
+    place :place_1, :int
+    place :place_2, :int
+    place :output_1, :int
+    place :output_2, :int
 
     transition :parallel_split do
-      input(:input, bind({1, x}))
-      output(:place_1, {1, x})
-      output(:place_2, {1, x})
+      input :input, bind({1, x})
+      output :place_1, {1, x}
+      output :place_2, {1, x}
     end
 
     transition :pass_through_1 do
-      input(:place_1, bind({1, x}))
-      output(:output_1, {1, x})
+      input :place_1, bind({1, x})
+      output :output_1, {1, x}
     end
 
     transition :pass_through_2 do
-      input(:place_2, bind({1, x}))
-      output(:output_2, {1, x})
+      input :place_2, bind({1, x})
+      output :output_2, {1, x}
     end
   end
 
@@ -89,17 +89,17 @@ defmodule ColouredFlow.DSL.CpnetExamplesTest do
 
     var x :: int()
 
-    place(:input1, :int)
-    place(:input2, :int)
-    place(:input3, :int)
-    place(:output, :int)
+    place :input1, :int
+    place :input2, :int
+    place :input3, :int
+    place :output, :int
 
     transition :and_join do
-      input(:input1, bind({1, x}), label: "input1")
-      input(:input2, bind({1, x}), label: "input2")
-      input(:input3, bind({1, x}), label: "input3")
+      input :input1, bind({1, x}), label: "input1"
+      input :input2, bind({1, x}), label: "input2"
+      input :input3, bind({1, x}), label: "input3"
 
-      output(:output, {1, x}, label: "output")
+      output :output, {1, x}, label: "output"
     end
   end
 
@@ -110,23 +110,23 @@ defmodule ColouredFlow.DSL.CpnetExamplesTest do
 
     var x :: int()
 
-    place(:input, :int)
-    place(:merge, :int)
-    place(:output, :int)
+    place :input, :int
+    place :merge, :int
+    place :output, :int
 
     transition :branch_1 do
-      input(:input, bind({1, x}))
-      output(:merge, {1, x})
+      input :input, bind({1, x})
+      output :merge, {1, x}
     end
 
     transition :branch_2 do
-      input(:input, bind({1, x}))
-      output(:merge, {1, x})
+      input :input, bind({1, x})
+      output :merge, {1, x}
     end
 
     transition :thread_merge do
-      input(:merge, bind({2, 1}))
-      output(:output, {1, 1})
+      input :merge, bind({2, 1})
+      output :output, {1, 1}
     end
   end
 
@@ -144,51 +144,51 @@ defmodule ColouredFlow.DSL.CpnetExamplesTest do
     var data :: data()
     var success :: bool()
 
-    place(:packets_to_send, :no_data)
-    place(:a, :no_data)
-    place(:b, :no_data)
-    place(:data_recevied, :data)
-    place(:next_rec, :no)
-    place(:c, :no)
-    place(:d, :no)
-    place(:next_send, :no)
+    place :packets_to_send, :no_data
+    place :a, :no_data
+    place :b, :no_data
+    place :data_recevied, :data
+    place :next_rec, :no
+    place :c, :no
+    place :d, :no
+    place :next_send, :no
 
     transition :send_packet do
-      input(:packets_to_send, bind({1, {n, d}}))
-      input(:next_send, bind({1, {1, n}}))
+      input :packets_to_send, bind({1, {n, d}})
+      input :next_send, bind({1, {1, n}})
 
-      output(:packets_to_send, {1, {n, d}})
-      output(:a, {1, {n, d}})
-      output(:next_send, {1, {1, n}})
+      output :packets_to_send, {1, {n, d}}
+      output :a, {1, {n, d}}
+      output :next_send, {1, {1, n}}
     end
 
     transition :transmit_packet do
-      input(:a, bind({1, {n, d}}))
+      input :a, bind({1, {n, d}})
 
-      output(:b, if(success, do: {1, {n, d}}, else: {0, {n, d}}))
+      output :b, if(success, do: {1, {n, d}}, else: {0, {n, d}})
     end
 
     transition :receive_packet do
-      input(:b, bind({1, {n, d}}))
-      input(:data_recevied, bind({1, data}))
-      input(:next_rec, bind({1, k}))
+      input :b, bind({1, {n, d}})
+      input :data_recevied, bind({1, data})
+      input :next_rec, bind({1, k})
 
-      output(:data_recevied, if(n == k, do: {1, data <> d}, else: {1, data}))
-      output(:c, if(n == k, do: {1, k + 1}, else: {1, k}))
-      output(:next_rec, if(n == k, do: {1, k + 1}, else: {1, k}))
+      output :data_recevied, if(n == k, do: {1, data <> d}, else: {1, data})
+      output :c, if(n == k, do: {1, k + 1}, else: {1, k})
+      output :next_rec, if(n == k, do: {1, k + 1}, else: {1, k})
     end
 
     transition :transmit_ack do
-      input(:c, bind({1, n}))
+      input :c, bind({1, n})
 
-      output(:d, if(success, do: {1, n}, else: {0, n}))
+      output :d, if(success, do: {1, n}, else: {0, n})
     end
 
     transition :receive_ack do
-      input(:next_send, bind({1, k}))
-      input(:d, bind({1, n}))
+      input :next_send, bind({1, k})
+      input :d, bind({1, n})
 
-      output(:next_send, {1, n})
+      output :next_send, {1, n}
     end
   end
 

--- a/test/coloured_flow/dsl/cpnet_examples_test.exs
+++ b/test/coloured_flow/dsl/cpnet_examples_test.exs
@@ -1,0 +1,273 @@
+defmodule ColouredFlow.DSL.CpnetExamplesTest do
+  @moduledoc """
+  Each `:sample_cpn` from `ColouredFlow.CpnetBuilder` is reproduced via the DSL
+  and compared structurally against the builder output.
+  """
+
+  use ExUnit.Case, async: true
+
+  alias ColouredFlow.Definition.ColouredPetriNet
+
+  defmodule SimpleSequenceDSL do
+    use ColouredFlow.DSL
+
+    colset int() :: integer()
+
+    var x :: int()
+
+    place(:input, :int)
+    place(:output, :int)
+
+    transition :pass_through do
+      input(:input, bind({1, x}), label: "in")
+      output(:output, {1, x}, label: "out")
+    end
+  end
+
+  defmodule DeferredChoiceDSL do
+    use ColouredFlow.DSL
+
+    colset int() :: integer()
+
+    var x :: int()
+
+    place(:input, :int)
+    place(:place, :int)
+    place(:output_1, :int)
+    place(:output_2, :int)
+
+    transition :pass_through do
+      input(:input, bind({1, x}))
+      output(:place, {1, x})
+    end
+
+    transition :deferred_choice_1 do
+      input(:place, bind({1, x}))
+      output(:output_1, {1, x})
+    end
+
+    transition :deferred_choice_2 do
+      input(:place, bind({1, x}))
+      output(:output_2, {1, x})
+    end
+  end
+
+  defmodule ParallelSplitDSL do
+    use ColouredFlow.DSL
+
+    colset int() :: integer()
+
+    var x :: int()
+
+    place(:input, :int)
+    place(:place_1, :int)
+    place(:place_2, :int)
+    place(:output_1, :int)
+    place(:output_2, :int)
+
+    transition :parallel_split do
+      input(:input, bind({1, x}))
+      output(:place_1, {1, x})
+      output(:place_2, {1, x})
+    end
+
+    transition :pass_through_1 do
+      input(:place_1, bind({1, x}))
+      output(:output_1, {1, x})
+    end
+
+    transition :pass_through_2 do
+      input(:place_2, bind({1, x}))
+      output(:output_2, {1, x})
+    end
+  end
+
+  defmodule GeneralizedAndJoinDSL do
+    use ColouredFlow.DSL
+
+    colset int() :: integer()
+
+    var x :: int()
+
+    place(:input1, :int)
+    place(:input2, :int)
+    place(:input3, :int)
+    place(:output, :int)
+
+    transition :and_join do
+      input(:input1, bind({1, x}), label: "input1")
+      input(:input2, bind({1, x}), label: "input2")
+      input(:input3, bind({1, x}), label: "input3")
+
+      output(:output, {1, x}, label: "output")
+    end
+  end
+
+  defmodule ThreadMergeDSL do
+    use ColouredFlow.DSL
+
+    colset int() :: integer()
+
+    var x :: int()
+
+    place(:input, :int)
+    place(:merge, :int)
+    place(:output, :int)
+
+    transition :branch_1 do
+      input(:input, bind({1, x}))
+      output(:merge, {1, x})
+    end
+
+    transition :branch_2 do
+      input(:input, bind({1, x}))
+      output(:merge, {1, x})
+    end
+
+    transition :thread_merge do
+      input(:merge, bind({2, 1}))
+      output(:output, {1, 1})
+    end
+  end
+
+  defmodule TransmissionProtocolDSL do
+    use ColouredFlow.DSL
+
+    colset no() :: integer()
+    colset data() :: binary()
+    colset no_data() :: {integer(), binary()}
+    colset bool() :: boolean()
+
+    var n :: no()
+    var k :: no()
+    var d :: data()
+    var data :: data()
+    var success :: bool()
+
+    place(:packets_to_send, :no_data)
+    place(:a, :no_data)
+    place(:b, :no_data)
+    place(:data_recevied, :data)
+    place(:next_rec, :no)
+    place(:c, :no)
+    place(:d, :no)
+    place(:next_send, :no)
+
+    transition :send_packet do
+      input(:packets_to_send, bind({1, {n, d}}))
+      input(:next_send, bind({1, {1, n}}))
+
+      output(:packets_to_send, {1, {n, d}})
+      output(:a, {1, {n, d}})
+      output(:next_send, {1, {1, n}})
+    end
+
+    transition :transmit_packet do
+      input(:a, bind({1, {n, d}}))
+
+      output(:b, if(success, do: {1, {n, d}}, else: {0, {n, d}}))
+    end
+
+    transition :receive_packet do
+      input(:b, bind({1, {n, d}}))
+      input(:data_recevied, bind({1, data}))
+      input(:next_rec, bind({1, k}))
+
+      output(:data_recevied, if(n == k, do: {1, data <> d}, else: {1, data}))
+      output(:c, if(n == k, do: {1, k + 1}, else: {1, k}))
+      output(:next_rec, if(n == k, do: {1, k + 1}, else: {1, k}))
+    end
+
+    transition :transmit_ack do
+      input(:c, bind({1, n}))
+
+      output(:d, if(success, do: {1, n}, else: {0, n}))
+    end
+
+    transition :receive_ack do
+      input(:next_send, bind({1, k}))
+      input(:d, bind({1, n}))
+
+      output(:next_send, {1, n})
+    end
+  end
+
+  describe "DSL produces the same cpnet as the builder" do
+    test "simple_sequence", do: assert_equivalent(:simple_sequence, SimpleSequenceDSL)
+    test "deferred_choice", do: assert_equivalent(:deferred_choice, DeferredChoiceDSL)
+    test "parallel_split", do: assert_equivalent(:parallel_split, ParallelSplitDSL)
+
+    test "generalized_and_join",
+      do: assert_equivalent(:generalized_and_join, GeneralizedAndJoinDSL)
+
+    test "thread_merge", do: assert_equivalent(:thread_merge, ThreadMergeDSL)
+
+    test "transmission_protocol",
+      do: assert_equivalent(:transmission_protocol, TransmissionProtocolDSL)
+  end
+
+  defp assert_equivalent(name, mod) do
+    # Apply the same high-level build pipeline (currently `SetActionOutputs`)
+    # the DSL runs, so action outputs computed from arc free-vars line up.
+    expected = name |> ColouredFlow.CpnetBuilder.build_cpnet() |> ColouredFlow.Builder.build()
+    actual = mod.cpnet()
+    assert normalize(actual) == normalize(expected)
+  end
+
+  defp normalize(%ColouredPetriNet{} = cpnet) do
+    %ColouredPetriNet{
+      cpnet
+      | colour_sets: Enum.sort_by(cpnet.colour_sets, & &1.name),
+        places: Enum.sort_by(cpnet.places, & &1.name),
+        transitions:
+          cpnet.transitions
+          |> Enum.map(&normalize_transition/1)
+          |> Enum.sort_by(& &1.name),
+        arcs:
+          cpnet.arcs
+          |> Enum.map(&normalize_arc/1)
+          |> Enum.sort_by(&arc_key/1),
+        variables: Enum.sort_by(cpnet.variables, & &1.name),
+        constants: Enum.sort_by(cpnet.constants, & &1.name),
+        functions:
+          cpnet.functions
+          |> Enum.map(&normalize_procedure/1)
+          |> Enum.sort_by(& &1.name)
+    }
+  end
+
+  defp normalize_transition(transition) do
+    %{transition | guard: normalize_expression(transition.guard)}
+  end
+
+  defp normalize_arc(arc) do
+    %{arc | expression: normalize_expression(arc.expression)}
+  end
+
+  defp normalize_procedure(procedure) do
+    %{procedure | expression: normalize_expression(procedure.expression)}
+  end
+
+  # The `code` field is a human-readable rendering of the AST and depends on
+  # how the AST was originally written. Two functionally identical
+  # expressions can have different `code` strings (e.g. `bind {1, x}` vs
+  # `bind({1, x})`). The semantic content lives in `vars` plus the parsed
+  # AST, so we drop `code` and the meta-line/column info from `expr` for
+  # comparison purposes.
+  defp normalize_expression(nil), do: nil
+
+  defp normalize_expression(%{code: _code, expr: expr, vars: vars} = expression) do
+    %{expression | code: nil, expr: scrub_meta(expr), vars: vars}
+  end
+
+  defp scrub_meta(ast) do
+    Macro.prewalk(ast, fn
+      {form, _meta, args} -> {form, [], args}
+      other -> other
+    end)
+  end
+
+  defp arc_key(arc) do
+    {arc.transition, arc.orientation, arc.place, arc.label || ""}
+  end
+end

--- a/test/coloured_flow/dsl/dsl_test.exs
+++ b/test/coloured_flow/dsl/dsl_test.exs
@@ -1,0 +1,37 @@
+defmodule ColouredFlow.DSLTest do
+  use ExUnit.Case, async: true
+
+  alias ColouredFlow.Definition.ColouredPetriNet
+
+  describe "use ColouredFlow.DSL end-to-end" do
+    test "produces a valid cpnet/0 from a complete workflow" do
+      defmodule SimpleSequenceDSL do
+        use ColouredFlow.DSL
+
+        name("Simple Sequence")
+        version("1.0.0")
+
+        colset int() :: integer()
+
+        var x :: int()
+
+        place(:input, :int)
+        place(:output, :int)
+
+        transition :pass_through do
+          input(:input, bind({1, x}), label: "in")
+          output(:output, {1, x}, label: "out")
+        end
+      end
+
+      assert %ColouredPetriNet{} = cpnet = SimpleSequenceDSL.cpnet()
+
+      assert SimpleSequenceDSL.__cf_name__() == "Simple Sequence"
+      assert SimpleSequenceDSL.__cf_version__() == "1.0.0"
+
+      assert length(cpnet.places) == 2
+      assert length(cpnet.transitions) == 1
+      assert length(cpnet.arcs) == 2
+    end
+  end
+end

--- a/test/coloured_flow/dsl/dsl_test.exs
+++ b/test/coloured_flow/dsl/dsl_test.exs
@@ -1,7 +1,10 @@
 defmodule ColouredFlow.DSLTest do
   use ExUnit.Case, async: true
 
+  import ColouredFlow.MultiSet, only: [sigil_MS: 2]
+
   alias ColouredFlow.Definition.ColouredPetriNet
+  alias ColouredFlow.Enactment.Marking
 
   describe "use ColouredFlow.DSL end-to-end" do
     test "produces a valid cpnet/0 from a complete workflow" do
@@ -32,6 +35,93 @@ defmodule ColouredFlow.DSLTest do
       assert length(cpnet.places) == 2
       assert length(cpnet.transitions) == 1
       assert length(cpnet.arcs) == 2
+    end
+  end
+
+  describe "initial_markings/0 accessor" do
+    test "returns an empty list when no initial markings are declared" do
+      defmodule NoInitialMarkings do
+        use ColouredFlow.DSL
+
+        name("NoInitialMarkings")
+
+        colset int() :: integer()
+
+        var x :: int()
+
+        place(:input, :int)
+        place(:output, :int)
+
+        transition :t do
+          input(:input, bind({1, x}))
+          output(:output, {1, x})
+        end
+      end
+
+      assert NoInitialMarkings.initial_markings() == []
+    end
+
+    test "returns %Marking{} structs with string place names and multiset tokens" do
+      defmodule WithInitialMarkings do
+        use ColouredFlow.DSL
+
+        name("WithInitialMarkings")
+
+        colset int() :: integer()
+
+        var x :: int()
+
+        place(:input, :int)
+        place(:output, :int)
+
+        initial_marking(:input, ~MS[1 2 3])
+
+        transition :t do
+          input(:input, bind({1, x}))
+          output(:output, {1, x})
+        end
+      end
+
+      assert [
+               %Marking{place: "input", tokens: tokens}
+             ] = WithInitialMarkings.initial_markings()
+
+      assert tokens == ~MS[1 2 3]
+    end
+
+    test "accumulates multiple initial_marking declarations across places" do
+      defmodule MultipleInitialMarkings do
+        use ColouredFlow.DSL
+
+        name("MultipleInitialMarkings")
+
+        colset int() :: integer()
+
+        var x :: int()
+
+        place(:input, :int)
+        place(:output, :int)
+
+        initial_marking(:input, ~MS[1 2])
+        initial_marking(:output, ~MS[3])
+
+        transition :t do
+          input(:input, bind({1, x}))
+          output(:output, {1, x})
+        end
+      end
+
+      markings = MultipleInitialMarkings.initial_markings()
+
+      assert length(markings) == 2
+
+      input_marking = Enum.find(markings, &(&1.place == "input"))
+      output_marking = Enum.find(markings, &(&1.place == "output"))
+
+      assert %Marking{place: "input", tokens: input_tokens} = input_marking
+      assert %Marking{place: "output", tokens: output_tokens} = output_marking
+      assert input_tokens == ~MS[1 2]
+      assert output_tokens == ~MS[3]
     end
   end
 end

--- a/test/coloured_flow/dsl/dsl_test.exs
+++ b/test/coloured_flow/dsl/dsl_test.exs
@@ -29,8 +29,8 @@ defmodule ColouredFlow.DSLTest do
 
       assert %ColouredPetriNet{} = cpnet = SimpleSequenceDSL.cpnet()
 
-      assert SimpleSequenceDSL.__cf_name__() == "Simple Sequence"
-      assert SimpleSequenceDSL.__cf_version__() == "1.0.0"
+      assert SimpleSequenceDSL.__cpn__(:name) == "Simple Sequence"
+      assert SimpleSequenceDSL.__cpn__(:version) == "1.0.0"
 
       assert length(cpnet.places) == 2
       assert length(cpnet.transitions) == 1
@@ -38,7 +38,7 @@ defmodule ColouredFlow.DSLTest do
     end
   end
 
-  describe "initial_markings/0 accessor" do
+  describe "__cpn__(:initial_markings) reflection" do
     test "returns an empty list when no initial markings are declared" do
       defmodule NoInitialMarkings do
         use ColouredFlow.DSL
@@ -58,7 +58,7 @@ defmodule ColouredFlow.DSLTest do
         end
       end
 
-      assert NoInitialMarkings.initial_markings() == []
+      assert NoInitialMarkings.__cpn__(:initial_markings) == []
     end
 
     test "returns %Marking{} structs with string place names and multiset tokens" do
@@ -84,7 +84,7 @@ defmodule ColouredFlow.DSLTest do
 
       assert [
                %Marking{place: "input", tokens: tokens}
-             ] = WithInitialMarkings.initial_markings()
+             ] = WithInitialMarkings.__cpn__(:initial_markings)
 
       assert tokens == ~MS[1 2 3]
     end
@@ -111,7 +111,7 @@ defmodule ColouredFlow.DSLTest do
         end
       end
 
-      markings = MultipleInitialMarkings.initial_markings()
+      markings = MultipleInitialMarkings.__cpn__(:initial_markings)
 
       assert length(markings) == 2
 

--- a/test/coloured_flow/dsl/dsl_test.exs
+++ b/test/coloured_flow/dsl/dsl_test.exs
@@ -11,19 +11,19 @@ defmodule ColouredFlow.DSLTest do
       defmodule SimpleSequenceDSL do
         use ColouredFlow.DSL
 
-        name("Simple Sequence")
-        version("1.0.0")
+        name "Simple Sequence"
+        version "1.0.0"
 
         colset int() :: integer()
 
         var x :: int()
 
-        place(:input, :int)
-        place(:output, :int)
+        place :input, :int
+        place :output, :int
 
         transition :pass_through do
-          input(:input, bind({1, x}), label: "in")
-          output(:output, {1, x}, label: "out")
+          input :input, bind({1, x}), label: "in"
+          output :output, {1, x}, label: "out"
         end
       end
 
@@ -43,18 +43,18 @@ defmodule ColouredFlow.DSLTest do
       defmodule NoInitialMarkings do
         use ColouredFlow.DSL
 
-        name("NoInitialMarkings")
+        name "NoInitialMarkings"
 
         colset int() :: integer()
 
         var x :: int()
 
-        place(:input, :int)
-        place(:output, :int)
+        place :input, :int
+        place :output, :int
 
         transition :t do
-          input(:input, bind({1, x}))
-          output(:output, {1, x})
+          input :input, bind({1, x})
+          output :output, {1, x}
         end
       end
 
@@ -65,20 +65,20 @@ defmodule ColouredFlow.DSLTest do
       defmodule WithInitialMarkings do
         use ColouredFlow.DSL
 
-        name("WithInitialMarkings")
+        name "WithInitialMarkings"
 
         colset int() :: integer()
 
         var x :: int()
 
-        place(:input, :int)
-        place(:output, :int)
+        place :input, :int
+        place :output, :int
 
-        initial_marking(:input, ~MS[1 2 3])
+        initial_marking :input, ~MS[1 2 3]
 
         transition :t do
-          input(:input, bind({1, x}))
-          output(:output, {1, x})
+          input :input, bind({1, x})
+          output :output, {1, x}
         end
       end
 
@@ -93,21 +93,21 @@ defmodule ColouredFlow.DSLTest do
       defmodule MultipleInitialMarkings do
         use ColouredFlow.DSL
 
-        name("MultipleInitialMarkings")
+        name "MultipleInitialMarkings"
 
         colset int() :: integer()
 
         var x :: int()
 
-        place(:input, :int)
-        place(:output, :int)
+        place :input, :int
+        place :output, :int
 
-        initial_marking(:input, ~MS[1 2])
-        initial_marking(:output, ~MS[3])
+        initial_marking :input, ~MS[1 2]
+        initial_marking :output, ~MS[3]
 
         transition :t do
-          input(:input, bind({1, x}))
-          output(:output, {1, x})
+          input :input, bind({1, x})
+          output :output, {1, x}
         end
       end
 

--- a/test/coloured_flow/dsl/expression_helper_test.exs
+++ b/test/coloured_flow/dsl/expression_helper_test.exs
@@ -1,0 +1,119 @@
+defmodule ColouredFlow.DSL.ExpressionHelperTest do
+  use ExUnit.Case, async: true
+
+  alias ColouredFlow.DSL.ExpressionHelper
+
+  alias ColouredFlow.Definition.Expression
+
+  describe "build_from_ast/1" do
+    test "builds an Expression from an AST with no free vars" do
+      ast =
+        quote do
+          1 + 2
+        end
+
+      assert %Expression{} = expr = ExpressionHelper.build_from_ast!(ast)
+      assert expr.code == "1 + 2"
+      assert expr.vars == []
+    end
+
+    test "extracts free vars and sorts them" do
+      ast =
+        quote do
+          x + y - z
+        end
+
+      assert %Expression{vars: vars} = ExpressionHelper.build_from_ast!(ast)
+      assert vars == [:x, :y, :z]
+    end
+
+    test "ignores bound vars" do
+      ast =
+        quote do
+          z = x + 1
+          z * 2
+        end
+
+      assert %Expression{vars: vars} = ExpressionHelper.build_from_ast!(ast)
+      assert vars == [:x]
+    end
+
+    test "code is the stringified AST" do
+      ast =
+        quote do
+          if x > 0 do
+            x
+          else
+            -x
+          end
+        end
+
+      assert %Expression{code: code} = ExpressionHelper.build_from_ast!(ast)
+      assert is_binary(code)
+      assert code =~ "if x > 0"
+    end
+
+    test "expression with bind/1 round-trips through Expression.build/1" do
+      ast =
+        quote do
+          bind({1, x})
+        end
+
+      assert %Expression{vars: vars} = ExpressionHelper.build_from_ast!(ast)
+      assert vars == [:x]
+    end
+  end
+
+  describe "build_arc_expression!/2" do
+    test "builds an :p_to_t arc expression" do
+      ast =
+        quote do
+          bind({1, x})
+        end
+
+      assert %Expression{} = expr = ExpressionHelper.build_arc_expression!(:p_to_t, ast)
+      assert expr.vars == [:x]
+    end
+
+    test "raises for :p_to_t arc without bind/1" do
+      ast =
+        quote do
+          {1, x}
+        end
+
+      assert_raise RuntimeError, ~r/missing `bind`/, fn ->
+        ExpressionHelper.build_arc_expression!(:p_to_t, ast)
+      end
+    end
+
+    test "builds an :t_to_p arc expression without bind/1" do
+      ast =
+        quote do
+          {1, x}
+        end
+
+      assert %Expression{} = expr = ExpressionHelper.build_arc_expression!(:t_to_p, ast)
+      assert expr.vars == [:x]
+    end
+  end
+
+  describe "free_vars/1" do
+    test "extracts a sorted list of free atom-vars" do
+      ast =
+        quote do
+          a + b + c
+        end
+
+      assert ExpressionHelper.free_vars(ast) == [:a, :b, :c]
+    end
+
+    test "returns empty list when no free vars" do
+      ast =
+        quote do
+          1 + 2 * 3
+        end
+
+      assert ExpressionHelper.free_vars(ast) == []
+    end
+  end
+end

--- a/test/coloured_flow/dsl/function_test.exs
+++ b/test/coloured_flow/dsl/function_test.exs
@@ -1,0 +1,132 @@
+defmodule ColouredFlow.DSL.FunctionTest do
+  use ExUnit.Case, async: true
+
+  alias ColouredFlow.Definition.Procedure
+
+  describe "function/2 single-line form" do
+    test "declares a procedure with single-line body" do
+      defmodule SingleLineFun do
+        use ColouredFlow.DSL
+
+        name("SingleLineFun")
+
+        colset int() :: integer()
+        colset bool() :: boolean()
+
+        function(is_even(x) :: bool(), do: Integer.mod(x, 2) === 0)
+
+        var x :: int()
+
+        place(:input, :int)
+        place(:output, :int)
+
+        transition :t do
+          input(:input, bind({1, x}))
+          output(:output, {1, x})
+        end
+      end
+
+      cpnet = SingleLineFun.cpnet()
+
+      assert [%Procedure{name: :is_even} = procedure] = cpnet.functions
+      # `:bool` is a user-defined colour set wrapping `:boolean`. The Builder
+      # resolves the procedure result to the underlying primitive descr.
+      assert procedure.result == {:boolean, []}
+    end
+  end
+
+  describe "function/2 multi-line form" do
+    test "declares a procedure with do block" do
+      defmodule MultiLineFun do
+        use ColouredFlow.DSL
+
+        name("MultiLineFun")
+
+        colset int() :: integer()
+
+        function double(x) :: int() do
+          x * 2
+        end
+
+        var x :: int()
+
+        place(:input, :int)
+        place(:output, :int)
+
+        transition :t do
+          input(:input, bind({1, x}))
+          output(:output, {1, x})
+        end
+      end
+
+      cpnet = MultiLineFun.cpnet()
+
+      assert [%Procedure{name: :double} = procedure] = cpnet.functions
+      # `:int` is a user-defined colour set wrapping `:integer`. The Builder
+      # resolves the procedure result to the underlying primitive descr.
+      assert procedure.result == {:integer, []}
+    end
+  end
+
+  describe "result-type resolution" do
+    test "resolves nested compound colour sets recursively" do
+      defmodule NestedTupleFun do
+        use ColouredFlow.DSL
+
+        name("NestedTupleFun")
+
+        colset int() :: integer()
+        colset bool() :: boolean()
+        colset my_pair() :: {int(), bool()}
+
+        function pack(x, b) :: my_pair() do
+          {x, b}
+        end
+
+        var x :: int()
+        var b :: bool()
+
+        place(:input, :int)
+        place(:output, :int)
+
+        transition :t do
+          input(:input, bind({1, x}))
+          output(:output, {1, x})
+        end
+      end
+
+      cpnet = NestedTupleFun.cpnet()
+
+      assert [%Procedure{name: :pack} = procedure] = cpnet.functions
+      assert procedure.result == {:tuple, [{:integer, []}, {:boolean, []}]}
+    end
+  end
+
+  describe "function/2 validation" do
+    test "rejects unused declared args at compile time" do
+      assert_raise CompileError, ~r/not referenced/i, fn ->
+        defmodule UnusedArg do
+          use ColouredFlow.DSL
+
+          name("UnusedArg")
+
+          colset int() :: integer()
+
+          function constant_one(x) :: int() do
+            1
+          end
+
+          var x :: int()
+
+          place(:input, :int)
+          place(:output, :int)
+
+          transition :t do
+            input(:input, bind({1, x}))
+            output(:output, {1, x})
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/coloured_flow/dsl/function_test.exs
+++ b/test/coloured_flow/dsl/function_test.exs
@@ -8,21 +8,21 @@ defmodule ColouredFlow.DSL.FunctionTest do
       defmodule SingleLineFun do
         use ColouredFlow.DSL
 
-        name("SingleLineFun")
+        name "SingleLineFun"
 
         colset int() :: integer()
         colset bool() :: boolean()
 
-        function(is_even(x) :: bool(), do: Integer.mod(x, 2) === 0)
+        function is_even(x) :: bool(), do: Integer.mod(x, 2) === 0
 
         var x :: int()
 
-        place(:input, :int)
-        place(:output, :int)
+        place :input, :int
+        place :output, :int
 
         transition :t do
-          input(:input, bind({1, x}))
-          output(:output, {1, x})
+          input :input, bind({1, x})
+          output :output, {1, x}
         end
       end
 
@@ -40,7 +40,7 @@ defmodule ColouredFlow.DSL.FunctionTest do
       defmodule MultiLineFun do
         use ColouredFlow.DSL
 
-        name("MultiLineFun")
+        name "MultiLineFun"
 
         colset int() :: integer()
 
@@ -50,12 +50,12 @@ defmodule ColouredFlow.DSL.FunctionTest do
 
         var x :: int()
 
-        place(:input, :int)
-        place(:output, :int)
+        place :input, :int
+        place :output, :int
 
         transition :t do
-          input(:input, bind({1, x}))
-          output(:output, {1, x})
+          input :input, bind({1, x})
+          output :output, {1, x}
         end
       end
 
@@ -73,7 +73,7 @@ defmodule ColouredFlow.DSL.FunctionTest do
       defmodule NestedTupleFun do
         use ColouredFlow.DSL
 
-        name("NestedTupleFun")
+        name "NestedTupleFun"
 
         colset int() :: integer()
         colset bool() :: boolean()
@@ -86,12 +86,12 @@ defmodule ColouredFlow.DSL.FunctionTest do
         var x :: int()
         var b :: bool()
 
-        place(:input, :int)
-        place(:output, :int)
+        place :input, :int
+        place :output, :int
 
         transition :t do
-          input(:input, bind({1, x}))
-          output(:output, {1, x})
+          input :input, bind({1, x})
+          output :output, {1, x}
         end
       end
 
@@ -108,7 +108,7 @@ defmodule ColouredFlow.DSL.FunctionTest do
         defmodule UnusedArg do
           use ColouredFlow.DSL
 
-          name("UnusedArg")
+          name "UnusedArg"
 
           colset int() :: integer()
 
@@ -118,12 +118,12 @@ defmodule ColouredFlow.DSL.FunctionTest do
 
           var x :: int()
 
-          place(:input, :int)
-          place(:output, :int)
+          place :input, :int
+          place :output, :int
 
           transition :t do
-            input(:input, bind({1, x}))
-            output(:output, {1, x})
+            input :input, bind({1, x})
+            output :output, {1, x}
           end
         end
       end

--- a/test/coloured_flow/dsl/place_test.exs
+++ b/test/coloured_flow/dsl/place_test.exs
@@ -8,18 +8,18 @@ defmodule ColouredFlow.DSL.PlaceTest do
       defmodule TwoPlaces do
         use ColouredFlow.DSL
 
-        name("TwoPlaces")
+        name "TwoPlaces"
 
         colset int() :: integer()
 
-        place(:input, :int)
-        place(:output, :int)
+        place :input, :int
+        place :output, :int
 
         var x :: int()
 
         transition :pass do
-          input(:input, bind({1, x}))
-          output(:output, {1, x})
+          input :input, bind({1, x})
+          output :output, {1, x}
         end
       end
 
@@ -38,18 +38,18 @@ defmodule ColouredFlow.DSL.PlaceTest do
         defmodule DuplicatePlaces do
           use ColouredFlow.DSL
 
-          name("DuplicatePlaces")
+          name "DuplicatePlaces"
 
           colset int() :: integer()
 
-          place(:input, :int)
-          place(:input, :int)
+          place :input, :int
+          place :input, :int
 
           var x :: int()
 
           transition :t do
-            input(:input, bind({1, x}))
-            output(:input, {1, x})
+            input :input, bind({1, x})
+            output :input, {1, x}
           end
         end
       end
@@ -60,16 +60,16 @@ defmodule ColouredFlow.DSL.PlaceTest do
         defmodule UnknownColset do
           use ColouredFlow.DSL
 
-          name("UnknownColset")
+          name "UnknownColset"
 
           colset int() :: integer()
 
-          place(:input, :ghost)
+          place :input, :ghost
 
           var x :: int()
 
           transition :t do
-            input(:input, bind({1, x}))
+            input :input, bind({1, x})
           end
         end
       end

--- a/test/coloured_flow/dsl/place_test.exs
+++ b/test/coloured_flow/dsl/place_test.exs
@@ -34,45 +34,63 @@ defmodule ColouredFlow.DSL.PlaceTest do
     end
 
     test "rejects duplicate place names at compile time" do
-      assert_raise CompileError, ~r/duplicate|unique|already/i, fn ->
-        defmodule DuplicatePlaces do
-          use ColouredFlow.DSL
+      source = """
+      defmodule ColouredFlow.DSL.PlaceTest.DuplicatePlaces do
+        use ColouredFlow.DSL
 
-          name "DuplicatePlaces"
+        name "DuplicatePlaces"
 
-          colset int() :: integer()
+        colset int() :: integer()
 
-          place :input, :int
-          place :input, :int
+        place :input, :int
+        place :input, :int
 
-          var x :: int()
+        var x :: int()
 
-          transition :t do
-            input :input, bind({1, x})
-            output :input, {1, x}
-          end
+        transition :t do
+          input :input, bind({1, x})
+          output :input, {1, x}
         end
       end
+      """
+
+      error =
+        assert_raise CompileError, ~r/duplicate|unique|already/i, fn ->
+          Code.compile_string(source, "duplicate_places.exs")
+        end
+
+      assert error.file == "duplicate_places.exs"
+      # Points at the second `place :input, :int` (line 9, 1-indexed).
+      assert error.line == 9
     end
 
     test "rejects unknown colour set" do
-      assert_raise CompileError, ~r/colour set|undefined|unknown/i, fn ->
-        defmodule UnknownColset do
-          use ColouredFlow.DSL
+      source = """
+      defmodule ColouredFlow.DSL.PlaceTest.UnknownColset do
+        use ColouredFlow.DSL
 
-          name "UnknownColset"
+        name "UnknownColset"
 
-          colset int() :: integer()
+        colset int() :: integer()
 
-          place :input, :ghost
+        place :input, :ghost
 
-          var x :: int()
+        var x :: int()
 
-          transition :t do
-            input :input, bind({1, x})
-          end
+        transition :t do
+          input :input, bind({1, x})
         end
       end
+      """
+
+      error =
+        assert_raise CompileError, ~r/colour set|undefined|unknown/i, fn ->
+          Code.compile_string(source, "unknown_colset.exs")
+        end
+
+      assert error.file == "unknown_colset.exs"
+      # Points at the offending `place :input, :ghost` (line 8, 1-indexed).
+      assert error.line == 8
     end
   end
 end

--- a/test/coloured_flow/dsl/place_test.exs
+++ b/test/coloured_flow/dsl/place_test.exs
@@ -1,0 +1,78 @@
+defmodule ColouredFlow.DSL.PlaceTest do
+  use ExUnit.Case, async: true
+
+  alias ColouredFlow.Definition.Place
+
+  describe "place/2 in defworkflow" do
+    test "accumulates places into cpnet/0" do
+      defmodule TwoPlaces do
+        use ColouredFlow.DSL
+
+        name("TwoPlaces")
+
+        colset int() :: integer()
+
+        place(:input, :int)
+        place(:output, :int)
+
+        var x :: int()
+
+        transition :pass do
+          input(:input, bind({1, x}))
+          output(:output, {1, x})
+        end
+      end
+
+      cpnet = TwoPlaces.cpnet()
+
+      names = Enum.map(cpnet.places, & &1.name)
+      assert "input" in names
+      assert "output" in names
+
+      assert %Place{name: "input", colour_set: :int} =
+               Enum.find(cpnet.places, &(&1.name == "input"))
+    end
+
+    test "rejects duplicate place names at compile time" do
+      assert_raise CompileError, ~r/duplicate|unique|already/i, fn ->
+        defmodule DuplicatePlaces do
+          use ColouredFlow.DSL
+
+          name("DuplicatePlaces")
+
+          colset int() :: integer()
+
+          place(:input, :int)
+          place(:input, :int)
+
+          var x :: int()
+
+          transition :t do
+            input(:input, bind({1, x}))
+            output(:input, {1, x})
+          end
+        end
+      end
+    end
+
+    test "rejects unknown colour set" do
+      assert_raise CompileError, ~r/colour set|undefined|unknown/i, fn ->
+        defmodule UnknownColset do
+          use ColouredFlow.DSL
+
+          name("UnknownColset")
+
+          colset int() :: integer()
+
+          place(:input, :ghost)
+
+          var x :: int()
+
+          transition :t do
+            input(:input, bind({1, x}))
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/coloured_flow/dsl/termination_test.exs
+++ b/test/coloured_flow/dsl/termination_test.exs
@@ -1,0 +1,56 @@
+defmodule ColouredFlow.DSL.TerminationTest do
+  use ExUnit.Case, async: true
+
+  alias ColouredFlow.Definition.TerminationCriteria
+  alias ColouredFlow.Definition.TerminationCriteria.Markings
+
+  describe "termination/1 block" do
+    test "captures on_markings expression" do
+      defmodule TerminationFlow do
+        use ColouredFlow.DSL
+
+        name("TerminationFlow")
+
+        colset int() :: integer()
+
+        var x :: int()
+
+        place(:input, :int)
+        place(:output, :int)
+
+        transition :t do
+          input(:input, bind({1, x}))
+          output(:output, {1, x})
+        end
+
+        termination do
+          on_markings do
+            match?(%{"output" => out_ms} when multi_set_coefficient(out_ms, 1) >= 5, markings)
+          end
+        end
+      end
+
+      cpnet = TerminationFlow.cpnet()
+
+      assert %TerminationCriteria{markings: %Markings{} = markings} = cpnet.termination_criteria
+      assert markings.expression.vars == [:markings]
+      assert markings.expression.code =~ "multi_set_coefficient"
+    end
+
+    test "on_markings outside termination raises" do
+      assert_raise CompileError, ~r/on_markings.+termination/i, fn ->
+        defmodule MarkingsOutside do
+          use ColouredFlow.DSL
+
+          name("MarkingsOutside")
+
+          colset int() :: integer()
+
+          on_markings do
+            true
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/coloured_flow/dsl/termination_test.exs
+++ b/test/coloured_flow/dsl/termination_test.exs
@@ -52,5 +52,45 @@ defmodule ColouredFlow.DSL.TerminationTest do
         end
       end
     end
+
+    test "rejects duplicate on_markings in same termination block" do
+      source = """
+      defmodule ColouredFlow.DSL.TerminationTest.DuplicateOnMarkings do
+        use ColouredFlow.DSL
+
+        name("DuplicateOnMarkings")
+
+        colset int() :: integer()
+
+        var x :: int()
+
+        place(:input, :int)
+        place(:output, :int)
+
+        transition :t do
+          input(:input, bind({1, x}))
+          output(:output, {1, x})
+        end
+
+        termination do
+          on_markings do
+            match?(%{"output" => _}, markings)
+          end
+
+          on_markings do
+            match?(%{"input" => _}, markings)
+          end
+        end
+      end
+      """
+
+      error =
+        assert_raise CompileError, ~r/on_markings.+already.+declared/i, fn ->
+          Code.compile_string(source, "duplicate_on_markings.exs")
+        end
+
+      # Points at the second `on_markings` (line 23, 1-indexed).
+      assert error.line == 23
+    end
   end
 end

--- a/test/coloured_flow/dsl/termination_test.exs
+++ b/test/coloured_flow/dsl/termination_test.exs
@@ -89,8 +89,52 @@ defmodule ColouredFlow.DSL.TerminationTest do
           Code.compile_string(source, "duplicate_on_markings.exs")
         end
 
+      assert error.file == "duplicate_on_markings.exs"
       # Points at the second `on_markings` (line 23, 1-indexed).
       assert error.line == 23
+    end
+
+    test "rejects multiple termination blocks in the same workflow" do
+      source = """
+      defmodule ColouredFlow.DSL.TerminationTest.MultipleTermination do
+        use ColouredFlow.DSL
+
+        name "MultipleTermination"
+
+        colset int() :: integer()
+
+        var x :: int()
+
+        place :input, :int
+        place :output, :int
+
+        transition :t do
+          input :input, bind({1, x})
+          output :output, {1, x}
+        end
+
+        termination do
+          on_markings do
+            match?(%{"output" => _}, markings)
+          end
+        end
+
+        termination do
+          on_markings do
+            match?(%{"input" => _}, markings)
+          end
+        end
+      end
+      """
+
+      error =
+        assert_raise CompileError, ~r/termination.+already.+declared/i, fn ->
+          Code.compile_string(source, "multiple_termination.exs")
+        end
+
+      assert error.file == "multiple_termination.exs"
+      # Points at the second `termination do ... end` (line 24, 1-indexed).
+      assert error.line == 24
     end
   end
 end

--- a/test/coloured_flow/dsl/termination_test.exs
+++ b/test/coloured_flow/dsl/termination_test.exs
@@ -9,18 +9,18 @@ defmodule ColouredFlow.DSL.TerminationTest do
       defmodule TerminationFlow do
         use ColouredFlow.DSL
 
-        name("TerminationFlow")
+        name "TerminationFlow"
 
         colset int() :: integer()
 
         var x :: int()
 
-        place(:input, :int)
-        place(:output, :int)
+        place :input, :int
+        place :output, :int
 
         transition :t do
-          input(:input, bind({1, x}))
-          output(:output, {1, x})
+          input :input, bind({1, x})
+          output :output, {1, x}
         end
 
         termination do
@@ -42,7 +42,7 @@ defmodule ColouredFlow.DSL.TerminationTest do
         defmodule MarkingsOutside do
           use ColouredFlow.DSL
 
-          name("MarkingsOutside")
+          name "MarkingsOutside"
 
           colset int() :: integer()
 
@@ -58,18 +58,18 @@ defmodule ColouredFlow.DSL.TerminationTest do
       defmodule ColouredFlow.DSL.TerminationTest.DuplicateOnMarkings do
         use ColouredFlow.DSL
 
-        name("DuplicateOnMarkings")
+        name "DuplicateOnMarkings"
 
         colset int() :: integer()
 
         var x :: int()
 
-        place(:input, :int)
-        place(:output, :int)
+        place :input, :int
+        place :output, :int
 
         transition :t do
-          input(:input, bind({1, x}))
-          output(:output, {1, x})
+          input :input, bind({1, x})
+          output :output, {1, x}
         end
 
         termination do

--- a/test/coloured_flow/dsl/transition_test.exs
+++ b/test/coloured_flow/dsl/transition_test.exs
@@ -1,0 +1,108 @@
+defmodule ColouredFlow.DSL.TransitionTest do
+  use ExUnit.Case, async: true
+
+  alias ColouredFlow.Definition.Action
+  alias ColouredFlow.Definition.Transition
+
+  describe "transition/2 block" do
+    test "captures guard, action, input, output" do
+      defmodule FullTransition do
+        use ColouredFlow.DSL
+
+        name("FullTransition")
+
+        colset int() :: integer()
+
+        var x :: int()
+
+        place(:input, :int)
+        place(:output, :int)
+
+        transition :pass_through do
+          guard(x > 0)
+
+          input(:input, bind({1, x}), label: "in")
+          output(:output, {1, x * 2}, label: "out")
+
+          action do
+            :ok
+          end
+        end
+      end
+
+      cpnet = FullTransition.cpnet()
+
+      assert [%Transition{name: "pass_through"} = transition] = cpnet.transitions
+      assert transition.guard.code == "x > 0"
+      assert transition.guard.vars == [:x]
+      assert %Action{payload: payload} = transition.action
+      assert payload =~ ":ok"
+
+      assert length(cpnet.arcs) == 2
+      [in_arc, out_arc] = cpnet.arcs
+      assert in_arc.label == "in"
+      assert in_arc.transition == "pass_through"
+      assert out_arc.label == "out"
+      assert out_arc.transition == "pass_through"
+    end
+
+    test "guard outside transition raises" do
+      assert_raise CompileError, ~r/guard.+transition/i, fn ->
+        defmodule GuardOutside do
+          use ColouredFlow.DSL
+
+          name("GuardOutside")
+
+          colset int() :: integer()
+
+          guard(true)
+        end
+      end
+    end
+
+    test "input outside transition raises" do
+      assert_raise CompileError, ~r/input.+transition/i, fn ->
+        defmodule InputOutside do
+          use ColouredFlow.DSL
+
+          name "InputOutside"
+
+          colset int() :: integer()
+
+          var x :: int()
+
+          place :input, :int
+
+          input :input, bind({1, x})
+        end
+      end
+    end
+
+    test "rejects duplicate transition names at compile time" do
+      assert_raise CompileError, ~r/duplicate|unique|transition/i, fn ->
+        defmodule DuplicateTransitions do
+          use ColouredFlow.DSL
+
+          name "DuplicateTransitions"
+
+          colset int() :: integer()
+
+          var x :: int()
+
+          place :input, :int
+          place :output, :int
+
+          transition :t do
+            input :input, bind({1, x})
+            output :output, {1, x}
+          end
+
+          transition :t do
+            input :input, bind({1, x})
+            output :output, {1, x}
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/coloured_flow/dsl/transition_test.exs
+++ b/test/coloured_flow/dsl/transition_test.exs
@@ -104,5 +104,71 @@ defmodule ColouredFlow.DSL.TransitionTest do
         end
       end
     end
+
+    test "rejects duplicate guard in same transition" do
+      source = """
+      defmodule ColouredFlow.DSL.TransitionTest.DuplicateGuard do
+        use ColouredFlow.DSL
+
+        name("DuplicateGuard")
+
+        colset int() :: integer()
+
+        var x :: int()
+
+        place(:input, :int)
+        place(:output, :int)
+
+        transition :t do
+          guard x > 0
+          guard x < 10
+
+          input :input, bind({1, x})
+          output :output, {1, x}
+        end
+      end
+      """
+
+      error =
+        assert_raise CompileError, ~r/guard.+already.+declared/i, fn ->
+          Code.compile_string(source, "duplicate_guard.exs")
+        end
+
+      # Points at the second `guard` (line 15, 1-indexed).
+      assert error.line == 15
+    end
+
+    test "rejects duplicate action in same transition" do
+      source = """
+      defmodule ColouredFlow.DSL.TransitionTest.DuplicateAction do
+        use ColouredFlow.DSL
+
+        name("DuplicateAction")
+
+        colset int() :: integer()
+
+        var x :: int()
+
+        place(:input, :int)
+        place(:output, :int)
+
+        transition :t do
+          input :input, bind({1, x})
+          output :output, {1, x}
+
+          action :ok
+          action :also_ok
+        end
+      end
+      """
+
+      error =
+        assert_raise CompileError, ~r/action.+already.+declared/i, fn ->
+          Code.compile_string(source, "duplicate_action.exs")
+        end
+
+      # Points at the second `action` (line 18, 1-indexed).
+      assert error.line == 18
+    end
   end
 end

--- a/test/coloured_flow/dsl/transition_test.exs
+++ b/test/coloured_flow/dsl/transition_test.exs
@@ -9,20 +9,20 @@ defmodule ColouredFlow.DSL.TransitionTest do
       defmodule FullTransition do
         use ColouredFlow.DSL
 
-        name("FullTransition")
+        name "FullTransition"
 
         colset int() :: integer()
 
         var x :: int()
 
-        place(:input, :int)
-        place(:output, :int)
+        place :input, :int
+        place :output, :int
 
         transition :pass_through do
-          guard(x > 0)
+          guard x > 0
 
-          input(:input, bind({1, x}), label: "in")
-          output(:output, {1, x * 2}, label: "out")
+          input :input, bind({1, x}), label: "in"
+          output :output, {1, x * 2}, label: "out"
 
           action do
             :ok
@@ -51,11 +51,11 @@ defmodule ColouredFlow.DSL.TransitionTest do
         defmodule GuardOutside do
           use ColouredFlow.DSL
 
-          name("GuardOutside")
+          name "GuardOutside"
 
           colset int() :: integer()
 
-          guard(true)
+          guard true
         end
       end
     end
@@ -110,14 +110,14 @@ defmodule ColouredFlow.DSL.TransitionTest do
       defmodule ColouredFlow.DSL.TransitionTest.DuplicateGuard do
         use ColouredFlow.DSL
 
-        name("DuplicateGuard")
+        name "DuplicateGuard"
 
         colset int() :: integer()
 
         var x :: int()
 
-        place(:input, :int)
-        place(:output, :int)
+        place :input, :int
+        place :output, :int
 
         transition :t do
           guard x > 0
@@ -143,14 +143,14 @@ defmodule ColouredFlow.DSL.TransitionTest do
       defmodule ColouredFlow.DSL.TransitionTest.DuplicateAction do
         use ColouredFlow.DSL
 
-        name("DuplicateAction")
+        name "DuplicateAction"
 
         colset int() :: integer()
 
         var x :: int()
 
-        place(:input, :int)
-        place(:output, :int)
+        place :input, :int
+        place :output, :int
 
         transition :t do
           input :input, bind({1, x})

--- a/test/coloured_flow/dsl/transition_test.exs
+++ b/test/coloured_flow/dsl/transition_test.exs
@@ -79,30 +79,41 @@ defmodule ColouredFlow.DSL.TransitionTest do
     end
 
     test "rejects duplicate transition names at compile time" do
-      assert_raise CompileError, ~r/duplicate|unique|transition/i, fn ->
-        defmodule DuplicateTransitions do
-          use ColouredFlow.DSL
+      source = """
+      defmodule ColouredFlow.DSL.TransitionTest.DuplicateTransitions do
+        use ColouredFlow.DSL
 
-          name "DuplicateTransitions"
+        name "DuplicateTransitions"
 
-          colset int() :: integer()
+        colset int() :: integer()
 
-          var x :: int()
+        var x :: int()
 
-          place :input, :int
-          place :output, :int
+        place :a, :int
+        place :b, :int
+        place :c, :int
+        place :d, :int
 
-          transition :t do
-            input :input, bind({1, x})
-            output :output, {1, x}
-          end
+        transition :t do
+          input :a, bind({1, x})
+          output :b, {1, x}
+        end
 
-          transition :t do
-            input :input, bind({1, x})
-            output :output, {1, x}
-          end
+        transition :t do
+          input :c, bind({1, x})
+          output :d, {1, x}
         end
       end
+      """
+
+      error =
+        assert_raise CompileError, ~r/unique|transition/i, fn ->
+          Code.compile_string(source, "duplicate_transitions.exs")
+        end
+
+      assert error.file == "duplicate_transitions.exs"
+      # Points at the second `transition :t do ... end` (line 20, 1-indexed).
+      assert error.line == 20
     end
 
     test "rejects duplicate guard in same transition" do
@@ -134,6 +145,7 @@ defmodule ColouredFlow.DSL.TransitionTest do
           Code.compile_string(source, "duplicate_guard.exs")
         end
 
+      assert error.file == "duplicate_guard.exs"
       # Points at the second `guard` (line 15, 1-indexed).
       assert error.line == 15
     end
@@ -167,6 +179,7 @@ defmodule ColouredFlow.DSL.TransitionTest do
           Code.compile_string(source, "duplicate_action.exs")
         end
 
+      assert error.file == "duplicate_action.exs"
       # Points at the second `action` (line 18, 1-indexed).
       assert error.line == 18
     end

--- a/test/coloured_flow/validators/definition/functions_validator_test.exs
+++ b/test/coloured_flow/validators/definition/functions_validator_test.exs
@@ -1,0 +1,242 @@
+defmodule ColouredFlow.Validators.Definition.FunctionsValidatorTest do
+  use ExUnit.Case, async: true
+
+  use ColouredFlow.DefinitionHelpers
+  import ColouredFlow.Notation.Colset
+
+  alias ColouredFlow.Definition.Expression
+  alias ColouredFlow.Definition.Procedure
+  alias ColouredFlow.Validators.Definition.FunctionsValidator
+  alias ColouredFlow.Validators.Exceptions.MissingColourSetError
+  alias ColouredFlow.Validators.Exceptions.UniqueNameViolationError
+
+  setup do
+    cpnet = %ColouredPetriNet{
+      colour_sets: [
+        colset(int() :: integer()),
+        colset(user() :: %{name: binary(), age: int()})
+      ],
+      places: [],
+      transitions: [],
+      arcs: [],
+      variables: [],
+      functions: []
+    }
+
+    [cpnet: cpnet]
+  end
+
+  describe "happy path" do
+    test "passes when there are no functions", %{cpnet: cpnet} do
+      assert {:ok, ^cpnet} = FunctionsValidator.validate(cpnet)
+    end
+
+    test "passes when all procedures have primitive result descrs", %{cpnet: cpnet} do
+      cpnet = %{
+        cpnet
+        | functions: [
+            %Procedure{
+              name: :add,
+              expression: Expression.build!("x + y"),
+              result: {:integer, []}
+            },
+            %Procedure{
+              name: :greet,
+              expression: Expression.build!(~S|"hello"|),
+              result: {:binary, []}
+            },
+            %Procedure{
+              name: :truthy?,
+              expression: Expression.build!("true"),
+              result: {:boolean, []}
+            }
+          ]
+      }
+
+      assert {:ok, ^cpnet} = FunctionsValidator.validate(cpnet)
+    end
+
+    test "passes when result descr is a deeply nested composite of primitives", %{cpnet: cpnet} do
+      cpnet = %{
+        cpnet
+        | functions: [
+            %Procedure{
+              name: :nested,
+              expression: Expression.build!("[{1, [2.0]}]"),
+              result:
+                {:list,
+                 {:tuple,
+                  [
+                    {:integer, []},
+                    {:list, {:float, []}}
+                  ]}}
+            },
+            %Procedure{
+              name: :map_result,
+              expression: Expression.build!("%{a: 1, b: 2.0}"),
+              result: {:map, %{a: {:integer, []}, b: {:float, []}}}
+            },
+            %Procedure{
+              name: :colour_choice,
+              expression: Expression.build!(":red"),
+              result: {:enum, [:red, :green, :blue]}
+            },
+            %Procedure{
+              name: :tagged,
+              expression: Expression.build!("{:ok, 1}"),
+              result: {:union, %{ok: {:integer, []}, err: {:binary, []}}}
+            }
+          ]
+      }
+
+      assert {:ok, ^cpnet} = FunctionsValidator.validate(cpnet)
+    end
+  end
+
+  describe "duplicate procedure names" do
+    test "fails with UniqueNameViolationError using :function scope", %{cpnet: cpnet} do
+      cpnet = %{
+        cpnet
+        | functions: [
+            %Procedure{
+              name: :add,
+              expression: Expression.build!("x + y"),
+              result: {:integer, []}
+            },
+            %Procedure{
+              name: :add,
+              expression: Expression.build!("x + y + 1"),
+              result: {:integer, []}
+            }
+          ]
+      }
+
+      assert {
+               :error,
+               %UniqueNameViolationError{scope: :function, name: :add}
+             } = FunctionsValidator.validate(cpnet)
+    end
+  end
+
+  describe "result descrs must be fully resolved" do
+    test "fails with MissingColourSetError when result references unknown name",
+         %{cpnet: cpnet} do
+      cpnet = %{
+        cpnet
+        | functions: [
+            %Procedure{
+              name: :is_odd,
+              expression: Expression.build!("rem(x, 2) == 1"),
+              # ":bool" is not declared in cpnet.colour_sets
+              result: {:bool, []}
+            }
+          ]
+      }
+
+      assert {:error, %MissingColourSetError{colour_set: :bool} = error} =
+               FunctionsValidator.validate(cpnet)
+
+      message = Exception.message(error)
+      assert message =~ "is_odd"
+      assert message =~ "bool"
+    end
+
+    test "fails when an inner leaf of a deeply nested composite is unresolved",
+         %{cpnet: cpnet} do
+      cpnet = %{
+        cpnet
+        | functions: [
+            %Procedure{
+              name: :produce_pairs,
+              expression: Expression.build!("[]"),
+              result:
+                {:list,
+                 {:tuple,
+                  [
+                    {:integer, []},
+                    # ":ghost" is not declared
+                    {:list, {:ghost, []}}
+                  ]}}
+            }
+          ]
+      }
+
+      assert {:error, %MissingColourSetError{colour_set: :ghost} = error} =
+               FunctionsValidator.validate(cpnet)
+
+      message = Exception.message(error)
+      assert message =~ "produce_pairs"
+      assert message =~ "ghost"
+    end
+
+    test "fails when an inner leaf of a map descr is unresolved", %{cpnet: cpnet} do
+      cpnet = %{
+        cpnet
+        | functions: [
+            %Procedure{
+              name: :build_user,
+              expression: Expression.build!("%{name: \"alice\", age: 21}"),
+              result:
+                {:map,
+                 %{
+                   name: {:binary, []},
+                   age: {:phantom_int, []}
+                 }}
+            }
+          ]
+      }
+
+      assert {:error, %MissingColourSetError{colour_set: :phantom_int} = error} =
+               FunctionsValidator.validate(cpnet)
+
+      message = Exception.message(error)
+      assert message =~ "build_user"
+      assert message =~ "phantom_int"
+    end
+
+    test "fails when a union arm is unresolved", %{cpnet: cpnet} do
+      cpnet = %{
+        cpnet
+        | functions: [
+            %Procedure{
+              name: :tagged,
+              expression: Expression.build!("{:ok, 1}"),
+              result:
+                {:union,
+                 %{
+                   ok: {:integer, []},
+                   err: {:missing_type, []}
+                 }}
+            }
+          ]
+      }
+
+      assert {:error, %MissingColourSetError{colour_set: :missing_type} = error} =
+               FunctionsValidator.validate(cpnet)
+
+      assert Exception.message(error) =~ "tagged"
+    end
+
+    test "passes when nested composite leaves all resolve to declared colour sets",
+         %{cpnet: cpnet} do
+      # `:int` and `:user` are declared in setup
+      cpnet = %{
+        cpnet
+        | functions: [
+            %Procedure{
+              name: :user_list,
+              expression: Expression.build!("[]"),
+              result: {:list, {:user, []}}
+            },
+            %Procedure{
+              name: :wrap_int,
+              expression: Expression.build!("{:ok, 1}"),
+              result: {:union, %{ok: {:int, []}, err: {:binary, []}}}
+            }
+          ]
+      }
+
+      assert {:ok, ^cpnet} = FunctionsValidator.validate(cpnet)
+    end
+  end
+end

--- a/test/coloured_flow/validators/definition/guard_validator_test.exs
+++ b/test/coloured_flow/validators/definition/guard_validator_test.exs
@@ -75,4 +75,84 @@ defmodule ColouredFlow.Validators.Definition.GuardValidatorTest do
 
     assert {:error, %InvalidGuardError{reason: :unbound_vars}} = GuardValidator.validate(cpnet)
   end
+
+  describe "per-transition guard scope" do
+    setup do
+      # Two transitions, each with its own incoming arc binding a different
+      # variable. The guard scope must be evaluated per-transition rather than
+      # over the union of all bindings across the net.
+      cpnet = %ColouredPetriNet{
+        colour_sets: [
+          colset(int() :: integer())
+        ],
+        places: [
+          %Place{name: "in_a", colour_set: :int},
+          %Place{name: "in_b", colour_set: :int},
+          %Place{name: "out_a", colour_set: :int},
+          %Place{name: "out_b", colour_set: :int}
+        ],
+        transitions: [
+          build_transition!(name: "t1", guard: "true"),
+          build_transition!(name: "t2", guard: "true")
+        ],
+        arcs: [
+          build_arc!(
+            place: "in_a",
+            transition: "t1",
+            orientation: :p_to_t,
+            expression: "bind {1, x}"
+          ),
+          build_arc!(
+            place: "out_a",
+            transition: "t1",
+            orientation: :t_to_p,
+            expression: "{1, x}"
+          ),
+          build_arc!(
+            place: "in_b",
+            transition: "t2",
+            orientation: :p_to_t,
+            expression: "bind {1, y}"
+          ),
+          build_arc!(
+            place: "out_b",
+            transition: "t2",
+            orientation: :t_to_p,
+            expression: "{1, y}"
+          )
+        ],
+        variables: [
+          %Variable{name: :x, colour_set: :int},
+          %Variable{name: :y, colour_set: :int}
+        ]
+      }
+
+      [cpnet: cpnet]
+    end
+
+    test "fails when t1's guard references a var bound only by t2's incoming arc",
+         %{cpnet: cpnet} do
+      cpnet = put_t1_guard(cpnet, "y > 0")
+
+      assert {:error, %InvalidGuardError{reason: :unbound_vars}} =
+               GuardValidator.validate(cpnet)
+    end
+
+    test "passes when t1's guard references a var bound by t1's own incoming arc",
+         %{cpnet: cpnet} do
+      cpnet = put_t1_guard(cpnet, "x > 0")
+
+      assert {:ok, _cpnet} = GuardValidator.validate(cpnet)
+    end
+
+    defp put_t1_guard(%ColouredPetriNet{transitions: [_t1, t2]} = cpnet, guard) do
+      %ColouredPetriNet{
+        cpnet
+        | transitions: [
+            build_transition!(name: "t1", guard: guard),
+            t2
+          ]
+      }
+    end
+  end
 end

--- a/test/coloured_flow/validators/definition/places_validator_test.exs
+++ b/test/coloured_flow/validators/definition/places_validator_test.exs
@@ -1,0 +1,66 @@
+defmodule ColouredFlow.Validators.Definition.PlacesValidatorTest do
+  use ExUnit.Case, async: true
+
+  import ColouredFlow.Notation.Colset
+
+  alias ColouredFlow.Definition.ColouredPetriNet
+  alias ColouredFlow.Definition.Place
+  alias ColouredFlow.Validators.Definition.PlacesValidator
+  alias ColouredFlow.Validators.Exceptions.MissingColourSetError
+
+  setup do
+    cpnet = %ColouredPetriNet{
+      colour_sets: [
+        colset(int :: integer()),
+        colset(user :: %{name: binary(), age: int()})
+      ],
+      places: [],
+      transitions: [],
+      arcs: [],
+      variables: []
+    }
+
+    [cpnet: cpnet]
+  end
+
+  test "valid: each place colour set resolves", %{cpnet: cpnet} do
+    cpnet = %{
+      cpnet
+      | places: [
+          %Place{name: "p1", colour_set: :int},
+          %Place{name: "p2", colour_set: :user}
+        ]
+    }
+
+    assert {:ok, ^cpnet} = PlacesValidator.validate(cpnet)
+  end
+
+  test "valid: multiple places sharing the same colour set", %{cpnet: cpnet} do
+    cpnet = %{
+      cpnet
+      | places: [
+          %Place{name: "a", colour_set: :int},
+          %Place{name: "b", colour_set: :int},
+          %Place{name: "c", colour_set: :int}
+        ]
+    }
+
+    assert {:ok, ^cpnet} = PlacesValidator.validate(cpnet)
+  end
+
+  test "invalid: place references an unknown colour set", %{cpnet: cpnet} do
+    cpnet = %{
+      cpnet
+      | places: [
+          %Place{name: "p1", colour_set: :int},
+          %Place{name: "p2", colour_set: :ghost}
+        ]
+    }
+
+    assert {:error, %MissingColourSetError{colour_set: :ghost} = error} =
+             PlacesValidator.validate(cpnet)
+
+    assert Exception.message(error) =~ "p2"
+    assert Exception.message(error) =~ "ghost"
+  end
+end

--- a/test/support/cpnet_builder.ex
+++ b/test/support/cpnet_builder.ex
@@ -430,7 +430,7 @@ defmodule ColouredFlow.CpnetBuilder do
             [
               place: "b",
               orientation: :t_to_p,
-              expression: "if success do: {1, {n, d}}, else: {0, {n, d}}"
+              expression: "if success, do: {1, {n, d}}, else: {0, {n, d}}"
             ]
           ]),
           build_transition_arcs!("receive_packet", [
@@ -452,7 +452,7 @@ defmodule ColouredFlow.CpnetBuilder do
             [
               place: "data_recevied",
               orientation: :t_to_p,
-              expression: "if n == k do: {1, data <> d}, else: {1, data}"
+              expression: "if n == k, do: {1, data <> d}, else: {1, data}"
             ],
             [
               place: "c",
@@ -474,7 +474,7 @@ defmodule ColouredFlow.CpnetBuilder do
             [
               place: "d",
               orientation: :t_to_p,
-              expression: "if success do: {1, n}, else: {0, n}"
+              expression: "if success, do: {1, n}, else: {0, n}"
             ]
           ]),
           build_transition_arcs!("receive_ack", [


### PR DESCRIPTION
## Summary

New high-level declarative DSL `ColouredFlow.DSL` for defining Coloured Petri Nets, layered on top of existing `ColouredFlow.Notation.*` low-level macros (`colset/1`, `var/1`, `val/1`).

```elixir
defmodule MyWorkflow do
  use ColouredFlow.DSL

  name "My Workflow"
  version "1.0.0"

  colset int() :: integer()
  colset bool() :: boolean()

  var x :: int()

  function is_even(x) :: bool() do
    Integer.mod(x, 2) === 0
  end

  place :input, :int
  place :output, :int

  initial_marking :input, ~MS[1, 2, 3]

  transition :pass_through do
    guard x > 0

    input :input, bind({1, x}), label: "in"

    output :output do
      if is_even(x), do: {1, x}, else: {1, x + 1}
    end

    action do
      :ok
    end
  end

  termination do
    on_markings do
      match?(
        %{"output" => out_ms} when multi_set_coefficient(out_ms, 1) >= 5,
        markings
      )
    end
  end
end

MyWorkflow.cpnet() #=> %ColouredFlow.Definition.ColouredPetriNet{...}
```

Spec lives in `lib/coloured_flow/dsl/spec.md` and is loaded into `ColouredFlow.DSL`'s `@moduledoc` via `@external_resource` so editing the markdown triggers recompilation.

## Universal expression rule

Every macro that accepts an expression follows the same pattern:

- single-line: expression is the last positional arg
- multi-line: `do ... end` block; the block body **is** the expression (no `expr do ... end` wrapper)
- options (e.g., `label:`): keyword args before the `do` block

## What lands

**lib/**:
- `lib/coloured_flow/dsl.ex` — entry, `__using__/1`, top-level macros
- `lib/coloured_flow/dsl/builder.ex` — `__before_compile__` hook, runs `Builder.build/1` + `Validators.run/1`
- `lib/coloured_flow/dsl/place.ex` — `place/2`, `initial_marking/2`
- `lib/coloured_flow/dsl/transition.ex` — `transition/2`, `guard/1`, `action/1`
- `lib/coloured_flow/dsl/arc.ex` — `input/{2,3}`, `output/{2,3}`
- `lib/coloured_flow/dsl/function.ex` — `function/{1,2}`
- `lib/coloured_flow/dsl/termination.ex` — `termination/1`, `on_markings/1`
- `lib/coloured_flow/dsl/expression_helper.ex` — AST → `%Expression{}` conversion
- `lib/coloured_flow/dsl/spec.md` — full spec doc
- `lib/coloured_flow/validators/definition/places_validator.ex` — new validator (place.colour_set must resolve)
- `lib/coloured_flow/validators/validators.ex` — register `PlacesValidator`

**test/**: full coverage including `cpnet_examples_test.exs` that reproduces all 6 sample CPNs from `test/support/cpnet_builder.ex` (`:simple_sequence` through `:transmission_protocol`) via the DSL and asserts structural equivalence with the procedural builder output.

## Migration touch

The `:transmission_protocol` fixture used non-standard `if X do: ..., else: ...` (no comma) expression strings. Elixir parses this as `if(X([do: ..., else: ...]))` — `X` is a function call rather than a free var, dropping `:success` from the expression's `vars` list. Migrated all such occurrences to standard `if X, do: ..., else: ...` form. Updated `presentation_test.exs` mermaid expectations accordingly.

## Test plan

- [x] `mix compile --warnings-as-errors` — clean
- [x] `mix format --check-formatted` — clean
- [x] `mix credo --strict` — 0 issues
- [x] `mix dialyzer` — no new errors (baseline 6 skipped)
- [x] `MIX_ENV=test mix test` — 467 tests pass (404 + 63 doctests, 0 failures)
- [x] All 6 sample CPNs reproduced via DSL with structural equivalence

## Followups

Codex review surfaced 4 correctness blockers + 1 simplification + 1 risk; all confirmed with the user one-by-one. Two parallel followup PRs target this branch:

- `feat/dsl-validators` — `FunctionsValidator` + per-transition `GuardValidator` scope
- `feat/dsl-macros-followup` — `initial_markings/0` accessor, duplicate-declaration hygiene, caller line/file in errors, shared `__decompose_type__/1` helper

Final codex pass after both followups land before merging this stack to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)