### PR TITLE
feat: add coloured-flow agent skill

### DIFF
--- a/.claude/skills/coloured-flow/SKILL.md
+++ b/.claude/skills/coloured-flow/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: coloured-flow
+description: Build a Coloured Petri Net workflow as a `use ColouredFlow.DSL` Elixir module. Use when the user asks to model concurrent or stateful processes, state machines with event sourcing, business flows that decompose into independently firable steps with shared state, or anything described as a workflow, pipeline with branches, choreography, or saga. Output is a single Elixir module validated at `mix compile`. Skip for purely sequential scripts, one-shot calculations, or flows with no concurrency and no shared state.
+---
+
+# ColouredFlow workflow modelling
+
+Solve the problem by emitting a `defmodule … do; use ColouredFlow.DSL; … end` module. The DSL's `@before_compile` pass runs the full validator suite, so a green `mix compile` is the proof that the model is structurally sound — undeclared colour sets, unbound variables, free vars not provable from incoming arcs, dangling arc endpoints, and mismatched colour sets all surface there. Dynamic side effects (actions, lifecycle reactions) live inside the same module and dispatch through the runner's `LifecycleHooks` callbacks.
+
+## When to use
+
+Reach for this skill when the problem has at least one of:
+
+- multiple steps that can fire concurrently or in any order;
+- shared state observed across steps (token counts, queues, locks, set membership);
+- explicit state-machine transitions where the next step depends on what is currently true;
+- a need for replay, snapshot, or event-sourced recovery;
+- business rules expressed as preconditions on shared state rather than control flow inside one function.
+
+Skip it when:
+
+- the flow is a straight line of function calls — write a function;
+- there is no state shared between steps — write a pipeline (`|>`);
+- the problem is dominated by data transformation rather than control flow;
+- one process / GenServer with a `:state` atom is enough.
+
+## Mental model
+
+| CPN concept | Elixir DSL                    | Read as                                                  |
+| ----------- | ----------------------------- | -------------------------------------------------------- |
+| place       | `place :name, :colset`        | typed slot that holds tokens                             |
+| token       | element of `~MS[…]`           | single piece of data sitting on a place                  |
+| colour set  | `colset name() :: type()`     | type that a place's tokens must conform to               |
+| variable    | `var x :: colset()`           | binding consumed by an arc, reusable in expressions      |
+| constant    | `val k :: colset() = literal` | named compile-time literal                               |
+| transition  | `transition :name do … end`   | event that consumes input tokens and produces outputs    |
+| input arc   | `input :place, bind({n, x})`  | consume `n` copies matching `x` from `:place`            |
+| output arc  | `output :place, {n, expr}`    | put `n` copies of `expr` onto `:place`                   |
+| guard       | `guard expr`                  | bool over bound vars; falsy disables the binding         |
+| action      | `action do … end`             | side effect run after the firing commits                 |
+| termination | `on_markings do … end`        | predicate over the current marking that ends the run     |
+| function    | `function f(args) :: ret()`   | pure CPN procedure callable from any expression position |
+
+A *binding* is a concrete assignment of variables to consumed tokens that satisfies every input arc and the guard. Each enabled binding becomes a *workitem* (`enabled → started → completed`). Firing it emits an `Occurrence` — the event-sourced ground truth that the runner replays to rebuild state after a crash.
+
+Tokens are bag-multiplied: `bind({2, 1})` consumes *two* copies of the literal `1`; `output :p, {3, x}` puts *three* copies of `x`. The first element is the multiplicity, the second is the value.
+
+## Minimal viable workflow
+
+```elixir
+defmodule MyApp.Workflows.PassThrough do
+  use ColouredFlow.DSL
+
+  name "Pass Through"
+  version "1.0.0"
+
+  colset int() :: integer()
+  var x :: int()
+
+  place :input, :int
+  place :output, :int
+
+  initial_marking :input, ~MS[1 2 3]
+
+  transition :move do
+    input :input, bind({1, x})
+    output :output, {1, x}
+  end
+end
+```
+
+Compile it: `mix compile`. Any structural problem (undeclared colour set, unbound variable, type mismatch, missing arc endpoint) raises a `CompileError` pointing at the offending line. From `iex -S mix`, `MyApp.Workflows.PassThrough.cpnet()` returns the materialised `%ColouredPetriNet{}`.
+
+## Modelling checklist
+
+Before writing the module, answer in order:
+
+1. **What types flow through this system?** → one `colset` per type. Reuse primitives (`int()`, `bool()`, `binary()`); add tuple/union colsets for compound data.
+2. **What are the stable states the system passes through?** → one `place` per state. Place names are atoms; their stored form is the string version (use the string when matching `markings` in termination).
+3. **What events move the system between states?** → one `transition` per event.
+4. **For each transition: what must already be true?** → input arcs (consume from places) and `guard` (boolean over bound vars).
+5. **What changes after the event fires?** → output arcs (produce to places) and optional `action do … end` for side effects.
+6. **What does it mean for the workflow to be done?** → `termination do; on_markings do … end; end`. Otherwise the runner stops only when no transition is enabled (`:implicit`) or the operator forces it (`:force`).
+7. **What initial state?** → `initial_marking :place, ~MS[…]` for every place that should not start empty.
+
+## Output discipline
+
+- One workflow = one module. Keep helper logic (renderers, drivers) as private/public functions on the same module so the lifecycle hook bodies can call them by name.
+- Every `colset` that appears in a `place` declaration must be declared. The atom in `place :p, :int` refers to a `colset int() :: …` — the parens form is mandatory at the declaration site.
+- Variables must be declared with `var` before any arc references them. The DSL does not infer.
+- Inside `output do … end` blocks, every branch must evaluate to either a `{multiplicity, value}` tuple or `~MS[…]`-shaped data. `if`/`case` works as long as every branch returns the same colour set.
+- Inside `input do … end` blocks, every branch must be a `bind/1` call.
+
+## Validation loop
+
+1. `mix compile` — must succeed; treat each `CompileError` as a model bug, fix at the source.
+2. `iex -S mix` → `cpnet()` returns a struct → `__cpn__(:initial_markings)` returns the seed list.
+3. For runtime testing, see `references/running.md`.
+4. For larger / more interesting shapes, copy from `references/patterns.md` and adapt.
+
+## References
+
+- `references/dsl-reference.md` — every macro, every option, exhaustive surface area.
+- `references/patterns.md` — canonical workflow patterns (sequence, parallel-split, deferred choice, AND-join, thread-merge, transmission protocol, state machine with lifecycle drive).
+- `references/running.md` — set up storage, insert flow + enactment, drive workitems, observe markings, wire lifecycle hooks, terminate.
+- Project-level authoritative sources: `lib/coloured_flow/dsl/spec.md` (DSL spec) and `examples/traffic_light.livemd` (full Livebook walkthrough). Read these when references are insufficient.

--- a/.claude/skills/coloured-flow/references/dsl-reference.md
+++ b/.claude/skills/coloured-flow/references/dsl-reference.md
@@ -1,0 +1,318 @@
+# DSL reference
+
+Every macro the DSL exposes, every option it accepts, with a runnable snippet. Authoritative source: `lib/coloured_flow/dsl/spec.md`. This page is a working reference; reach for the spec when something here is silent.
+
+## Module setup
+
+```elixir
+defmodule MyApp.Workflows.MyFlow do
+  use ColouredFlow.DSL
+  # … declarations …
+end
+```
+
+### Module options
+
+`use ColouredFlow.DSL` accepts:
+
+- `:task_supervisor` — registered name of a `Task.Supervisor` that wraps every `action do … end` body and every `on_enactment_*` body. Without it, bodies fall back to an unsupervised `Task.start/1`. Production code should always provide one.
+
+```elixir
+use ColouredFlow.DSL, task_supervisor: MyApp.WorkflowTaskSup
+```
+
+## Universal expression rule
+
+Every macro that takes an expression follows the same shape:
+
+- **Single-line**: the expression is the last positional argument.
+- **Multi-line**: pass a `do … end` block; the block body *is* the expression. There is no `expr do … end` wrapper.
+- **Options** (e.g., `label:`): keyword arguments only, between the positional arguments and the `do` block.
+
+```elixir
+guard x > 0                               # single-line
+guard do x > 0 and y > 0 end              # multi-line
+
+input :p, bind({1, x})                    # single-line, no label
+input :p, bind({1, x}), label: "in"       # single-line, label
+input :p, label: "in" do                  # multi-line, label
+  if x > 0, do: bind({1, x}), else: bind({2, x})
+end
+```
+
+## Top-level macros
+
+### `name/1`
+
+Human-readable name. Optional but recommended.
+
+```elixir
+name "Order Pipeline"
+```
+
+### `version/1`
+
+Version string. Free-form; semver is conventional. Optional.
+
+```elixir
+version "1.0.0"
+```
+
+### `colset/1`
+
+Declares a colour set. Re-exported from `ColouredFlow.Notation.Colset`.
+
+```elixir
+colset int()    :: integer()
+colset bool()   :: boolean()
+colset bin()    :: binary()
+colset signal() :: {}                            # unit type
+colset point()  :: {integer(), integer()}        # tuple
+colset status() :: ok | err                      # union of atoms
+colset id_data() :: {integer(), binary()}        # heterogeneous tuple
+```
+
+The colour-set name is referenced as an atom in `place/2`: `place :input, :int` refers to `colset int() :: …`.
+
+### `var/1`
+
+Declares a variable bound to a colour set. Re-exported from `ColouredFlow.Notation.Var`. Variables are reusable across transitions but are scoped by where they appear (each transition's incoming arcs bind their own copy).
+
+```elixir
+var x :: int()
+var s :: signal()
+var n :: no()
+```
+
+### `val/1`
+
+Declares a constant. Re-exported from `ColouredFlow.Notation.Val`.
+
+```elixir
+val pi :: float() = 3.14
+val limit :: int() = 100
+```
+
+### `place/2`
+
+Declares a place. Place names are atoms; the underlying `%Place{}` stores them as strings, which matters when matching against the `markings` map in termination.
+
+```elixir
+place :input, :int
+place :output, :int
+```
+
+### `initial_marking/2`
+
+Declares an initial marking on a place. Multiple `initial_marking/2` calls accumulate in declaration order. The `cpnet/0` struct itself is *not* affected; the markings are exposed via `__cpn__(:initial_markings)` and consumed when an enactment is started.
+
+```elixir
+initial_marking :input, ~MS[1 2 3]
+initial_marking :output, ~MS[]
+initial_marking :red_ew, ~MS[{}]                 # signal token
+```
+
+The `~MS` sigil literal: `~MS[a b c]` = three tokens (`a`, `b`, `c`), `~MS[{2, x}]` = two copies of `x`, `~MS[{}]` = single unit token.
+
+### `function/1` and `function/2`
+
+Declares a user-defined function (CPN procedure) callable from any arc / guard / action / termination expression.
+
+```elixir
+function is_even(x) :: bool(), do: Integer.mod(x, 2) === 0
+
+function double(x) :: int() do
+  x * 2
+end
+```
+
+Argument names listed in the head must appear as free variables in the body; the colour set after `::` is the result type. Function names must be unique within a module.
+
+### `transition/2`
+
+Declares a transition. The block accepts `guard/1`, `action/1`, `input/{2,3}`, and `output/{2,3}`.
+
+```elixir
+transition :pass_through do
+  guard x > 0
+
+  input :input, bind({1, x})
+  output :output, {1, x * 2}
+
+  action do
+    :ok
+  end
+end
+```
+
+### `termination/1`
+
+Declares termination criteria. The block currently accepts `on_markings/1`. Future kinds (`on_time`, `on_workitem_count`, …) plug in here without changing call sites.
+
+```elixir
+termination do
+  on_markings do
+    match?(
+      %{"output" => out_ms} when multi_set_coefficient(out_ms, 1) >= 5,
+      markings
+    )
+  end
+end
+```
+
+## Transition-scope macros
+
+### `guard/1`
+
+Boolean expression over bound variables. Optional. A falsy result disables the transition for the current binding. At most one `guard` per transition.
+
+```elixir
+guard x > 0
+guard do
+  x > 0 and is_even(x)
+end
+```
+
+### `action/1`
+
+Side-effect body, evaluated by the auto-generated `on_workitem_completed/2` callback after the firing commits. Optional. At most one `action` per transition. The body compiles into `__action_for__/3` and runs inside the configured `Task.Supervisor` (or unsupervised `Task.start/1` when none).
+
+Magic bindings inside the body:
+
+- every CPN variable bound by this transition's incoming arcs;
+- `event` — `%{enactment_id, markings, workitem, occurrence, binding}` of the completed-workitem event;
+- `options` — the keyword list registered with the hook module via the `{module, options}` tuple form (or `[]` when the module is registered alone).
+
+```elixir
+action do
+  Phoenix.PubSub.broadcast(
+    MyApp.PubSub,
+    options[:topic] || "fires",
+    {:fired, event.workitem.binding_element.transition, x}
+  )
+end
+```
+
+Exceptions raised from `action` bodies are caught and discarded — the runner must never block on user side effects. Anything that has to fail loudly should fail at definition time, not runtime.
+
+### `input/2` and `input/3`
+
+Declares an incoming arc (place → transition). The expression must use `bind/1` to consume tokens. Option: `:label`.
+
+```elixir
+input :input, bind({1, x})
+input :input, bind({1, x}), label: "in"
+input :input, label: "in" do
+  if x > 0, do: bind({1, x}), else: bind({2, x})
+end
+input :merge, bind({2, 1})                       # require two copies of literal 1
+```
+
+### `output/2` and `output/3`
+
+Declares an outgoing arc (transition → place). The expression evaluates to a `{multiplicity, value}` tuple, a multiset, or — inside a `do` block — any expression whose every branch evaluates to the same colour set. Option: `:label`.
+
+```elixir
+output :output, {1, x}
+output :output, {1, x}, label: "out"
+output :output, label: "out" do
+  if x > 0, do: {1, x}, else: {0, x}             # zero copies = no token produced
+end
+output :a, {1, {n, d}}                           # heterogeneous tuple token
+```
+
+## Termination-scope macros
+
+### `on_markings/1`
+
+Boolean expression over the magic variable `markings` — a map keyed by *string* place names (because `place :input` is stored as `"input"`) to token multisets. Truthy result terminates the enactment with reason `:explicit`. At most one `on_markings` per workflow.
+
+```elixir
+on_markings do
+  match?(
+    %{"output" => out_ms} when multi_set_coefficient(out_ms, 1) >= 5,
+    markings
+  )
+end
+```
+
+`multi_set_coefficient/2` returns the multiplicity of a value in a multiset.
+
+## Lifecycle macros
+
+These compile to `ColouredFlow.Runner.Enactment.LifecycleHooks` callbacks. They are the structured per-instance counterpart to `:telemetry`. Each may appear at most once per workflow; a duplicate is a compile-time error. Magic bindings: `event` (event payload) and `options` (the keyword list registered alongside the hook module via `{module, options}`).
+
+### `on_enactment_start/1`
+
+Runs after the enactment process has booted and replayed history.
+
+```elixir
+on_enactment_start do
+  TrafficLight.render(options[:frames], event.markings)
+  TrafficLight.drive_next(event.enactment_id, "turn_green_ew")
+end
+```
+
+### `on_enactment_terminate/1`
+
+Runs when termination is reached (any kind).
+
+```elixir
+on_enactment_terminate do
+  Logger.info("Enactment #{event.enactment_id} terminated: #{inspect(event.reason)}")
+end
+```
+
+### `on_enactment_exception/1`
+
+Runs when the enactment enters the `:exception` state.
+
+```elixir
+on_enactment_exception do
+  Logger.error("Exception in #{event.enactment_id}: #{inspect(event.reason)}")
+end
+```
+
+## Generated module surface
+
+A module that uses `ColouredFlow.DSL` exposes:
+
+```elixir
+MyFlow.cpnet()                                    # %ColouredPetriNet{}
+MyFlow.__cpn__(:name)                             # String.t() | nil
+MyFlow.__cpn__(:version)                          # String.t() | nil
+MyFlow.__cpn__(:initial_markings)                 # [%ColouredFlow.Enactment.Marking{}]
+
+MyFlow.insert_enactment(flow_id)                  # {:ok, %Schemas.Enactment{}}
+MyFlow.insert_enactment(flow_id, [%Marking{}])
+MyFlow.insert_enactment(flow_id, [%Marking{}], opts)
+MyFlow.start_enactment(enactment_id, opts)        # DynamicSupervisor.on_start_child()
+
+# LifecycleHooks callbacks (auto-dispatched)
+MyFlow.on_workitem_completed(event, options)      # always emitted; dispatches `action` bodies
+MyFlow.on_enactment_start(event, options)         # only if `on_enactment_start` declared
+MyFlow.on_enactment_terminate(event, options)     # only if declared
+MyFlow.on_enactment_exception(event, options)     # only if declared
+```
+
+`cpnet/0` is the **main API** — the static CPN reused across every enactment of the workflow. `__cpn__/1` is a **reflection helper** modeled after `Ecto.Schema.__schema__/1`; pass an atom key to read declaration metadata.
+
+`insert_enactment/3` is a thin wrapper over `ColouredFlow.Runner.Storage.insert_enactment/1`. It is *not* idempotent — every call inserts a fresh row, so application code must deduplicate at boot if needed. The flow row itself must already exist; insert flows directly via the storage primitives:
+
+- `Default` backend: `%Schemas.Flow{} |> Ecto.Changeset.cast(...) |> Repo.insert!()`
+- `InMemory` backend: `Storage.InMemory.insert_flow!/1`
+
+`start_enactment/2` registers the workflow module as the per-instance `LifecycleHooks`. To inject per-instance configuration, pass `lifecycle_hooks: {__MODULE__, options}` — the `options` keyword list is forwarded to every callback as the second argument and exposed inside DSL bodies as the magic binding `options`. To disable hooks for one enactment, pass `lifecycle_hooks: nil`.
+
+## Compile-time validation
+
+The `@before_compile` hook builds a `%ColouredPetriNet{}` from the accumulated declarations, runs `ColouredFlow.Builder.build/1` (which populates `action.outputs` from arc/guard analysis), and runs `ColouredFlow.Validators.run/1`. Failures raise `CompileError` with `{file, line}` metadata captured at macro expansion. The validator checks:
+
+- colour-set declarations are well-formed;
+- place / variable / constant colour-set references resolve;
+- arc endpoints exist (place, transition);
+- incoming arcs use `bind/1`;
+- free variables in expressions resolve to a `var/1` (or function arg);
+- guard variables are bound by the same transition's incoming arcs;
+- function names are unique and result descrs fully resolve;
+- termination criteria reference only `markings`.

--- a/.claude/skills/coloured-flow/references/patterns.md
+++ b/.claude/skills/coloured-flow/references/patterns.md
@@ -1,0 +1,357 @@
+# Workflow patterns
+
+Canonical patterns mined from the project's own test fixtures (`test/coloured_flow/dsl/cpnet_examples_test.exs`) and the `examples/traffic_light.livemd` walkthrough. Each one compiles. Adapt the colour sets, place/transition names, and guards to fit the problem; keep the structural shape.
+
+## 1. Simple sequence
+
+One transition moves a token from input to output unchanged.
+
+**When**: a single observable step with shared state.
+
+```elixir
+defmodule SimpleSequence do
+  use ColouredFlow.DSL
+
+  colset int() :: integer()
+  var x :: int()
+
+  place :input, :int
+  place :output, :int
+
+  transition :pass_through do
+    input :input, bind({1, x}), label: "in"
+    output :output, {1, x}, label: "out"
+  end
+end
+```
+
+## 2. Parallel split
+
+One transition produces tokens onto several downstream places, each consumed by an independent transition. The two `:pass_through_*` workitems run independently and concurrently.
+
+**When**: a single event fans out into multiple independent follow-ups.
+
+```elixir
+defmodule ParallelSplit do
+  use ColouredFlow.DSL
+
+  colset int() :: integer()
+  var x :: int()
+
+  place :input, :int
+  place :place_1, :int
+  place :place_2, :int
+  place :output_1, :int
+  place :output_2, :int
+
+  transition :parallel_split do
+    input :input, bind({1, x})
+    output :place_1, {1, x}
+    output :place_2, {1, x}
+  end
+
+  transition :pass_through_1 do
+    input :place_1, bind({1, x})
+    output :output_1, {1, x}
+  end
+
+  transition :pass_through_2 do
+    input :place_2, bind({1, x})
+    output :output_2, {1, x}
+  end
+end
+```
+
+## 3. Deferred choice
+
+Multiple transitions consume from the same input place. The first one to fire wins; the runner / external driver decides which. There is no built-in branch-selection logic — the *deferring* is the point.
+
+**When**: an event has alternative responses and the choice is made by whoever drives the workitems (a user, a scheduler, an LLM acting on policy).
+
+```elixir
+defmodule DeferredChoice do
+  use ColouredFlow.DSL
+
+  colset int() :: integer()
+  var x :: int()
+
+  place :input, :int
+  place :place, :int
+  place :output_1, :int
+  place :output_2, :int
+
+  transition :pass_through do
+    input :input, bind({1, x})
+    output :place, {1, x}
+  end
+
+  transition :deferred_choice_1 do
+    input :place, bind({1, x})
+    output :output_1, {1, x}
+  end
+
+  transition :deferred_choice_2 do
+    input :place, bind({1, x})
+    output :output_2, {1, x}
+  end
+end
+```
+
+## 4. Generalised AND-join
+
+A transition with multiple input places that all must contribute matching tokens before it can fire. The default (no extra constraint) requires *one token from each input*; share a variable across input arcs to require matching values.
+
+**When**: multiple precondition streams must all be ready before the next step.
+
+```elixir
+defmodule GeneralizedAndJoin do
+  use ColouredFlow.DSL
+
+  colset int() :: integer()
+  var x :: int()
+
+  place :input1, :int
+  place :input2, :int
+  place :input3, :int
+  place :output, :int
+
+  transition :and_join do
+    input :input1, bind({1, x}), label: "input1"
+    input :input2, bind({1, x}), label: "input2"
+    input :input3, bind({1, x}), label: "input3"
+
+    output :output, {1, x}, label: "output"
+  end
+end
+```
+
+The shared `x` across all three input arcs forces *the same value* to appear on every input — that is what makes this a generalised AND-join rather than three independent consumers. Use distinct variables (`x`, `y`, `z`) to drop that constraint.
+
+## 5. Thread merge (counted join)
+
+A single transition that pulls *N copies* off one place. Use `bind({N, value})` on the input arc.
+
+**When**: collecting N parallel results before continuing (counting semaphore, batch threshold).
+
+```elixir
+defmodule ThreadMerge do
+  use ColouredFlow.DSL
+
+  colset int() :: integer()
+  var x :: int()
+
+  place :input, :int
+  place :merge, :int
+  place :output, :int
+
+  transition :branch_1 do
+    input :input, bind({1, x})
+    output :merge, {1, x}
+  end
+
+  transition :branch_2 do
+    input :input, bind({1, x})
+    output :merge, {1, x}
+  end
+
+  transition :thread_merge do
+    input :merge, bind({2, 1})                   # require two copies of literal 1
+    output :output, {1, 1}
+  end
+end
+```
+
+The literal value (`1`) in `bind({2, 1})` makes the merge insensitive to the actual values on `:merge`; replace with a variable to require *N copies of the same value*.
+
+## 6. Transmission protocol with retries
+
+Looped flow with conditional outputs (success / failure branches), an explicit acknowledgement channel, and stateful counters that survive across firings.
+
+**When**: protocols, retry loops, idempotent re-delivery, anything where the same transition must keep firing until a condition holds.
+
+```elixir
+defmodule TransmissionProtocol do
+  use ColouredFlow.DSL
+
+  colset no()      :: integer()
+  colset data()    :: binary()
+  colset no_data() :: {integer(), binary()}
+  colset bool()    :: boolean()
+
+  var n :: no()
+  var k :: no()
+  var d :: data()
+  var data :: data()
+  var success :: bool()
+
+  place :packets_to_send, :no_data
+  place :a, :no_data
+  place :b, :no_data
+  place :data_recevied, :data
+  place :next_rec, :no
+  place :c, :no
+  place :d, :no
+  place :next_send, :no
+
+  transition :send_packet do
+    input :packets_to_send, bind({1, {n, d}})
+    input :next_send, bind({1, {1, n}})
+
+    output :packets_to_send, {1, {n, d}}         # keep packet (loop until acked)
+    output :a, {1, {n, d}}
+    output :next_send, {1, {1, n}}
+  end
+
+  transition :transmit_packet do
+    input :a, bind({1, {n, d}})
+
+    # `success` is a free variable in the output expression; the runner
+    # treats it as nondeterministic and explores both branches.
+    output :b, if(success, do: {1, {n, d}}, else: {0, {n, d}})
+  end
+
+  transition :receive_packet do
+    input :b, bind({1, {n, d}})
+    input :data_recevied, bind({1, data})
+    input :next_rec, bind({1, k})
+
+    output :data_recevied, if(n == k, do: {1, data <> d}, else: {1, data})
+    output :c, if(n == k, do: {1, k + 1}, else: {1, k})
+    output :next_rec, if(n == k, do: {1, k + 1}, else: {1, k})
+  end
+
+  transition :transmit_ack do
+    input :c, bind({1, n})
+
+    output :d, if(success, do: {1, n}, else: {0, n})
+  end
+
+  transition :receive_ack do
+    input :next_send, bind({1, k})
+    input :d, bind({1, n})
+
+    output :next_send, {1, n}
+  end
+end
+```
+
+Key tricks:
+
+- `output :packets_to_send, {1, {n, d}}` on `:send_packet` *re-deposits* the packet, so the sender keeps trying until acknowledgement bumps the sequence number.
+- `output :p, if(cond, do: {1, …}, else: {0, …})` — multiplicity `0` means "produce nothing". This is the idiomatic conditional output.
+- Sequence numbers (`n`, `k`) live in dedicated counter places (`:next_send`, `:next_rec`); transitions read-and-write them in one firing.
+
+## 7. State machine with lifecycle drive
+
+A finite-state machine where a single token (often the unit token `{}`) cycles through a fixed sequence of places, with side effects scheduled by `action` and the next firing kicked off by a lifecycle hook.
+
+**When**: traffic lights, signalling protocols, recurring schedulers, anywhere the workflow itself is the supervisor of its own clock.
+
+Reduced from `examples/traffic_light.livemd`:
+
+```elixir
+defmodule TrafficLight do
+  use ColouredFlow.DSL, task_supervisor: TrafficLight.TaskSup
+
+  alias ColouredFlow.Runner.Enactment.WorkitemTransition
+  alias ColouredFlow.Runner.Storage
+
+  name "TrafficLight"
+
+  colset signal() :: {}
+  var s :: signal()
+
+  place :red_ew, :signal
+  place :green_ew, :signal
+  place :yellow_ew, :signal
+  place :red_ns, :signal
+  place :green_ns, :signal
+  place :yellow_ns, :signal
+  place :safe_ew, :signal
+  place :safe_ns, :signal
+
+  initial_marking :red_ew, ~MS[{}]
+  initial_marking :red_ns, ~MS[{}]
+  initial_marking :safe_ew, ~MS[{}]
+
+  transition :turn_green_ew do
+    input :red_ew, bind({1, s})
+    input :safe_ew, bind({1, s})
+    output :green_ew, {1, s}
+
+    action do
+      TrafficLight.render(options[:frames], event.markings)
+      :timer.sleep(10_000)
+      TrafficLight.drive_next(event.enactment_id, "turn_yellow_ew")
+    end
+  end
+
+  transition :turn_yellow_ew do
+    input :green_ew, bind({1, s})
+    output :yellow_ew, {1, s}
+
+    action do
+      TrafficLight.render(options[:frames], event.markings)
+      :timer.sleep(3_000)
+      TrafficLight.drive_next(event.enactment_id, "turn_red_ew")
+    end
+  end
+
+  transition :turn_red_ew do
+    input :yellow_ew, bind({1, s})
+    output :red_ew, {1, s}
+    output :safe_ns, {1, s}
+
+    action do
+      TrafficLight.render(options[:frames], event.markings)
+      TrafficLight.drive_next(event.enactment_id, "turn_green_ns")
+    end
+  end
+
+  # … symmetrical NS transitions …
+
+  on_enactment_start do
+    TrafficLight.render(options[:frames], event.markings)
+    TrafficLight.drive_next(event.enactment_id, "turn_green_ew")
+  end
+
+  @doc false
+  def drive_next(enactment_id, transition_name) when is_binary(transition_name) do
+    enactment_id
+    |> Storage.list_live_workitems()
+    |> Enum.find(fn wi ->
+      wi.state == :enabled and wi.binding_element.transition == transition_name
+    end)
+    |> case do
+      nil ->
+        :ok
+
+      %{id: workitem_id} ->
+        {:ok, _started} = WorkitemTransition.start_workitem(enactment_id, workitem_id)
+        {:ok, _completed} = WorkitemTransition.complete_workitem(enactment_id, {workitem_id, []})
+        :ok
+    end
+  end
+end
+```
+
+Key tricks:
+
+- The `:safe_ew` / `:safe_ns` places are *interlock tokens*: only one direction can hold one at a time, so `:turn_green_ew` and `:turn_green_ns` are mutually exclusive.
+- `signal()` is the unit colour set (`{}`); the actual data does not matter — what matters is *where the token sits*.
+- `on_enactment_start` is the bootstrap: it calls `drive_next/2` once, which starts and completes the first workitem. Each `action` block ends by calling `drive_next/2` for the *next* transition, creating a self-driving loop.
+- Pattern variant: replace `:timer.sleep` + recursive drive with a `Process.send_after/3` scheduled by `on_enactment_start`, so the runner's task never blocks.
+
+## Choosing between patterns
+
+| Need                                          | Pattern                          |
+| --------------------------------------------- | -------------------------------- |
+| linear stage progression                      | sequence                         |
+| event fans out, follow-ups don't interact     | parallel split                   |
+| event has alternative responses               | deferred choice                  |
+| every input must be ready                     | generalised AND-join             |
+| collect N items before continuing             | thread merge                     |
+| retry / idempotent re-delivery / counters     | transmission protocol            |
+| recurring state cycle with timed transitions  | state machine + lifecycle drive  |
+
+Real workflows usually compose two or three of these — a parallel split feeding two AND-joins, a state machine whose transitions internally use deferred choice, and so on. The DSL makes the composition just a matter of more `place` and `transition` declarations; nothing changes at the boundary.

--- a/.claude/skills/coloured-flow/references/running.md
+++ b/.claude/skills/coloured-flow/references/running.md
@@ -1,0 +1,187 @@
+# Running an enactment
+
+Once the workflow module compiles, the runner turns it into a supervised, persistent process tree. This page is the recipe for getting from "module compiles" to "instance is live and observable". Reduced from `examples/traffic_light.livemd`; the same shape works for any workflow.
+
+## Storage backend
+
+Pick the backend before starting anything. Configured globally:
+
+```elixir
+# config/config.exs
+config :coloured_flow, ColouredFlow.Runner.Storage,
+  storage: ColouredFlow.Runner.Storage.InMemory   # tests / dev
+  # storage: ColouredFlow.Runner.Storage.Default  # prod (Ecto/Postgres)
+```
+
+| Backend           | Use            | Storage                                                              |
+| ----------------- | -------------- | -------------------------------------------------------------------- |
+| `Storage.InMemory`| tests, demos   | ETS-backed, in-process                                               |
+| `Storage.Default` | production     | Ecto/Postgres; migrations under `lib/coloured_flow/runner/storage/migrations/V0..V3` |
+
+For Livebook / `iex` use:
+
+```elixir
+{:ok, _pid} = ColouredFlow.Runner.Storage.InMemory.start_link()
+{:ok, _pid} = ColouredFlow.Runner.Supervisor.start_link()
+```
+
+## Insert flow row + enactment row
+
+A *flow* is the persisted CPN definition; an *enactment* is one running instance of that flow. Both must exist in storage before the runner can start the GenServer.
+
+### InMemory
+
+```elixir
+import ColouredFlow.Runner.Storage.InMemory, only: :macros
+
+alias ColouredFlow.Runner.Storage.InMemory
+
+flow = InMemory.insert_flow!(MyFlow.cpnet())
+{:ok, enactment_record} = MyFlow.insert_enactment(flow(flow, :id))
+enactment_id = enactment(enactment_record, :id)
+```
+
+The `flow/2` and `enactment/2` macros are field accessors for the InMemory record types.
+
+### Default (Ecto/Postgres)
+
+```elixir
+alias ColouredFlow.Runner.Storage.Schemas
+
+{:ok, %Schemas.Flow{id: flow_id}} =
+  %Schemas.Flow{}
+  |> Ecto.Changeset.cast(%{cpn: MyFlow.cpnet()}, [:cpn])
+  |> MyApp.Repo.insert()
+
+{:ok, %Schemas.Enactment{id: enactment_id}} = MyFlow.insert_enactment(flow_id)
+```
+
+`MyFlow.insert_enactment/1` uses the markings declared via `initial_marking/2`. To override per-instance, pass them explicitly:
+
+```elixir
+MyFlow.insert_enactment(flow_id, [
+  %ColouredFlow.Enactment.Marking{place: "input", tokens: ~MS[42 99]}
+])
+```
+
+`insert_enactment/3` is *not* idempotent — every call inserts a fresh row. Deduplicate at the call site if you need that.
+
+## Start the enactment
+
+```elixir
+{:ok, enactment_pid} = MyFlow.start_enactment(enactment_id)
+```
+
+The runner:
+
+1. Loads the latest `Snapshot` (or the initial markings if no snapshot exists).
+2. Replays `Occurrence`s after the snapshot via `CatchingUp`.
+3. Recomputes enabled bindings via `WorkitemCalibration`.
+4. Takes a fresh snapshot.
+5. Goes idle, waiting for workitems to be driven externally or by lifecycle hooks.
+
+### With per-instance options
+
+When the workflow has lifecycle hooks (`action`, `on_enactment_*`) that need configuration, pass options as the second tuple element:
+
+```elixir
+{:ok, enactment_pid} =
+  MyFlow.start_enactment(enactment_id,
+    lifecycle_hooks: {MyFlow, [topic: "orders:42", frames: %{…}]}
+  )
+```
+
+Inside any DSL body, `options` is the magic binding holding that keyword list:
+
+```elixir
+action do
+  Phoenix.PubSub.broadcast(MyApp.PubSub, options[:topic], {:fired, x})
+end
+```
+
+To disable hooks for one enactment, pass `lifecycle_hooks: nil`.
+
+## Drive workitems
+
+A *workitem* moves through `enabled → started → completed`. The runner enumerates `enabled` items but never auto-fires them — it waits for an external driver (a UI, an LLM, another supervisor process) to start and complete them.
+
+```elixir
+alias ColouredFlow.Runner.Enactment.WorkitemTransition
+alias ColouredFlow.Runner.Storage
+
+# Pick an enabled workitem for a given transition.
+%{id: workitem_id} =
+  enactment_id
+  |> Storage.list_live_workitems()
+  |> Enum.find(fn wi ->
+    wi.state == :enabled and wi.binding_element.transition == "my_transition"
+  end)
+
+# Move it through the lifecycle.
+{:ok, _started}   = WorkitemTransition.start_workitem(enactment_id, workitem_id)
+{:ok, _completed} = WorkitemTransition.complete_workitem(enactment_id, {workitem_id, []})
+```
+
+The second element of the `complete_workitem/2` tuple is the *free-binding list* — values for any output free variables (`success` in the transmission protocol pattern). Pass `[]` when there are no free variables to resolve. Pass `[success: true]` (etc.) when the transition's outputs need them.
+
+Workitems can also be **withdrawn** (`WorkitemTransition.withdraw_workitem/2`) when an external system decides the work has been cancelled, or **reoffered** (`WorkitemTransition.reoffer_workitem/2`) to recover from an exception state.
+
+### Self-driving via `action`
+
+For state machines that should run themselves, drive the next transition from inside an `action do … end` body. See `references/patterns.md` "State machine with lifecycle drive". The general shape:
+
+```elixir
+action do
+  # … side effects …
+  MyFlow.drive_next(event.enactment_id, "next_transition_name")
+end
+```
+
+…where `drive_next/2` does the `list_live_workitems` + `start_workitem` + `complete_workitem` dance. Keep the helper on the workflow module so the action body can call it by a fully qualified name.
+
+## Observe markings
+
+```elixir
+# Live workitems (one row per enabled / started / completed instance).
+Storage.list_live_workitems(enactment_id)
+
+# The enactment process state — markings + workitems + version.
+:sys.get_state({:via, Registry, {ColouredFlow.Runner.Enactment.Registry, enactment_id}})
+```
+
+For streaming observation:
+
+```elixir
+# Cursor-based stream of workitem state changes.
+ColouredFlow.Runner.Worklist.WorkitemStream.list_live(enactment_id)
+
+# Live query — see `examples/traffic_light.livemd` for a full PubSub-backed observer.
+ColouredFlow.Runner.Worklist.WorkitemStream.live_query(enactment_id, …)
+```
+
+## Termination
+
+The runner ends an enactment in one of three modes:
+
+| Reason     | Trigger                                                                                |
+| ---------- | -------------------------------------------------------------------------------------- |
+| `:implicit`| no firable workitems remain reachable                                                  |
+| `:explicit`| the workflow's `on_markings` predicate evaluates truthy                                |
+| `:force`   | `ColouredFlow.Runner.Termination.force_terminate(enactment_id, reason)` is called      |
+
+If the enactment hits an error it cannot recover from, it transitions to the `:exception` state. From there it can be `:reoffer`-ed (returning to `:running`) or force-terminated.
+
+## Lifecycle hooks beyond the DSL
+
+The DSL macros (`on_enactment_start`, `on_enactment_terminate`, `on_enactment_exception`) compile to module callbacks. To register a *separate* hook module that does not use the DSL, implement the `ColouredFlow.Runner.Enactment.LifecycleHooks` behaviour and pass it explicitly:
+
+```elixir
+{:ok, enactment_pid} =
+  MyFlow.start_enactment(enactment_id, lifecycle_hooks: {MyExternalHooks, [opts]})
+```
+
+That replaces the DSL-generated hook callbacks for this one enactment. The `action do … end` bodies inside the workflow still need `MyFlow` to be the hook module, so prefer the DSL form for normal use; the explicit form is for dashboards, audit logs, or testing harnesses that observe but do not change behaviour.
+
+## Telemetry
+
+The runner emits `:telemetry` events throughout the enactment lifecycle (booted, workitem-state-changed, occurrence-emitted, snapshotted, terminated, exception). See `lib/coloured_flow/runner/telemetry/` for the event names and payload shapes. Use telemetry for cross-cutting concerns (metrics, tracing); use lifecycle hooks for workflow-specific side effects.


### PR DESCRIPTION
## Summary

- Adds `.claude/skills/coloured-flow/` so AI coding agents can produce `use ColouredFlow.DSL` modules from natural-language requests, treating CPN compile-time validation as the verification loop.
- `SKILL.md` covers when-to-use, the place/transition/token mental model, a minimal viable workflow, and a 7-step modelling checklist.
- `references/dsl-reference.md` mirrors `lib/coloured_flow/dsl/spec.md` with every macro, option, and the generated module surface (`cpnet/0`, `__cpn__/1`, `insert_enactment/{1,2,3}`, `start_enactment/2`, lifecycle callbacks).
- `references/patterns.md` collects canonical shapes — sequence, parallel split, deferred choice, generalised AND-join, thread merge, transmission protocol, state machine + lifecycle drive — sourced from `test/coloured_flow/dsl/cpnet_examples_test.exs` and `examples/traffic_light.livemd`.
- `references/running.md` walks through storage setup, flow + enactment insertion, workitem driving, marking observation, lifecycle hook wiring, and termination.

Embodies the split: deterministic CPN runtime as the tool, LLM as the modeller — the skill is what tells the LLM how to reach for that tool.

## Test plan

- [ ] `coloured-flow` shows up in the available-skills list when an agent session starts in this repo.
- [ ] A fresh agent reading only `SKILL.md` can produce the minimal pass-through workflow and `mix compile` it without falling back to the source.
- [ ] Each pattern snippet in `references/patterns.md` compiles when pasted into a scratch module.
- [ ] `references/running.md` recipes match current `Storage.InMemory` / `Storage.Default` APIs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)