### PR TITLE
fix(docs): kino grid headers + drop redundant livemd subheading

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,8 @@ defmodule TrafficLight do
         {"#{color}_#{dir}", Kino.Frame.new(placeholder: false)}
       end
 
-    grid = Kino.Layout.grid([EW, NS] ++ Keyword.values(lights), columns: 2)
+    headers = [Kino.Text.new("EW"), Kino.Text.new("NS")]
+    grid = Kino.Layout.grid(headers ++ Keyword.values(lights), columns: 2)
 
     {grid, lights}
   end

--- a/examples/traffic_light.livemd
+++ b/examples/traffic_light.livemd
@@ -147,7 +147,8 @@ defmodule TrafficLight do
         {"#{color}_#{dir}", Kino.Frame.new(placeholder: false)}
       end
 
-    grid = Kino.Layout.grid([EW, NS] ++ Keyword.values(lights), columns: 2)
+    headers = [Kino.Text.new("EW"), Kino.Text.new("NS")]
+    grid = Kino.Layout.grid(headers ++ Keyword.values(lights), columns: 2)
 
     {grid, lights}
   end
@@ -210,12 +211,6 @@ Kino.inspect("Runner supervisor started: #{inspect(supervisor_pid)}")
 
 :ok
 ```
-
-## Action runner
-
-Every transition's `action do ... end` body runs inside a `Task` spawned under
-the workflow's `Task.Supervisor`. The supervisor below owns that single child;
-the runner keeps no separate per-direction process.
 
 ```elixir
 defmodule TrafficLight.Supervisor do


### PR DESCRIPTION
## Summary

Two follow-up fixes for PR #88's traffic-light rewrite, surfaced by Copilot review on the merged PR.

- **`[EW, NS]` in `Kino.Layout.grid/2`** is parsed as the *module aliases* \`:Elixir.EW\` / \`:Elixir.NS\`, not as Kino renderables — the grid would crash at runtime. Replace with explicit \`[Kino.Text.new(\"EW\"), Kino.Text.new(\"NS\")]\` headers in both `README.md` and `examples/traffic_light.livemd`.
- **Redundant `## Action runner` subheading** in the livemd: the prior subagent introduced it to host a 3-line note about action bodies running under the workflow's `Task.Supervisor`. The simplified `TrafficLight.Supervisor` cell hangs naturally under the existing `## Prepare the storage and supervisor` heading; drop the heading + note.

## Test plan

- [x] \`mix format --check-formatted README.md examples/traffic_light.livemd\` — clean.
- [ ] Manual: render the livemd in Livebook end-to-end to confirm the grid renders \"EW\" / \"NS\" headers above the light frames.

🤖 Generated with [Claude Code](https://claude.com/claude-code)