### PR TITLE
feat(validators): functions validator + per-transition guard scope

### DIFF
--- a/lib/coloured_flow/validators/definition/functions_validator.ex
+++ b/lib/coloured_flow/validators/definition/functions_validator.ex
@@ -1,0 +1,104 @@
+defmodule ColouredFlow.Validators.Definition.FunctionsValidator do
+  @moduledoc """
+  This validator ensures that procedures (a.k.a. functions) within a ColouredFlow
+  definition are valid.
+
+  It validates these aspects of a procedure:
+
+  1. Procedure names are unique within the net.
+  2. The `result` descr of each procedure is fully resolved: every leaf terminates
+     at a primitive type, or at a colour set declared in `cpnet.colour_sets`. No
+     leaf may reference an unresolved user-defined name.
+  """
+
+  alias ColouredFlow.Definition.ColourSet
+  alias ColouredFlow.Definition.ColouredPetriNet
+  alias ColouredFlow.Definition.Procedure
+  alias ColouredFlow.Validators.Exceptions.MissingColourSetError
+  alias ColouredFlow.Validators.Exceptions.UniqueNameViolationError
+
+  @spec validate(ColouredPetriNet.t()) ::
+          {:ok, ColouredPetriNet.t()}
+          | {:error, UniqueNameViolationError.t() | MissingColourSetError.t()}
+  def validate(%ColouredPetriNet{functions: []} = cpnet), do: {:ok, cpnet}
+
+  def validate(%ColouredPetriNet{} = cpnet) do
+    declared_colour_sets = MapSet.new(cpnet.colour_sets, & &1.name)
+
+    with :ok <- validate_unique_names(cpnet.functions),
+         :ok <- validate_results_resolved(cpnet.functions, declared_colour_sets) do
+      {:ok, cpnet}
+    end
+  end
+
+  @spec validate_unique_names([Procedure.t()]) ::
+          :ok | {:error, UniqueNameViolationError.t()}
+  defp validate_unique_names(functions) do
+    functions
+    |> Enum.reduce_while(MapSet.new(), fn %Procedure{name: name}, seen ->
+      if MapSet.member?(seen, name) do
+        {:halt, {:error, UniqueNameViolationError.exception(scope: :function, name: name)}}
+      else
+        {:cont, MapSet.put(seen, name)}
+      end
+    end)
+    |> case do
+      {:error, _exception} = error -> error
+      _seen -> :ok
+    end
+  end
+
+  @spec validate_results_resolved([Procedure.t()], MapSet.t(ColourSet.name())) ::
+          :ok | {:error, MissingColourSetError.t()}
+  defp validate_results_resolved(functions, declared_colour_sets) do
+    Enum.reduce_while(functions, :ok, fn %Procedure{} = procedure, :ok ->
+      case find_unresolved_descr(procedure.result, declared_colour_sets) do
+        nil ->
+          {:cont, :ok}
+
+        unresolved_name ->
+          {:halt, {:error, missing_colour_set_error(procedure, unresolved_name)}}
+      end
+    end)
+  end
+
+  @spec find_unresolved_descr(ColourSet.descr(), MapSet.t(ColourSet.name())) ::
+          ColourSet.name() | nil
+  defp find_unresolved_descr(descr, declared)
+
+  defp find_unresolved_descr({:integer, []}, _declared), do: nil
+  defp find_unresolved_descr({:float, []}, _declared), do: nil
+  defp find_unresolved_descr({:boolean, []}, _declared), do: nil
+  defp find_unresolved_descr({:binary, []}, _declared), do: nil
+  defp find_unresolved_descr({:unit, []}, _declared), do: nil
+
+  defp find_unresolved_descr({:tuple, types}, declared) when is_list(types) do
+    Enum.find_value(types, &find_unresolved_descr(&1, declared))
+  end
+
+  defp find_unresolved_descr({:map, types}, declared) when is_map(types) do
+    Enum.find_value(types, fn {_key, descr} -> find_unresolved_descr(descr, declared) end)
+  end
+
+  defp find_unresolved_descr({:enum, items}, _declared) when is_list(items), do: nil
+
+  defp find_unresolved_descr({:union, types}, declared) when is_map(types) do
+    Enum.find_value(types, fn {_tag, descr} -> find_unresolved_descr(descr, declared) end)
+  end
+
+  defp find_unresolved_descr({:list, type}, declared), do: find_unresolved_descr(type, declared)
+
+  defp find_unresolved_descr({name, []}, declared) when is_atom(name) do
+    if MapSet.member?(declared, name), do: nil, else: name
+  end
+
+  @spec missing_colour_set_error(Procedure.t(), ColourSet.name()) :: MissingColourSetError.t()
+  defp missing_colour_set_error(%Procedure{} = procedure, unresolved_name) do
+    MissingColourSetError.exception(
+      colour_set: unresolved_name,
+      message: """
+      procedure #{inspect(procedure.name)} declares a result that references the unknown colour set #{inspect(unresolved_name)}
+      """
+    )
+  end
+end

--- a/lib/coloured_flow/validators/definition/guard_validator.ex
+++ b/lib/coloured_flow/validators/definition/guard_validator.ex
@@ -33,9 +33,13 @@ defmodule ColouredFlow.Validators.Definition.GuardValidator do
     :ok
   end
 
-  defp validate_guard(%Transition{guard: %Expression{} = guard}, %ColouredPetriNet{} = cpnet) do
+  defp validate_guard(
+         %Transition{guard: %Expression{} = guard} = transition,
+         %ColouredPetriNet{} = cpnet
+       ) do
     bound_vars =
       cpnet.arcs
+      |> Enum.filter(&(&1.transition == transition.name))
       |> Enum.flat_map(fn
         %Arc{orientation: :p_to_t} = arc -> arc.expression.vars
         %Arc{} -> []

--- a/lib/coloured_flow/validators/exceptions/unique_name_violation_error.ex
+++ b/lib/coloured_flow/validators/exceptions/unique_name_violation_error.ex
@@ -7,7 +7,7 @@ defmodule ColouredFlow.Validators.Exceptions.UniqueNameViolationError do
   use TypedStructor
 
   typed_structor definer: :defexception, enforce: true do
-    field :scope, :colour_set | :variable | :place | :transition
+    field :scope, :colour_set | :variable | :place | :transition | :function
     field :name, String.t() | atom()
   end
 

--- a/lib/coloured_flow/validators/validators.ex
+++ b/lib/coloured_flow/validators/validators.ex
@@ -9,6 +9,7 @@ defmodule ColouredFlow.Validators do
   alias ColouredFlow.Validators.Definition.ArcValidator
   alias ColouredFlow.Validators.Definition.ColourSetValidator
   alias ColouredFlow.Validators.Definition.ConstantsValidator
+  alias ColouredFlow.Validators.Definition.FunctionsValidator
   alias ColouredFlow.Validators.Definition.GuardValidator
   alias ColouredFlow.Validators.Definition.PlacesValidator
   alias ColouredFlow.Validators.Definition.StructureValidator
@@ -24,6 +25,7 @@ defmodule ColouredFlow.Validators do
       {:ok, %ColouredPetriNet{} = cpnet} <- UniqueNameValidator.validate(cpnet),
       {:ok, %ColouredPetriNet{} = cpnet} <- ColourSetValidator.validate(cpnet),
       {:ok, %ColouredPetriNet{} = cpnet} <- PlacesValidator.validate(cpnet),
+      {:ok, %ColouredPetriNet{} = cpnet} <- FunctionsValidator.validate(cpnet),
       {:ok, constants} <- ConstantsValidator.validate(cpnet.constants, cpnet),
       cpnet = %{cpnet | constants: constants},
       {:ok, variables} <- VariablesValidator.validate(cpnet.variables, cpnet),

--- a/test/coloured_flow/validators/definition/functions_validator_test.exs
+++ b/test/coloured_flow/validators/definition/functions_validator_test.exs
@@ -1,0 +1,242 @@
+defmodule ColouredFlow.Validators.Definition.FunctionsValidatorTest do
+  use ExUnit.Case, async: true
+
+  use ColouredFlow.DefinitionHelpers
+  import ColouredFlow.Notation.Colset
+
+  alias ColouredFlow.Definition.Expression
+  alias ColouredFlow.Definition.Procedure
+  alias ColouredFlow.Validators.Definition.FunctionsValidator
+  alias ColouredFlow.Validators.Exceptions.MissingColourSetError
+  alias ColouredFlow.Validators.Exceptions.UniqueNameViolationError
+
+  setup do
+    cpnet = %ColouredPetriNet{
+      colour_sets: [
+        colset(int() :: integer()),
+        colset(user() :: %{name: binary(), age: int()})
+      ],
+      places: [],
+      transitions: [],
+      arcs: [],
+      variables: [],
+      functions: []
+    }
+
+    [cpnet: cpnet]
+  end
+
+  describe "happy path" do
+    test "passes when there are no functions", %{cpnet: cpnet} do
+      assert {:ok, ^cpnet} = FunctionsValidator.validate(cpnet)
+    end
+
+    test "passes when all procedures have primitive result descrs", %{cpnet: cpnet} do
+      cpnet = %{
+        cpnet
+        | functions: [
+            %Procedure{
+              name: :add,
+              expression: Expression.build!("x + y"),
+              result: {:integer, []}
+            },
+            %Procedure{
+              name: :greet,
+              expression: Expression.build!(~S|"hello"|),
+              result: {:binary, []}
+            },
+            %Procedure{
+              name: :truthy?,
+              expression: Expression.build!("true"),
+              result: {:boolean, []}
+            }
+          ]
+      }
+
+      assert {:ok, ^cpnet} = FunctionsValidator.validate(cpnet)
+    end
+
+    test "passes when result descr is a deeply nested composite of primitives", %{cpnet: cpnet} do
+      cpnet = %{
+        cpnet
+        | functions: [
+            %Procedure{
+              name: :nested,
+              expression: Expression.build!("[{1, [2.0]}]"),
+              result:
+                {:list,
+                 {:tuple,
+                  [
+                    {:integer, []},
+                    {:list, {:float, []}}
+                  ]}}
+            },
+            %Procedure{
+              name: :map_result,
+              expression: Expression.build!("%{a: 1, b: 2.0}"),
+              result: {:map, %{a: {:integer, []}, b: {:float, []}}}
+            },
+            %Procedure{
+              name: :colour_choice,
+              expression: Expression.build!(":red"),
+              result: {:enum, [:red, :green, :blue]}
+            },
+            %Procedure{
+              name: :tagged,
+              expression: Expression.build!("{:ok, 1}"),
+              result: {:union, %{ok: {:integer, []}, err: {:binary, []}}}
+            }
+          ]
+      }
+
+      assert {:ok, ^cpnet} = FunctionsValidator.validate(cpnet)
+    end
+  end
+
+  describe "duplicate procedure names" do
+    test "fails with UniqueNameViolationError using :function scope", %{cpnet: cpnet} do
+      cpnet = %{
+        cpnet
+        | functions: [
+            %Procedure{
+              name: :add,
+              expression: Expression.build!("x + y"),
+              result: {:integer, []}
+            },
+            %Procedure{
+              name: :add,
+              expression: Expression.build!("x + y + 1"),
+              result: {:integer, []}
+            }
+          ]
+      }
+
+      assert {
+               :error,
+               %UniqueNameViolationError{scope: :function, name: :add}
+             } = FunctionsValidator.validate(cpnet)
+    end
+  end
+
+  describe "result descrs must be fully resolved" do
+    test "fails with MissingColourSetError when result references unknown name",
+         %{cpnet: cpnet} do
+      cpnet = %{
+        cpnet
+        | functions: [
+            %Procedure{
+              name: :is_odd,
+              expression: Expression.build!("rem(x, 2) == 1"),
+              # ":bool" is not declared in cpnet.colour_sets
+              result: {:bool, []}
+            }
+          ]
+      }
+
+      assert {:error, %MissingColourSetError{colour_set: :bool} = error} =
+               FunctionsValidator.validate(cpnet)
+
+      message = Exception.message(error)
+      assert message =~ "is_odd"
+      assert message =~ "bool"
+    end
+
+    test "fails when an inner leaf of a deeply nested composite is unresolved",
+         %{cpnet: cpnet} do
+      cpnet = %{
+        cpnet
+        | functions: [
+            %Procedure{
+              name: :produce_pairs,
+              expression: Expression.build!("[]"),
+              result:
+                {:list,
+                 {:tuple,
+                  [
+                    {:integer, []},
+                    # ":ghost" is not declared
+                    {:list, {:ghost, []}}
+                  ]}}
+            }
+          ]
+      }
+
+      assert {:error, %MissingColourSetError{colour_set: :ghost} = error} =
+               FunctionsValidator.validate(cpnet)
+
+      message = Exception.message(error)
+      assert message =~ "produce_pairs"
+      assert message =~ "ghost"
+    end
+
+    test "fails when an inner leaf of a map descr is unresolved", %{cpnet: cpnet} do
+      cpnet = %{
+        cpnet
+        | functions: [
+            %Procedure{
+              name: :build_user,
+              expression: Expression.build!("%{name: \"alice\", age: 21}"),
+              result:
+                {:map,
+                 %{
+                   name: {:binary, []},
+                   age: {:phantom_int, []}
+                 }}
+            }
+          ]
+      }
+
+      assert {:error, %MissingColourSetError{colour_set: :phantom_int} = error} =
+               FunctionsValidator.validate(cpnet)
+
+      message = Exception.message(error)
+      assert message =~ "build_user"
+      assert message =~ "phantom_int"
+    end
+
+    test "fails when a union arm is unresolved", %{cpnet: cpnet} do
+      cpnet = %{
+        cpnet
+        | functions: [
+            %Procedure{
+              name: :tagged,
+              expression: Expression.build!("{:ok, 1}"),
+              result:
+                {:union,
+                 %{
+                   ok: {:integer, []},
+                   err: {:missing_type, []}
+                 }}
+            }
+          ]
+      }
+
+      assert {:error, %MissingColourSetError{colour_set: :missing_type} = error} =
+               FunctionsValidator.validate(cpnet)
+
+      assert Exception.message(error) =~ "tagged"
+    end
+
+    test "passes when nested composite leaves all resolve to declared colour sets",
+         %{cpnet: cpnet} do
+      # `:int` and `:user` are declared in setup
+      cpnet = %{
+        cpnet
+        | functions: [
+            %Procedure{
+              name: :user_list,
+              expression: Expression.build!("[]"),
+              result: {:list, {:user, []}}
+            },
+            %Procedure{
+              name: :wrap_int,
+              expression: Expression.build!("{:ok, 1}"),
+              result: {:union, %{ok: {:int, []}, err: {:binary, []}}}
+            }
+          ]
+      }
+
+      assert {:ok, ^cpnet} = FunctionsValidator.validate(cpnet)
+    end
+  end
+end

--- a/test/coloured_flow/validators/definition/guard_validator_test.exs
+++ b/test/coloured_flow/validators/definition/guard_validator_test.exs
@@ -75,4 +75,84 @@ defmodule ColouredFlow.Validators.Definition.GuardValidatorTest do
 
     assert {:error, %InvalidGuardError{reason: :unbound_vars}} = GuardValidator.validate(cpnet)
   end
+
+  describe "per-transition guard scope" do
+    setup do
+      # Two transitions, each with its own incoming arc binding a different
+      # variable. The guard scope must be evaluated per-transition rather than
+      # over the union of all bindings across the net.
+      cpnet = %ColouredPetriNet{
+        colour_sets: [
+          colset(int() :: integer())
+        ],
+        places: [
+          %Place{name: "in_a", colour_set: :int},
+          %Place{name: "in_b", colour_set: :int},
+          %Place{name: "out_a", colour_set: :int},
+          %Place{name: "out_b", colour_set: :int}
+        ],
+        transitions: [
+          build_transition!(name: "t1", guard: "true"),
+          build_transition!(name: "t2", guard: "true")
+        ],
+        arcs: [
+          build_arc!(
+            place: "in_a",
+            transition: "t1",
+            orientation: :p_to_t,
+            expression: "bind {1, x}"
+          ),
+          build_arc!(
+            place: "out_a",
+            transition: "t1",
+            orientation: :t_to_p,
+            expression: "{1, x}"
+          ),
+          build_arc!(
+            place: "in_b",
+            transition: "t2",
+            orientation: :p_to_t,
+            expression: "bind {1, y}"
+          ),
+          build_arc!(
+            place: "out_b",
+            transition: "t2",
+            orientation: :t_to_p,
+            expression: "{1, y}"
+          )
+        ],
+        variables: [
+          %Variable{name: :x, colour_set: :int},
+          %Variable{name: :y, colour_set: :int}
+        ]
+      }
+
+      [cpnet: cpnet]
+    end
+
+    test "fails when t1's guard references a var bound only by t2's incoming arc",
+         %{cpnet: cpnet} do
+      cpnet = put_t1_guard(cpnet, "y > 0")
+
+      assert {:error, %InvalidGuardError{reason: :unbound_vars}} =
+               GuardValidator.validate(cpnet)
+    end
+
+    test "passes when t1's guard references a var bound by t1's own incoming arc",
+         %{cpnet: cpnet} do
+      cpnet = put_t1_guard(cpnet, "x > 0")
+
+      assert {:ok, _cpnet} = GuardValidator.validate(cpnet)
+    end
+
+    defp put_t1_guard(%ColouredPetriNet{transitions: [_t1, t2]} = cpnet, guard) do
+      %ColouredPetriNet{
+        cpnet
+        | transitions: [
+            build_transition!(name: "t1", guard: guard),
+            t2
+          ]
+      }
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Addresses two findings from the codex review of the DSL PR:

- **Correctness #2 — Missing functions validator.** `cpnet.functions` was never validated. This PR adds `Validators.Definition.FunctionsValidator` which:
  1. Enforces unique procedure names within the net (raising `UniqueNameViolationError` with the new `:function` scope).
  2. Walks each procedure's `result :: ColourSet.descr()` recursively (`:tuple`, `:map`, `:list`, `:union`, `:enum`) and confirms every leaf terminates at a primitive type (`:integer | :float | :boolean | :binary | :unit`) or at a colour set declared in `cpnet.colour_sets`. Unresolved compound names like `{:bool, []}` raise `MissingColourSetError` with a message that names the offending procedure.

  Wired into the validator pipeline after `PlacesValidator` and before `ConstantsValidator`. `UniqueNameViolationError`'s `:scope` enum is extended with `:function`.

- **Correctness #3 — Guard scope leaks across transitions.** `GuardValidator` collected `bound_vars` from every transition's incoming arcs, so a guard on T1 could legally reference a variable bound only by T2's incoming arc. This mirrors the bug already fixed for `ArcValidator` in #78. Filter `cpnet.arcs` by `arc.transition == transition.name` before flattening.

## Test plan

- [x] `mix compile --warnings-as-errors` clean
- [x] `mix format --check-formatted` clean
- [x] `mix credo --strict` — 0 issues
- [x] `mix dialyzer` — `Total errors: 6, Skipped: 6` (matches baseline)
- [x] `MIX_ENV=test mix test` — 478 tests, 0 failures
- [x] New `FunctionsValidatorTest` covers happy path, duplicate names, primitive descrs, deeply nested composite descrs, and unresolved leaves at every level (`:list`, `:tuple`, `:map`, `:union`)
- [x] New `GuardValidatorTest` cases assert per-transition scoping: a guard in T1 referencing T2's bound variable now fails; a guard in T1 referencing T1's own bound variable still passes (regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)