### PR TITLE
feat(examples): pi-agent livemd — coding agent as CPN

### DIFF
--- a/examples/pi_agent.livemd
+++ b/examples/pi_agent.livemd
@@ -332,6 +332,9 @@ defmodule PiAgent.A do
     input :ready, bind({1, s})
     input :dialog, bind({1, d})
 
+    # Echo the dialog back so the final conversation stays visible
+    # in the UI after :explicit termination fires on `:answer`.
+    output :dialog, {1, d}
     output :answer, {1, ans}
   end
 
@@ -511,6 +514,9 @@ defmodule PiAgent.B do
     input :ready, bind({1, s})
     input :dialog, bind({1, d})
 
+    # Echo the dialog back so the final conversation stays visible
+    # in the UI after :explicit termination fires on `:answer`.
+    output :dialog, {1, d}
     output :answer, {1, ans}
   end
 
@@ -805,6 +811,9 @@ defmodule PiAgent.C do
     input :ready, bind({1, s})
     input :dialog, bind({1, d})
 
+    # Echo the dialog back so the final conversation stays visible
+    # in the UI after :explicit termination fires on `:answer`.
+    output :dialog, {1, d}
     output :answer, {1, ans}
   end
 

--- a/examples/pi_agent.livemd
+++ b/examples/pi_agent.livemd
@@ -709,13 +709,19 @@ Three upgrades over Section B:
    `:append_steering` transition lets the user push a follow-up message
    while the agent is mid-flight. `:inject_steering` drains the queue
    into `:dialog` *before* the next round.
-3. **Plan-then-act gate.** Section B let safe tools auto-fire and only
-   gated risky ones. Section C drops the safe/risky tag and routes
-   *every* tool call through a human-approval step:
-   `:propose_call → [:proposed_call] → :approve_proposal | :reject_proposal`.
-   Approval moves the call to `:pending_call` and `:run_tool` executes
-   it. Rejection appends a rejection note to `:dialog` and restores
-   `:ready`, kicking the loop back to `think`.
+3. **Plan-then-act gate with three branches.** Section B let safe
+   tools auto-fire and only gated risky ones. Section C drops the
+   safe/risky tag and routes *every* tool call through a human review
+   step: `:propose_call → [:proposed_call] → one of three exits`.
+   Each exit appends a `{:user, _}` line to the dialog so the next
+   planning round can quote it back via `MockLLM.proposal_text/2`:
+   * `:approve_proposal` — call moves to `:pending_call`, `:run_tool`
+     executes it; dialog gains `{:user, "approve"}`.
+   * `:reject_proposal` — drops the call, restores `:ready`; dialog
+     gains `{:user, "reject: <note>"}`.
+   * `:manual_input` — drops the call, restores `:ready`; dialog
+     gains the human's literal `{:user, <note>}` (a free-form override
+     that the next race round picks up via `proposal_text/2`).
 
 `append_steering` consumes a `:steering_capacity` token (a counting
 semaphore — bounds how many follow-ups the user may push) and produces
@@ -741,7 +747,7 @@ defmodule PiAgent.C do
   colset tool_call() :: {tool_name(), binary()}
   colset tool_result() :: binary()
   colset answer() :: binary()
-  colset reason() :: binary()
+  colset note() :: binary()
   colset proposal() :: binary()
   colset signal() :: {}
 
@@ -751,7 +757,7 @@ defmodule PiAgent.C do
   var ans :: answer()
   var s :: signal()
   var m :: msg()
-  var reason :: reason()
+  var note :: note()
   var proposal :: proposal()
 
   place :dialog, :dialog
@@ -799,10 +805,14 @@ defmodule PiAgent.C do
     output :answer, {1, ans}
   end
 
-  # Human-driven: move a proposed call into :pending_call and run it.
+  # Human-driven option 1: approve the plan. The proposed call moves to
+  # :pending_call and runs; an "approve" note lands in the dialog so the
+  # next round sees the human assented.
   transition :approve_proposal do
     input :proposed_call, bind({1, tc})
+    input :dialog, bind({1, d})
 
+    output :dialog, {1, d ++ [{:user, "approve"}]}
     output :pending_call, {1, tc}
 
     action do
@@ -811,14 +821,29 @@ defmodule PiAgent.C do
     end
   end
 
-  # Human-driven: drop the proposal, append a rejection note to dialog,
-  # and put :ready back so the agent thinks again. `reason` is supplied
-  # by the driver via the workitem's free-binding list.
+  # Human-driven option 2: reject the plan. Drops :proposed_call, appends
+  # a `reject: <note>` line to the dialog, and restores :ready.
   transition :reject_proposal do
     input :proposed_call, bind({1, tc})
     input :dialog, bind({1, d})
 
-    output :dialog, {1, d ++ [{:user, reason}]}
+    output :dialog, {1, d ++ [{:user, "reject: " <> note}]}
+    output :ready, {1, {}}
+
+    action do
+      PiAgent.UI.render(options, event)
+      PiAgent.C.think(event.enactment_id, event.markings)
+    end
+  end
+
+  # Human-driven option 3: override the plan with a manual instruction.
+  # The dropped proposal yields to a fresh `{:user, note}` line; the
+  # next race round picks the new instruction up via `proposal_text/2`.
+  transition :manual_input do
+    input :proposed_call, bind({1, tc})
+    input :dialog, bind({1, d})
+
+    output :dialog, {1, d ++ [{:user, note}]}
     output :ready, {1, {}}
 
     action do
@@ -924,11 +949,17 @@ defmodule PiAgent.C do
     drive(enactment_id, "approve_proposal", [])
   end
 
-  # Reject the pending plan with a reason. Default reason kept short so
-  # the dialog stays readable.
-  def reject(enactment_id, reason \\ "rejected the proposed plan; try a different tool")
-      when is_binary(reason) do
-    drive(enactment_id, "reject_proposal", reason: reason)
+  # Reject the pending plan. Default note kept short so dialog stays
+  # readable; the form-driven path passes a custom note.
+  def reject(enactment_id, note \\ "try a different tool")
+      when is_binary(note) do
+    drive(enactment_id, "reject_proposal", note: note)
+  end
+
+  # Override the pending plan with a manual instruction. Drops the
+  # proposal and lets the next planning round read the new note.
+  def override(enactment_id, note) when is_binary(note) and note != "" do
+    drive(enactment_id, "manual_input", note: note)
   end
 
   def steer(enactment_id, content) when is_binary(content) do
@@ -990,8 +1021,14 @@ events_c = Kino.Frame.new()
 
 steer_input =
   Kino.Control.form([msg: Kino.Input.text("Steering")],
-    submit: "Send",
+    submit: "Send steering",
     reset_on_submit: [:msg]
+  )
+
+manual_input =
+  Kino.Control.form([note: Kino.Input.text("Manual instruction")],
+    submit: "Override plan",
+    reset_on_submit: [:note]
   )
 
 approve_plan_btn = Kino.Control.button("Approve plan")
@@ -999,6 +1036,10 @@ reject_plan_btn = Kino.Control.button("Reject plan")
 
 Kino.listen(steer_input, fn %{data: %{msg: text}} ->
   if text != "", do: PiAgent.C.steer(enactment_c, text)
+end)
+
+Kino.listen(manual_input, fn %{data: %{note: text}} ->
+  if text != "", do: PiAgent.C.override(enactment_c, text)
 end)
 
 Kino.listen(approve_plan_btn, fn _ -> PiAgent.C.approve(enactment_c) end)
@@ -1012,8 +1053,9 @@ Kino.listen(reject_plan_btn, fn _ -> PiAgent.C.reject(enactment_c) end)
 Kino.Layout.grid(
   [
     Kino.Layout.grid([dialog_c, events_c], columns: 2),
-    steer_input,
-    Kino.Layout.grid([approve_plan_btn, reject_plan_btn], columns: 2)
+    Kino.Layout.grid([approve_plan_btn, reject_plan_btn], columns: 2),
+    manual_input,
+    steer_input
   ],
   boxed: true
 )
@@ -1021,30 +1063,31 @@ Kino.Layout.grid(
 
 ### How to test the section
 
-Three things to watch:
+Four interactive controls. Each one lands a `{:user, _}` message in
+the dialog, and the next planning round picks the latest such message
+up via `MockLLM.proposal_text/2` and quotes it back in the proposal so
+the human can verify the model heard them.
 
-1. **Plan-then-act gate** (every tool call). After each `think`, the
-   agent emits a `:proposed_call` token and pauses
-   (`🤔 awaiting plan approval`). Click **Approve plan** to fire
-   `:approve_proposal` (call moves to `:pending_call` and runs); click
-   **Reject plan** to fire `:reject_proposal` (a rejection note lands
-   in the dialog and the agent re-thinks). The events panel records
-   every `:propose_call` / `:approve_proposal` / `:reject_proposal`
-   firing.
-2. **Pre-seeded steering** (automatic). `:steering_queue` starts with
-   one token (`{:user, "Also count the files."}`). The first `think`
-   round calls `drain_steering`, fires `:inject_steering`, and the
-   message lands in the dialog as a `**user**` line *before* the first
-   plan proposal. Visible on every run with no input from you.
-3. **Live steering** (interactive). While the agent is paused at any
-   plan gate (or between rounds):
-   * Type a follow-up into the **Steering** field and click **Send**.
-   * Input clears (`reset_on_submit: [:msg]`); the queue is invisible
-     until drained.
-   * Click **Approve plan**. After the tool runs and merges, the next
-     `think` calls `drain_steering`, your message appears in the
-     dialog as another `**user**` line, and the agent re-plans with
-     the steering message in its context.
+1. **Approve plan** (button). Fires `:approve_proposal`. Dialog
+   gains `{:user, "approve"}`; tool runs; agent re-plans for next round.
+2. **Reject plan** (button). Fires `:reject_proposal` with a fixed
+   default note. Dialog gains `{:user, "reject: try a different
+   tool"}`; the proposal is dropped; agent re-plans, and the next
+   `propose_call` quotes the rejection back to you.
+3. **Manual instruction** (form). Type a custom note and click
+   **Override plan**. Fires `:manual_input` with your text as the
+   `note` free binding. Dialog gains `{:user, <your note>}`; proposal
+   dropped; agent re-plans with your override as the new context.
+4. **Steering** (form). Type a follow-up and click **Send steering**.
+   Fires `:append_steering` (queues the message). The next time
+   `:ready` and `:dialog` align — typically right after the current
+   tool merges or the current proposal resolves — `:inject_steering`
+   drains the queue into the dialog.
+
+Pre-seeded steering: `:steering_queue` starts with one token
+(`{:user, "Also count the files."}`). The very first `think` call
+drains it, so the first proposal already references it. You'll see
+this on every run with no input from you.
 
 If you click any control *after* the agent terminates (`✅ done`),
 nothing happens — `drive/3` finds no enabled workitem and returns

--- a/examples/pi_agent.livemd
+++ b/examples/pi_agent.livemd
@@ -22,12 +22,12 @@ Mix.install(
 calls tools (`read`, `grep`, `bash`, …), and keeps a session tree you can
 branch from. The execution loop has well-known shapes:
 
-- **think → tool → observe → repeat** — the ReAct cycle.
-- **safe vs. risky tool calls** — `read` runs unattended; `bash` waits on a
+* **think → tool → observe → repeat** — the ReAct cycle.
+* **safe vs. risky tool calls** — `read` runs unattended; `bash` waits on a
   human approval.
-- **multi-provider race** — the same prompt fans out to several vendors;
+* **multi-provider race** — the same prompt fans out to several vendors;
   fastest answer wins.
-- **steering** — the user injects a follow-up while the agent is mid-flight.
+* **steering** — the user injects a follow-up while the agent is mid-flight.
 
 Coloured Petri Nets express *exactly* these shapes natively: places hold
 state, transitions consume/produce tokens with guards, workitems sit in
@@ -37,11 +37,11 @@ last token state instead of re-running tool calls.
 
 We'll model Pi's loop in three passes:
 
-| | Adds | CPN feature |
-|---|---|---|
-| **A** | minimal ReAct cycle | deferred choice, free output bindings, self-driving via `action` |
-| **B** | risky-tool human gate | union colour set, workitem held in `:enabled` until human fires |
-| **C** | provider race + steering injection | concurrent enabled workitems, external-fed input place |
+|       | Adds                               | CPN feature                                                      |
+| ----- | ---------------------------------- | ---------------------------------------------------------------- |
+| **A** | minimal ReAct cycle                | deferred choice, free output bindings, self-driving via `action` |
+| **B** | risky-tool human gate              | union colour set, workitem held in `:enabled` until human fires  |
+| **C** | provider race + steering injection | concurrent enabled workitems, external-fed input place           |
 
 ## Mock LLM, mock tools, dialog renderer
 
@@ -50,7 +50,7 @@ workflow modules below. The mock LLM is a deterministic function of dialog
 length so the demo is reproducible. The dialog renderer is a pure markdown
 function passed into each enactment via `lifecycle_hooks` options.
 
-```elixir
+````elixir
 defmodule PiAgent.MockLLM do
   @moduledoc false
 
@@ -68,9 +68,9 @@ defmodule PiAgent.MockLLM do
   end
 
   # Provider-specific latency. Used by Section C to demo races.
-  def latency_ms(:anthropic), do: 80
-  def latency_ms(:openai), do: 130
-  def latency_ms(:google), do: 200
+  def latency_ms(:anthropic), do: 600
+  def latency_ms(:openai), do: 900
+  def latency_ms(:google), do: 1200
 end
 
 defmodule PiAgent.MockTool do
@@ -113,10 +113,17 @@ defmodule PiAgent.UI do
   defp state_label(markings) do
     cond do
       Map.has_key?(markings, "answer") -> "✅ done"
-      has_token?(markings, "pending_call_risky") -> "⏸ waiting for human approval"
+      risky_pending?(markings) -> "⏸ waiting for human approval"
       has_token?(markings, "pending_call") -> "⚙ tool running"
       has_token?(markings, "steering_queue") -> "📣 steering pending"
       true -> "💭 thinking"
+    end
+  end
+
+  defp risky_pending?(markings) do
+    case Map.get(markings, "pending_call") do
+      nil -> false
+      ms -> ms |> MultiSet.to_list() |> Enum.any?(&match?({:risky, _}, &1))
     end
   end
 
@@ -131,7 +138,7 @@ defmodule PiAgent.UI do
   defp format_msg({:assistant, c}), do: "**assistant** › #{c}"
   defp format_msg({:tool, c}), do: "```\n#{c}\n```"
 end
-```
+````
 
 ## Shared runtime: storage + supervisor
 
@@ -187,7 +194,6 @@ to one or the other.
 defmodule PiAgent.A do
   use ColouredFlow.DSL, task_supervisor: PiAgent.TaskSup
 
-  alias ColouredFlow.MultiSet
   alias ColouredFlow.Runner.Enactment.WorkitemTransition
   alias ColouredFlow.Runner.Storage
 
@@ -228,6 +234,7 @@ defmodule PiAgent.A do
 
     action do
       tc = Keyword.fetch!(event.occurrence.free_binding, :tc)
+      PiAgent.UI.render(options[:frame], event.markings)
       PiAgent.A.run_tool(event.enactment_id, tc)
     end
   end
@@ -278,9 +285,12 @@ defmodule PiAgent.A do
   end
 
   ## Driver — turns mock-LLM/mock-tool decisions into workitem firings.
+  # Sleeps simulate LLM/tool latency so the dialog frame visibly steps
+  # through each phase. Drop them in production.
 
   def think(enactment_id, markings) do
     dialog = PiAgent.UI.read_dialog(markings)
+    Process.sleep(700)
 
     case PiAgent.MockLLM.next_step(dialog) do
       {:tool, tc} -> drive(enactment_id, "think_tool", tc: tc)
@@ -289,11 +299,14 @@ defmodule PiAgent.A do
   end
 
   def run_tool(enactment_id, tc) do
-    Process.sleep(100)
+    Process.sleep(900)
     drive(enactment_id, "run_tool", tr: PiAgent.MockTool.run(tc))
   end
 
-  def merge(enactment_id), do: drive(enactment_id, "merge_result", [])
+  def merge(enactment_id) do
+    Process.sleep(400)
+    drive(enactment_id, "merge_result", [])
+  end
 
   def to_mermaid do
     cpnet()
@@ -317,7 +330,7 @@ defmodule PiAgent.A do
   end
 end
 
-PiAgent.A.to_mermaid()
+PiAgent.A.cpnet().__struct__
 ```
 
 ```elixir
@@ -345,8 +358,8 @@ Same loop — but the model now sometimes asks for a `:bash` call. We do
 `:think_tool` output flows into a **union-typed** `:pending_call` place,
 tagged `{:safe, op}` or `{:risky, op}`. Two consumers compete for it:
 
-- `:run_safe` matches `{:safe, op}` — driver auto-fires it.
-- `:run_risky` matches `{:risky, op}` — workitem stays in `:enabled` until
+* `:run_safe` matches `{:safe, op}` — driver auto-fires it.
+* `:run_risky` matches `{:risky, op}` — workitem stays in `:enabled` until
   a human clicks an approve button. The runner is happy to wait days.
 
 The crucial CPN trick is that **pattern-matching on a token's shape is
@@ -357,7 +370,6 @@ itself is the discriminator.
 defmodule PiAgent.B do
   use ColouredFlow.DSL, task_supervisor: PiAgent.TaskSup
 
-  alias ColouredFlow.MultiSet
   alias ColouredFlow.Runner.Enactment.WorkitemTransition
   alias ColouredFlow.Runner.Storage
 
@@ -400,6 +412,7 @@ defmodule PiAgent.B do
 
     action do
       tc = Keyword.fetch!(event.occurrence.free_binding, :tc)
+      PiAgent.UI.render(options[:frame], event.markings)
       PiAgent.B.dispatch_call(event.enactment_id, tc)
     end
   end
@@ -463,6 +476,7 @@ defmodule PiAgent.B do
 
   def think(enactment_id, markings) do
     dialog = PiAgent.UI.read_dialog(markings)
+    Process.sleep(700)
 
     case PiAgent.MockLLM.next_step(dialog) do
       {:tool, op} ->
@@ -477,7 +491,7 @@ defmodule PiAgent.B do
   # After :think_tool fires, route based on the tag — auto-run safe,
   # leave risky workitem dangling for human approval.
   def dispatch_call(enactment_id, {:safe, op}) do
-    Process.sleep(100)
+    Process.sleep(900)
     drive(enactment_id, "run_safe", tr: PiAgent.MockTool.run(op))
   end
 
@@ -489,7 +503,7 @@ defmodule PiAgent.B do
         :no_pending
 
       %{id: wid, binding_element: %{binding: binding}} ->
-        {:risky, op} = Keyword.fetch!(binding, :tc)
+        op = Keyword.fetch!(binding, :op)
         Process.sleep(100)
         {:ok, _} = WorkitemTransition.start_workitem(enactment_id, wid)
 
@@ -503,18 +517,30 @@ defmodule PiAgent.B do
     end
   end
 
+  # Compensation pattern: fire :run_risky with a synthetic "denied" result
+  # so the agent's loop continues with the rejection in the dialog.
   def deny(enactment_id) do
     case find_risky(enactment_id) do
       nil ->
         :no_pending
 
       %{id: wid} ->
-        {:ok, _} = WorkitemTransition.withdraw_workitem(enactment_id, wid)
+        {:ok, _} = WorkitemTransition.start_workitem(enactment_id, wid)
+
+        {:ok, _} =
+          WorkitemTransition.complete_workitem(
+            enactment_id,
+            {wid, [tr: "[denied by user]"]}
+          )
+
         :denied
     end
   end
 
-  def merge(enactment_id), do: drive(enactment_id, "merge_result", [])
+  def merge(enactment_id) do
+    Process.sleep(400)
+    drive(enactment_id, "merge_result", [])
+  end
 
   def to_mermaid do
     cpnet()
@@ -544,7 +570,7 @@ defmodule PiAgent.B do
   end
 end
 
-PiAgent.B.to_mermaid()
+PiAgent.B.cpnet().__struct__
 ```
 
 ```elixir
@@ -600,7 +626,6 @@ binding.
 defmodule PiAgent.C do
   use ColouredFlow.DSL, task_supervisor: PiAgent.TaskSup
 
-  alias ColouredFlow.MultiSet
   alias ColouredFlow.Runner.Enactment.WorkitemTransition
   alias ColouredFlow.Runner.Storage
 
@@ -648,6 +673,7 @@ defmodule PiAgent.C do
 
     action do
       tc = Keyword.fetch!(event.occurrence.free_binding, :tc)
+      PiAgent.UI.render(options[:frame], event.markings)
       PiAgent.C.dispatch_call(event.enactment_id, tc)
     end
   end
@@ -758,7 +784,7 @@ defmodule PiAgent.C do
   end
 
   def dispatch_call(enactment_id, {:safe, op}) do
-    Process.sleep(100)
+    Process.sleep(900)
     drive(enactment_id, "run_safe", tr: PiAgent.MockTool.run(op))
   end
 
@@ -770,8 +796,8 @@ defmodule PiAgent.C do
         :no_pending
 
       %{id: wid, binding_element: %{binding: binding}} ->
-        {:risky, op} = Keyword.fetch!(binding, :tc)
-        Process.sleep(100)
+        op = Keyword.fetch!(binding, :op)
+        Process.sleep(900)
         {:ok, _} = WorkitemTransition.start_workitem(enactment_id, wid)
 
         {:ok, _} =
@@ -788,7 +814,10 @@ defmodule PiAgent.C do
     drive(enactment_id, "append_steering", m: {:user, content})
   end
 
-  def merge(enactment_id), do: drive(enactment_id, "merge_result", [])
+  def merge(enactment_id) do
+    Process.sleep(400)
+    drive(enactment_id, "merge_result", [])
+  end
 
   def to_mermaid do
     cpnet()
@@ -827,7 +856,7 @@ defmodule PiAgent.C do
   end
 end
 
-PiAgent.C.to_mermaid()
+PiAgent.C.cpnet().__struct__
 ```
 
 ```elixir
@@ -857,16 +886,16 @@ Kino.Layout.grid([frame_c, steer_input, approve_btn_c], boxed: true)
 
 The same module is also:
 
-- **Crash-safe.** Kill the runner mid-`bash` and restart — the runner
+* **Crash-safe.** Kill the runner mid-`bash` and restart — the runner
   replays `Occurrence`s from the latest snapshot, the workitem state
   comes back exactly where it was, no duplicate tool calls.
-- **Time-travelable.** Every firing is a stored event; an audit UI gets
+* **Time-travelable.** Every firing is a stored event; an audit UI gets
   the agent's full reasoning trace for free.
-- **Branchable.** Insert a fresh enactment from a snapshot of an existing
+* **Branchable.** Insert a fresh enactment from a snapshot of an existing
   one and you have a session fork — the same primitive Pi exposes via
   `/fork` and `/clone`, but earned automatically by the event-source
   runner.
-- **Provider-agnostic.** The CPN cares about token shapes, not vendors.
+* **Provider-agnostic.** The CPN cares about token shapes, not vendors.
   Add a new provider in Section C by adding one line to
   `race_providers/2`; the structure of the net does not change.
 

--- a/examples/pi_agent.livemd
+++ b/examples/pi_agent.livemd
@@ -90,11 +90,20 @@ end
 defmodule PiAgent.UI do
   @moduledoc false
   alias ColouredFlow.MultiSet
+  alias ColouredFlow.Runner.Storage
 
-  def render(nil, _markings), do: :ok
+  # Renders dialog (left) and event history (right) frames from the
+  # lifecycle hook options. Either frame may be absent.
+  def render(opts, event) do
+    if frame = opts[:dialog_frame] do
+      Kino.Frame.render(frame, Kino.Markdown.new(format_dialog(event.markings)))
+    end
 
-  def render(frame, markings) do
-    Kino.Frame.render(frame, Kino.Markdown.new(format(markings)))
+    if frame = opts[:events_frame] do
+      Kino.Frame.render(frame, Kino.Markdown.new(format_events(event.enactment_id)))
+    end
+
+    :ok
   end
 
   def read_dialog(markings) do
@@ -104,10 +113,49 @@ defmodule PiAgent.UI do
     end
   end
 
-  defp format(markings) do
+  defp format_dialog(markings) do
     state = state_label(markings)
     body = markings |> read_dialog() |> Enum.map_join("\n\n", &format_msg/1)
     "**state**: #{state}\n\n---\n\n#{body}"
+  end
+
+  defp format_events(enactment_id) do
+    occurrences =
+      enactment_id
+      |> Storage.occurrences_stream(0)
+      |> Enum.to_list()
+
+    if occurrences == [] do
+      "**events** (0)\n\n_no firings yet_"
+    else
+      lines =
+        occurrences
+        |> Enum.with_index(1)
+        |> Enum.map_join("\n", fn {o, i} -> format_occurrence(o, i) end)
+
+      "**events** (#{length(occurrences)})\n\n#{lines}"
+    end
+  end
+
+  defp format_occurrence(occurrence, idx) do
+    name = occurrence.binding_element.transition
+    bindings = occurrence.binding_element.binding ++ occurrence.free_binding
+
+    "**#{idx}.** `:#{name}`" <> render_bindings(bindings)
+  end
+
+  defp render_bindings([]), do: ""
+
+  defp render_bindings(kvs) do
+    " · " <>
+      Enum.map_join(kvs, ", ", fn {k, v} ->
+        "`#{k}` = `#{inspect_short(v)}`"
+      end)
+  end
+
+  defp inspect_short(v) do
+    s = inspect(v, limit: 5, printable_limit: 50)
+    if String.length(s) > 70, do: String.slice(s, 0, 67) <> "…", else: s
   end
 
   defp state_label(markings) do
@@ -234,7 +282,7 @@ defmodule PiAgent.A do
 
     action do
       tc = Keyword.fetch!(event.occurrence.free_binding, :tc)
-      PiAgent.UI.render(options[:frame], event.markings)
+      PiAgent.UI.render(options, event)
       PiAgent.A.run_tool(event.enactment_id, tc)
     end
   end
@@ -264,7 +312,7 @@ defmodule PiAgent.A do
     output :ready, {1, {}}
 
     action do
-      PiAgent.UI.render(options[:frame], event.markings)
+      PiAgent.UI.render(options, event)
       PiAgent.A.think(event.enactment_id, event.markings)
     end
   end
@@ -276,12 +324,12 @@ defmodule PiAgent.A do
   end
 
   on_enactment_start do
-    PiAgent.UI.render(options[:frame], event.markings)
+    PiAgent.UI.render(options, event)
     PiAgent.A.think(event.enactment_id, event.markings)
   end
 
   on_enactment_terminate do
-    PiAgent.UI.render(options[:frame], event.markings)
+    PiAgent.UI.render(options, event)
   end
 
   ## Driver — turns mock-LLM/mock-tool decisions into workitem firings.
@@ -341,14 +389,15 @@ flow_a = InMemory.insert_flow!(PiAgent.A.cpnet())
 {:ok, e_a} = PiAgent.A.insert_enactment(flow(flow_a, :id))
 enactment_a = enactment(e_a, :id)
 
-frame_a = Kino.Frame.new()
+dialog_a = Kino.Frame.new()
+events_a = Kino.Frame.new()
 
 {:ok, _} =
   PiAgent.A.start_enactment(enactment_a,
-    lifecycle_hooks: {PiAgent.A, [frame: frame_a]}
+    lifecycle_hooks: {PiAgent.A, [dialog_frame: dialog_a, events_frame: events_a]}
   )
 
-frame_a
+Kino.Layout.grid([dialog_a, events_a], columns: 2, boxed: true)
 ```
 
 ## B. Risky-tool human gate
@@ -412,7 +461,7 @@ defmodule PiAgent.B do
 
     action do
       tc = Keyword.fetch!(event.occurrence.free_binding, :tc)
-      PiAgent.UI.render(options[:frame], event.markings)
+      PiAgent.UI.render(options, event)
       PiAgent.B.dispatch_call(event.enactment_id, tc)
     end
   end
@@ -452,7 +501,7 @@ defmodule PiAgent.B do
     output :ready, {1, {}}
 
     action do
-      PiAgent.UI.render(options[:frame], event.markings)
+      PiAgent.UI.render(options, event)
       PiAgent.B.think(event.enactment_id, event.markings)
     end
   end
@@ -464,12 +513,12 @@ defmodule PiAgent.B do
   end
 
   on_enactment_start do
-    PiAgent.UI.render(options[:frame], event.markings)
+    PiAgent.UI.render(options, event)
     PiAgent.B.think(event.enactment_id, event.markings)
   end
 
   on_enactment_terminate do
-    PiAgent.UI.render(options[:frame], event.markings)
+    PiAgent.UI.render(options, event)
   end
 
   ## Driver
@@ -578,7 +627,8 @@ flow_b = InMemory.insert_flow!(PiAgent.B.cpnet())
 {:ok, e_b} = PiAgent.B.insert_enactment(flow(flow_b, :id))
 enactment_b = enactment(e_b, :id)
 
-frame_b = Kino.Frame.new()
+dialog_b = Kino.Frame.new()
+events_b = Kino.Frame.new()
 approve_btn = Kino.Control.button("Approve risky tool")
 deny_btn = Kino.Control.button("Deny")
 
@@ -587,10 +637,14 @@ Kino.listen(deny_btn, fn _ -> PiAgent.B.deny(enactment_b) end)
 
 {:ok, _} =
   PiAgent.B.start_enactment(enactment_b,
-    lifecycle_hooks: {PiAgent.B, [frame: frame_b]}
+    lifecycle_hooks: {PiAgent.B, [dialog_frame: dialog_b, events_frame: events_b]}
   )
 
-Kino.Layout.grid([frame_b, Kino.Layout.grid([approve_btn, deny_btn], columns: 2)],
+Kino.Layout.grid(
+  [
+    Kino.Layout.grid([dialog_b, events_b], columns: 2),
+    Kino.Layout.grid([approve_btn, deny_btn], columns: 2)
+  ],
   boxed: true
 )
 ```
@@ -678,7 +732,7 @@ defmodule PiAgent.C do
 
     action do
       tc = Keyword.fetch!(event.occurrence.free_binding, :tc)
-      PiAgent.UI.render(options[:frame], event.markings)
+      PiAgent.UI.render(options, event)
       PiAgent.C.dispatch_call(event.enactment_id, tc)
     end
   end
@@ -718,7 +772,7 @@ defmodule PiAgent.C do
     output :ready, {1, {}}
 
     action do
-      PiAgent.UI.render(options[:frame], event.markings)
+      PiAgent.UI.render(options, event)
       PiAgent.C.think(event.enactment_id, event.markings)
     end
   end
@@ -738,7 +792,7 @@ defmodule PiAgent.C do
     output :ready, {1, s}
 
     action do
-      PiAgent.UI.render(options[:frame], event.markings)
+      PiAgent.UI.render(options, event)
       PiAgent.C.think(event.enactment_id, event.markings)
     end
   end
@@ -750,12 +804,12 @@ defmodule PiAgent.C do
   end
 
   on_enactment_start do
-    PiAgent.UI.render(options[:frame], event.markings)
+    PiAgent.UI.render(options, event)
     PiAgent.C.think(event.enactment_id, event.markings)
   end
 
   on_enactment_terminate do
-    PiAgent.UI.render(options[:frame], event.markings)
+    PiAgent.UI.render(options, event)
   end
 
   ## Driver
@@ -869,7 +923,8 @@ flow_c = InMemory.insert_flow!(PiAgent.C.cpnet())
 {:ok, e_c} = PiAgent.C.insert_enactment(flow(flow_c, :id))
 enactment_c = enactment(e_c, :id)
 
-frame_c = Kino.Frame.new()
+dialog_c = Kino.Frame.new()
+events_c = Kino.Frame.new()
 
 steer_input =
   Kino.Control.form([msg: Kino.Input.text("Steering")],
@@ -887,10 +942,17 @@ Kino.listen(approve_btn_c, fn _ -> PiAgent.C.approve(enactment_c) end)
 
 {:ok, _} =
   PiAgent.C.start_enactment(enactment_c,
-    lifecycle_hooks: {PiAgent.C, [frame: frame_c]}
+    lifecycle_hooks: {PiAgent.C, [dialog_frame: dialog_c, events_frame: events_c]}
   )
 
-Kino.Layout.grid([frame_c, steer_input, approve_btn_c], boxed: true)
+Kino.Layout.grid(
+  [
+    Kino.Layout.grid([dialog_c, events_c], columns: 2),
+    steer_input,
+    approve_btn_c
+  ],
+  boxed: true
+)
 ```
 
 ### How to test steering

--- a/examples/pi_agent.livemd
+++ b/examples/pi_agent.livemd
@@ -67,6 +67,37 @@ defmodule PiAgent.MockLLM do
     end
   end
 
+  # Builds the assistant's proposal message. If a steering / rejection
+  # has landed since the agent's last assistant turn, surface it so the
+  # human can confirm the model heard them.
+  #
+  # Pattern in action: after `:reject_proposal` or `:inject_steering`
+  # appends a `{:user, _}` to the dialog, the next planning round picks
+  # that message up and weaves it into the proposal.
+  def proposal_text(dialog, {tool, args}) do
+    call = "#{tool}(#{inspect(args)})"
+
+    case latest_steering(dialog) do
+      nil -> "proposing #{call}"
+      text -> "based on your note (#{inspect(text)}), proposing #{call}"
+    end
+  end
+
+  defp latest_steering(dialog) do
+    # The very first message is the user's original prompt; any
+    # subsequent {:user, _} is a steering or rejection note.
+    user_msgs =
+      dialog
+      |> Enum.filter(fn {role, _} -> role == :user end)
+      |> Enum.map(fn {:user, c} -> c end)
+
+    case user_msgs do
+      [_initial] -> nil
+      [_initial | rest] -> List.last(rest)
+      [] -> nil
+    end
+  end
+
   # Provider-specific latency. Used by Section C to demo races.
   def latency_ms(:anthropic), do: 600
   def latency_ms(:openai), do: 900
@@ -711,6 +742,7 @@ defmodule PiAgent.C do
   colset tool_result() :: binary()
   colset answer() :: binary()
   colset reason() :: binary()
+  colset proposal() :: binary()
   colset signal() :: {}
 
   var d :: dialog()
@@ -720,6 +752,7 @@ defmodule PiAgent.C do
   var s :: signal()
   var m :: msg()
   var reason :: reason()
+  var proposal :: proposal()
 
   place :dialog, :dialog
   place :ready, :signal
@@ -744,11 +777,14 @@ defmodule PiAgent.C do
 
   # Race producers fire :propose_call instead of running the tool. The
   # call sits in :proposed_call until a human approves or rejects it.
+  # `proposal` is a free binding the driver fills with the assistant's
+  # planning message — it can quote the latest steering / rejection
+  # so the human sees the model react to their note.
   transition :propose_call do
     input :ready, bind({1, s})
     input :dialog, bind({1, d})
 
-    output :dialog, {1, d ++ [{:assistant, "proposing tool call"}]}
+    output :dialog, {1, d ++ [{:assistant, proposal}]}
     output :proposed_call, {1, tc}
 
     action do
@@ -868,8 +904,12 @@ defmodule PiAgent.C do
         Process.sleep(PiAgent.MockLLM.latency_ms(vendor))
 
         case PiAgent.MockLLM.next_step(dialog, vendor) do
-          {:tool, op} -> drive(enactment_id, "propose_call", tc: op)
-          {:answer, ans} -> drive(enactment_id, "think_answer", ans: ans)
+          {:tool, op} ->
+            text = PiAgent.MockLLM.proposal_text(dialog, op)
+            drive(enactment_id, "propose_call", tc: op, proposal: text)
+
+          {:answer, ans} ->
+            drive(enactment_id, "think_answer", ans: ans)
         end
       end)
     end)

--- a/examples/pi_agent.livemd
+++ b/examples/pi_agent.livemd
@@ -124,10 +124,14 @@ defmodule PiAgent.UI do
   alias ColouredFlow.Runner.Storage
 
   # Renders dialog (left top), event history (right), and an optional
-  # controls frame (left bottom) from the lifecycle hook options. Once
-  # the enactment terminates (answer present), the controls frame is
-  # replaced with a "disabled" marker so the user cannot click stale
-  # buttons; the dialog gets a "workflow ended" footer.
+  # controls frame (left bottom) from the lifecycle hook options.
+  #
+  # The controls frame is rebuilt on every event so each widget only
+  # appears when its target workitem is actually firable: plan-gate
+  # buttons show up while `:proposed_call` has a token, the risky-tool
+  # buttons show up while `:pending_call` carries a `{:risky, _}`, the
+  # steering form is visible the whole run. After termination the
+  # frame is replaced with a "controls disabled" marker.
   def render(opts, event) do
     terminated? = Map.has_key?(event.markings, "answer")
 
@@ -139,14 +143,66 @@ defmodule PiAgent.UI do
       Kino.Frame.render(frame, Kino.Markdown.new(format_events(event.enactment_id)))
     end
 
-    if terminated? and (frame = opts[:controls_frame]) do
-      Kino.Frame.render(
-        frame,
-        Kino.Markdown.new("*✓ workflow ended — controls disabled.*")
-      )
+    if frame = opts[:controls_frame] do
+      content =
+        if terminated? do
+          Kino.Markdown.new("*✓ workflow ended — controls disabled.*")
+        else
+          build_controls(opts, event.markings)
+        end
+
+      Kino.Frame.render(frame, content)
     end
 
     :ok
+  end
+
+  defp build_controls(opts, markings) do
+    parts =
+      []
+      |> maybe_add_plan_gate(opts, markings)
+      |> maybe_add_risky_gate(opts, markings)
+      |> maybe_add_steer(opts)
+
+    case parts do
+      [] -> Kino.Markdown.new("*waiting for the agent to act…*")
+      [single] -> single
+      many -> Kino.Layout.grid(many, columns: 1)
+    end
+  end
+
+  defp maybe_add_plan_gate(parts, opts, markings) do
+    cond do
+      not has_token?(markings, "proposed_call") ->
+        parts
+
+      is_nil(opts[:approve_plan_btn]) or is_nil(opts[:reject_plan_btn]) ->
+        parts
+
+      true ->
+        plan_row =
+          Kino.Layout.grid([opts[:approve_plan_btn], opts[:reject_plan_btn]], columns: 2)
+
+        manual = if form = opts[:manual_form], do: [form], else: []
+        parts ++ [plan_row | manual]
+    end
+  end
+
+  defp maybe_add_risky_gate(parts, opts, markings) do
+    cond do
+      not risky_pending?(markings) ->
+        parts
+
+      is_nil(opts[:approve_btn]) or is_nil(opts[:deny_btn]) ->
+        parts
+
+      true ->
+        parts ++ [Kino.Layout.grid([opts[:approve_btn], opts[:deny_btn]], columns: 2)]
+    end
+  end
+
+  defp maybe_add_steer(parts, opts) do
+    if form = opts[:steer_form], do: parts ++ [form], else: parts
   end
 
   def read_dialog(markings) do
@@ -696,13 +752,17 @@ deny_btn = Kino.Control.button("Deny")
 Kino.listen(approve_btn, fn _ -> PiAgent.B.approve(enactment_b) end)
 Kino.listen(deny_btn, fn _ -> PiAgent.B.deny(enactment_b) end)
 
-Kino.Frame.render(controls_b, Kino.Layout.grid([approve_btn, deny_btn], columns: 2))
-
 {:ok, _} =
   PiAgent.B.start_enactment(enactment_b,
     lifecycle_hooks:
       {PiAgent.B,
-       [dialog_frame: dialog_b, events_frame: events_b, controls_frame: controls_b]}
+       [
+         dialog_frame: dialog_b,
+         events_frame: events_b,
+         controls_frame: controls_b,
+         approve_btn: approve_btn,
+         deny_btn: deny_btn
+       ]}
   )
 
 left_b = Kino.Layout.grid([dialog_b, controls_b], columns: 1)
@@ -1068,23 +1128,19 @@ end)
 Kino.listen(approve_plan_btn, fn _ -> PiAgent.C.approve(enactment_c) end)
 Kino.listen(reject_plan_btn, fn _ -> PiAgent.C.reject(enactment_c) end)
 
-Kino.Frame.render(
-  controls_c,
-  Kino.Layout.grid(
-    [
-      Kino.Layout.grid([approve_plan_btn, reject_plan_btn], columns: 2),
-      manual_input,
-      steer_input
-    ],
-    columns: 1
-  )
-)
-
 {:ok, _} =
   PiAgent.C.start_enactment(enactment_c,
     lifecycle_hooks:
       {PiAgent.C,
-       [dialog_frame: dialog_c, events_frame: events_c, controls_frame: controls_c]}
+       [
+         dialog_frame: dialog_c,
+         events_frame: events_c,
+         controls_frame: controls_c,
+         approve_plan_btn: approve_plan_btn,
+         reject_plan_btn: reject_plan_btn,
+         manual_form: manual_input,
+         steer_form: steer_input
+       ]}
   )
 
 left_c = Kino.Layout.grid([dialog_c, controls_c], columns: 1)

--- a/examples/pi_agent.livemd
+++ b/examples/pi_agent.livemd
@@ -5,7 +5,7 @@
 ```elixir
 Mix.install(
   [
-    {:coloured_flow, path: "/Users/fahchen/Projects/coloured_flow"},
+    {:coloured_flow, github: "Byzanteam/coloured_flow"},
     {:kino, "~> 0.14.1"}
   ],
   config: [

--- a/examples/pi_agent.livemd
+++ b/examples/pi_agent.livemd
@@ -170,6 +170,7 @@ defmodule PiAgent.UI do
   defp state_label(markings) do
     cond do
       Map.has_key?(markings, "answer") -> "✅ done"
+      has_token?(markings, "proposed_call") -> "🤔 awaiting plan approval"
       risky_pending?(markings) -> "⏸ waiting for human approval"
       has_token?(markings, "pending_call") -> "⚙ tool running"
       has_token?(markings, "steering_queue") -> "📣 steering pending"
@@ -663,27 +664,35 @@ on a `bash` call. The dialog renders `⏸ waiting for human approval` until
 you click **Approve** — the workitem fires, the result merges, the loop
 resumes.
 
-## C. Multi-provider race + steering
+## C. Multi-provider race + steering + plan-then-act
 
-Two upgrades, neither requires changing the existing places:
+Three upgrades over Section B:
 
-1. **Provider race.** `:think_tool` and `:think_answer` are both eligible
-   the moment `(:ready, :dialog)` align. Three independent driver tasks
-   call Anthropic / OpenAI / Google mocks in parallel; the first to finish
-   wins the workitem completion (CPN consumes the input tokens, the rest
-   no-op when their drive call finds an empty workitem list).
+1. **Provider race.** `:propose_call` and `:think_answer` are both
+   eligible the moment `(:ready, :dialog)` align. Three independent
+   driver tasks call Anthropic / OpenAI / Google mocks in parallel; the
+   first to finish wins the workitem completion (CPN consumes the input
+   tokens, the rest no-op when their drive call finds an empty workitem
+   list).
 2. **Steering queue.** A new `:steering_queue` place plus an
    `:append_steering` transition lets the user push a follow-up message
    while the agent is mid-flight. `:inject_steering` drains the queue
-   into `:dialog` *before* the next `think_*` round (it competes with
-   them for `(:ready, :dialog)` — driver picks it preferentially).
+   into `:dialog` *before* the next round.
+3. **Plan-then-act gate.** Section B let safe tools auto-fire and only
+   gated risky ones. Section C drops the safe/risky tag and routes
+   *every* tool call through a human-approval step:
+   `:propose_call → [:proposed_call] → :approve_proposal | :reject_proposal`.
+   Approval moves the call to `:pending_call` and `:run_tool` executes
+   it. Rejection appends a rejection note to `:dialog` and restores
+   `:ready`, kicking the loop back to `think`.
 
 `append_steering` consumes a `:steering_capacity` token (a counting
 semaphore — bounds how many follow-ups the user may push) and produces
 a `msg()` token in the queue. This is the canonical CPN pattern for
 **externally-fed input**: there is no "inject token" runner API; you
 declare a transition whose only job is to accept a value via a free
-binding.
+binding. The same pattern (`:approve_proposal` / `:reject_proposal`,
+each with a free binding) gates the plan-then-act review.
 
 ```elixir
 defmodule PiAgent.C do
@@ -692,28 +701,29 @@ defmodule PiAgent.C do
   alias ColouredFlow.Runner.Enactment.WorkitemTransition
   alias ColouredFlow.Runner.Storage
 
-  name "Pi Agent C — Race & Steering"
+  name "Pi Agent C — Race & Steering & Plan-then-act"
 
   colset role() :: :user | :assistant | :tool
   colset msg() :: {role(), binary()}
   colset dialog() :: list(msg())
   colset tool_name() :: :read | :grep | :ls | :write | :edit | :bash
-  colset tool_op() :: {tool_name(), binary()}
-  colset tool_call() :: {:safe, tool_op()} | {:risky, tool_op()}
+  colset tool_call() :: {tool_name(), binary()}
   colset tool_result() :: binary()
   colset answer() :: binary()
+  colset reason() :: binary()
   colset signal() :: {}
 
   var d :: dialog()
   var tc :: tool_call()
-  var op :: tool_op()
   var tr :: tool_result()
   var ans :: answer()
   var s :: signal()
   var m :: msg()
+  var reason :: reason()
 
   place :dialog, :dialog
   place :ready, :signal
+  place :proposed_call, :tool_call
   place :pending_call, :tool_call
   place :tool_result, :tool_result
   place :answer, :answer
@@ -732,17 +742,17 @@ defmodule PiAgent.C do
   initial_marking :steering_queue,
     ColouredFlow.MultiSet.new([{:user, "Also count the files."}])
 
-  transition :think_tool do
+  # Race producers fire :propose_call instead of running the tool. The
+  # call sits in :proposed_call until a human approves or rejects it.
+  transition :propose_call do
     input :ready, bind({1, s})
     input :dialog, bind({1, d})
 
-    output :dialog, {1, d ++ [{:assistant, "calling tool"}]}
-    output :pending_call, {1, tc}
+    output :dialog, {1, d ++ [{:assistant, "proposing tool call"}]}
+    output :proposed_call, {1, tc}
 
     action do
-      tc = Keyword.fetch!(event.occurrence.free_binding, :tc)
       PiAgent.UI.render(options, event)
-      PiAgent.C.dispatch_call(event.enactment_id, tc)
     end
   end
 
@@ -753,18 +763,36 @@ defmodule PiAgent.C do
     output :answer, {1, ans}
   end
 
-  transition :run_safe do
-    input :pending_call, bind({1, {:safe, op}})
+  # Human-driven: move a proposed call into :pending_call and run it.
+  transition :approve_proposal do
+    input :proposed_call, bind({1, tc})
 
-    output :tool_result, {1, tr}
+    output :pending_call, {1, tc}
 
     action do
-      PiAgent.C.merge(event.enactment_id)
+      PiAgent.UI.render(options, event)
+      PiAgent.C.run_tool(event.enactment_id, tc)
     end
   end
 
-  transition :run_risky do
-    input :pending_call, bind({1, {:risky, op}})
+  # Human-driven: drop the proposal, append a rejection note to dialog,
+  # and put :ready back so the agent thinks again. `reason` is supplied
+  # by the driver via the workitem's free-binding list.
+  transition :reject_proposal do
+    input :proposed_call, bind({1, tc})
+    input :dialog, bind({1, d})
+
+    output :dialog, {1, d ++ [{:user, reason}]}
+    output :ready, {1, {}}
+
+    action do
+      PiAgent.UI.render(options, event)
+      PiAgent.C.think(event.enactment_id, event.markings)
+    end
+  end
+
+  transition :run_tool do
+    input :pending_call, bind({1, tc})
 
     output :tool_result, {1, tr}
 
@@ -840,42 +868,27 @@ defmodule PiAgent.C do
         Process.sleep(PiAgent.MockLLM.latency_ms(vendor))
 
         case PiAgent.MockLLM.next_step(dialog, vendor) do
-          {:tool, op} ->
-            tagged = if PiAgent.MockTool.risky?(op), do: {:risky, op}, else: {:safe, op}
-            drive(enactment_id, "think_tool", tc: tagged)
-
-          {:answer, ans} ->
-            drive(enactment_id, "think_answer", ans: ans)
+          {:tool, op} -> drive(enactment_id, "propose_call", tc: op)
+          {:answer, ans} -> drive(enactment_id, "think_answer", ans: ans)
         end
       end)
     end)
   end
 
-  def dispatch_call(enactment_id, {:safe, op}) do
+  def run_tool(enactment_id, tc) do
     Process.sleep(900)
-    drive(enactment_id, "run_safe", tr: PiAgent.MockTool.run(op))
+    drive(enactment_id, "run_tool", tr: PiAgent.MockTool.run(tc))
   end
 
-  def dispatch_call(_enactment_id, {:risky, _op}), do: :ok
-
   def approve(enactment_id) do
-    case find_workitem(enactment_id, "run_risky") do
-      nil ->
-        :no_pending
+    drive(enactment_id, "approve_proposal", [])
+  end
 
-      %{id: wid, binding_element: %{binding: binding}} ->
-        op = Keyword.fetch!(binding, :op)
-        Process.sleep(900)
-        {:ok, _} = WorkitemTransition.start_workitem(enactment_id, wid)
-
-        {:ok, _} =
-          WorkitemTransition.complete_workitem(
-            enactment_id,
-            {wid, [tr: PiAgent.MockTool.run(op)]}
-          )
-
-        :ok
-    end
+  # Reject the pending plan with a reason. Default reason kept short so
+  # the dialog stays readable.
+  def reject(enactment_id, reason \\ "rejected the proposed plan; try a different tool")
+      when is_binary(reason) do
+    drive(enactment_id, "reject_proposal", reason: reason)
   end
 
   def steer(enactment_id, content) when is_binary(content) do
@@ -941,13 +954,15 @@ steer_input =
     reset_on_submit: [:msg]
   )
 
-approve_btn_c = Kino.Control.button("Approve risky tool")
+approve_plan_btn = Kino.Control.button("Approve plan")
+reject_plan_btn = Kino.Control.button("Reject plan")
 
 Kino.listen(steer_input, fn %{data: %{msg: text}} ->
   if text != "", do: PiAgent.C.steer(enactment_c, text)
 end)
 
-Kino.listen(approve_btn_c, fn _ -> PiAgent.C.approve(enactment_c) end)
+Kino.listen(approve_plan_btn, fn _ -> PiAgent.C.approve(enactment_c) end)
+Kino.listen(reject_plan_btn, fn _ -> PiAgent.C.reject(enactment_c) end)
 
 {:ok, _} =
   PiAgent.C.start_enactment(enactment_c,
@@ -958,38 +973,42 @@ Kino.Layout.grid(
   [
     Kino.Layout.grid([dialog_c, events_c], columns: 2),
     steer_input,
-    approve_btn_c
+    Kino.Layout.grid([approve_plan_btn, reject_plan_btn], columns: 2)
   ],
   boxed: true
 )
 ```
 
-### How to test steering
+### How to test the section
 
-Two steering paths run in this section:
+Three things to watch:
 
-1. **Pre-seeded steering** (automatic). `:steering_queue` starts with one
-   token (`{:user, "Also count the files."}`). The first `think` round
-   calls `drain_steering`, which fires `:inject_steering` and the message
-   appears in the dialog as a `**user**` line *before* the first tool
-   call. You'll see this on every run with no input from you.
-2. **Live steering** (interactive). The agent pauses at the `bash`
-   risky-tool gate (state shows `⏸ waiting for human approval`). While
-   it's paused:
-   * Type a follow-up into the **Steering** field, e.g.
-     `Make sure to mention the runner module.` and click **Send**.
-   * The input clears (`reset_on_submit: [:msg]`); the field stays empty
-     so you know the message was queued. There is no separate
-     "queued" indicator — the queue is invisible until drained.
-   * Click **Approve risky tool**. The bash result merges, the next
-     `think` calls `drain_steering`, your message lands in the dialog as
-     another `**user**` line, and the agent answers with the steering
-     msg in its context.
+1. **Plan-then-act gate** (every tool call). After each `think`, the
+   agent emits a `:proposed_call` token and pauses
+   (`🤔 awaiting plan approval`). Click **Approve plan** to fire
+   `:approve_proposal` (call moves to `:pending_call` and runs); click
+   **Reject plan** to fire `:reject_proposal` (a rejection note lands
+   in the dialog and the agent re-thinks). The events panel records
+   every `:propose_call` / `:approve_proposal` / `:reject_proposal`
+   firing.
+2. **Pre-seeded steering** (automatic). `:steering_queue` starts with
+   one token (`{:user, "Also count the files."}`). The first `think`
+   round calls `drain_steering`, fires `:inject_steering`, and the
+   message lands in the dialog as a `**user**` line *before* the first
+   plan proposal. Visible on every run with no input from you.
+3. **Live steering** (interactive). While the agent is paused at any
+   plan gate (or between rounds):
+   * Type a follow-up into the **Steering** field and click **Send**.
+   * Input clears (`reset_on_submit: [:msg]`); the queue is invisible
+     until drained.
+   * Click **Approve plan**. After the tool runs and merges, the next
+     `think` calls `drain_steering`, your message appears in the
+     dialog as another `**user**` line, and the agent re-plans with
+     the steering message in its context.
 
-If you click **Send** *after* the agent has terminated (`✅ done`),
-nothing happens — `drive/3` finds no enabled `:append_steering`
-workitem and returns silently. Re-evaluate the C run cell to start a
-fresh enactment.
+If you click any control *after* the agent terminates (`✅ done`),
+nothing happens — `drive/3` finds no enabled workitem and returns
+silently. Re-evaluate the C run cell to start a fresh enactment.
 
 ## What this buys you
 

--- a/examples/pi_agent.livemd
+++ b/examples/pi_agent.livemd
@@ -870,7 +870,13 @@ flow_c = InMemory.insert_flow!(PiAgent.C.cpnet())
 enactment_c = enactment(e_c, :id)
 
 frame_c = Kino.Frame.new()
-steer_input = Kino.Control.form([msg: Kino.Input.text("Steering")], submit: "Send")
+
+steer_input =
+  Kino.Control.form([msg: Kino.Input.text("Steering")],
+    submit: "Send",
+    reset_on_submit: [:msg]
+  )
+
 approve_btn_c = Kino.Control.button("Approve risky tool")
 
 Kino.listen(steer_input, fn %{data: %{msg: text}} ->
@@ -886,6 +892,33 @@ Kino.listen(approve_btn_c, fn _ -> PiAgent.C.approve(enactment_c) end)
 
 Kino.Layout.grid([frame_c, steer_input, approve_btn_c], boxed: true)
 ```
+
+### How to test steering
+
+Two steering paths run in this section:
+
+1. **Pre-seeded steering** (automatic). `:steering_queue` starts with one
+   token (`{:user, "Also count the files."}`). The first `think` round
+   calls `drain_steering`, which fires `:inject_steering` and the message
+   appears in the dialog as a `**user**` line *before* the first tool
+   call. You'll see this on every run with no input from you.
+2. **Live steering** (interactive). The agent pauses at the `bash`
+   risky-tool gate (state shows `⏸ waiting for human approval`). While
+   it's paused:
+   * Type a follow-up into the **Steering** field, e.g.
+     `Make sure to mention the runner module.` and click **Send**.
+   * The input clears (`reset_on_submit: [:msg]`); the field stays empty
+     so you know the message was queued. There is no separate
+     "queued" indicator — the queue is invisible until drained.
+   * Click **Approve risky tool**. The bash result merges, the next
+     `think` calls `drain_steering`, your message lands in the dialog as
+     another `**user**` line, and the agent answers with the steering
+     msg in its context.
+
+If you click **Send** *after* the agent has terminated (`✅ done`),
+nothing happens — `drive/3` finds no enabled `:append_steering`
+workitem and returns silently. Re-evaluate the C run cell to start a
+fresh enactment.
 
 ## What this buys you
 

--- a/examples/pi_agent.livemd
+++ b/examples/pi_agent.livemd
@@ -5,7 +5,7 @@
 ```elixir
 Mix.install(
   [
-    {:coloured_flow, github: "Byzanteam/coloured_flow"},
+    {:coloured_flow, path: "/Users/fahchen/Projects/coloured_flow"},
     {:kino, "~> 0.14.1"}
   ],
   config: [
@@ -330,7 +330,7 @@ defmodule PiAgent.A do
   end
 end
 
-PiAgent.A.cpnet().__struct__
+PiAgent.A.to_mermaid()
 ```
 
 ```elixir
@@ -570,7 +570,7 @@ defmodule PiAgent.B do
   end
 end
 
-PiAgent.B.cpnet().__struct__
+PiAgent.B.to_mermaid()
 ```
 
 ```elixir
@@ -663,6 +663,11 @@ defmodule PiAgent.C do
   initial_marking :ready, ~MS[{}]
   # 5 user-steering slots: each :append_steering consumes one.
   initial_marking :steering_capacity, ~MS[5**{}]
+
+  # Pre-seed a steering message so the demo always shows steering even
+  # without typing into the live form.
+  initial_marking :steering_queue,
+    ColouredFlow.MultiSet.new([{:user, "Also count the files."}])
 
   transition :think_tool do
     input :ready, bind({1, s})
@@ -856,7 +861,7 @@ defmodule PiAgent.C do
   end
 end
 
-PiAgent.C.cpnet().__struct__
+PiAgent.C.to_mermaid()
 ```
 
 ```elixir

--- a/examples/pi_agent.livemd
+++ b/examples/pi_agent.livemd
@@ -144,14 +144,11 @@ defmodule PiAgent.UI do
     end
 
     if frame = opts[:controls_frame] do
-      content =
-        if terminated? do
-          Kino.Markdown.new("*✓ workflow ended — controls disabled.*")
-        else
-          build_controls(opts, event.markings)
-        end
-
-      Kino.Frame.render(frame, content)
+      if terminated? do
+        Kino.Frame.clear(frame)
+      else
+        Kino.Frame.render(frame, build_controls(opts, event.markings))
+      end
     end
 
     :ok

--- a/examples/pi_agent.livemd
+++ b/examples/pi_agent.livemd
@@ -123,15 +123,27 @@ defmodule PiAgent.UI do
   alias ColouredFlow.MultiSet
   alias ColouredFlow.Runner.Storage
 
-  # Renders dialog (left) and event history (right) frames from the
-  # lifecycle hook options. Either frame may be absent.
+  # Renders dialog (left top), event history (right), and an optional
+  # controls frame (left bottom) from the lifecycle hook options. Once
+  # the enactment terminates (answer present), the controls frame is
+  # replaced with a "disabled" marker so the user cannot click stale
+  # buttons; the dialog gets a "workflow ended" footer.
   def render(opts, event) do
+    terminated? = Map.has_key?(event.markings, "answer")
+
     if frame = opts[:dialog_frame] do
-      Kino.Frame.render(frame, Kino.Markdown.new(format_dialog(event.markings)))
+      Kino.Frame.render(frame, Kino.Markdown.new(format_dialog(event.markings, terminated?)))
     end
 
     if frame = opts[:events_frame] do
       Kino.Frame.render(frame, Kino.Markdown.new(format_events(event.enactment_id)))
+    end
+
+    if terminated? and (frame = opts[:controls_frame]) do
+      Kino.Frame.render(
+        frame,
+        Kino.Markdown.new("*✓ workflow ended — controls disabled.*")
+      )
     end
 
     :ok
@@ -144,10 +156,11 @@ defmodule PiAgent.UI do
     end
   end
 
-  defp format_dialog(markings) do
+  defp format_dialog(markings, terminated? \\ false) do
     state = state_label(markings)
     body = markings |> read_dialog() |> Enum.map_join("\n\n", &format_msg/1)
-    "**state**: #{state}\n\n---\n\n#{body}"
+    footer = if terminated?, do: "\n\n---\n\n**✓ workflow ended.**", else: ""
+    "**state**: #{state}\n\n---\n\n#{body}#{footer}"
   end
 
   # Bindings that add noise to the events panel: :d is the full dialog
@@ -676,26 +689,23 @@ enactment_b = enactment(e_b, :id)
 
 dialog_b = Kino.Frame.new()
 events_b = Kino.Frame.new()
+controls_b = Kino.Frame.new()
 approve_btn = Kino.Control.button("Approve risky tool")
 deny_btn = Kino.Control.button("Deny")
 
 Kino.listen(approve_btn, fn _ -> PiAgent.B.approve(enactment_b) end)
 Kino.listen(deny_btn, fn _ -> PiAgent.B.deny(enactment_b) end)
 
+Kino.Frame.render(controls_b, Kino.Layout.grid([approve_btn, deny_btn], columns: 2))
+
 {:ok, _} =
   PiAgent.B.start_enactment(enactment_b,
-    lifecycle_hooks: {PiAgent.B, [dialog_frame: dialog_b, events_frame: events_b]}
+    lifecycle_hooks:
+      {PiAgent.B,
+       [dialog_frame: dialog_b, events_frame: events_b, controls_frame: controls_b]}
   )
 
-left_b =
-  Kino.Layout.grid(
-    [
-      dialog_b,
-      Kino.Layout.grid([approve_btn, deny_btn], columns: 2)
-    ],
-    columns: 1
-  )
-
+left_b = Kino.Layout.grid([dialog_b, controls_b], columns: 1)
 Kino.Layout.grid([left_b, events_b], columns: 2, boxed: true)
 ```
 
@@ -1030,6 +1040,7 @@ enactment_c = enactment(e_c, :id)
 
 dialog_c = Kino.Frame.new()
 events_c = Kino.Frame.new()
+controls_c = Kino.Frame.new()
 
 steer_input =
   Kino.Control.form([msg: Kino.Input.text("Steering")],
@@ -1057,22 +1068,26 @@ end)
 Kino.listen(approve_plan_btn, fn _ -> PiAgent.C.approve(enactment_c) end)
 Kino.listen(reject_plan_btn, fn _ -> PiAgent.C.reject(enactment_c) end)
 
-{:ok, _} =
-  PiAgent.C.start_enactment(enactment_c,
-    lifecycle_hooks: {PiAgent.C, [dialog_frame: dialog_c, events_frame: events_c]}
-  )
-
-left_c =
+Kino.Frame.render(
+  controls_c,
   Kino.Layout.grid(
     [
-      dialog_c,
       Kino.Layout.grid([approve_plan_btn, reject_plan_btn], columns: 2),
       manual_input,
       steer_input
     ],
     columns: 1
   )
+)
 
+{:ok, _} =
+  PiAgent.C.start_enactment(enactment_c,
+    lifecycle_hooks:
+      {PiAgent.C,
+       [dialog_frame: dialog_c, events_frame: events_c, controls_frame: controls_c]}
+  )
+
+left_c = Kino.Layout.grid([dialog_c, controls_c], columns: 1)
 Kino.Layout.grid([left_c, events_c], columns: 2, boxed: true)
 ```
 

--- a/examples/pi_agent.livemd
+++ b/examples/pi_agent.livemd
@@ -119,43 +119,52 @@ defmodule PiAgent.UI do
     "**state**: #{state}\n\n---\n\n#{body}"
   end
 
+  # Bindings that add noise to the events panel: :d is the full dialog
+  # (already shown in the left frame), :s is the signal unit token.
+  @event_noisy_keys [:d, :s]
+
   defp format_events(enactment_id) do
     occurrences =
       enactment_id
       |> Storage.occurrences_stream(0)
       |> Enum.to_list()
 
-    if occurrences == [] do
-      "**events** (0)\n\n_no firings yet_"
-    else
-      lines =
-        occurrences
-        |> Enum.with_index(1)
-        |> Enum.map_join("\n", fn {o, i} -> format_occurrence(o, i) end)
+    body =
+      case occurrences do
+        [] ->
+          "_no firings yet_"
 
-      "**events** (#{length(occurrences)})\n\n#{lines}"
-    end
+        list ->
+          list
+          |> Enum.with_index(1)
+          |> Enum.map_join("\n\n", fn {o, i} -> format_occurrence(o, i) end)
+      end
+
+    "**events** (#{length(occurrences)})\n\n#{body}"
   end
 
   defp format_occurrence(occurrence, idx) do
     name = occurrence.binding_element.transition
-    bindings = occurrence.binding_element.binding ++ occurrence.free_binding
 
-    "**#{idx}.** `:#{name}`" <> render_bindings(bindings)
+    bindings =
+      (occurrence.binding_element.binding ++ occurrence.free_binding)
+      |> Enum.reject(fn {k, _} -> k in @event_noisy_keys end)
+
+    case bindings do
+      [] -> "**#{idx}.** `:#{name}`"
+      kvs -> "**#{idx}.** `:#{name}`  \n#{render_bindings(kvs)}"
+    end
   end
 
-  defp render_bindings([]), do: ""
-
   defp render_bindings(kvs) do
-    " · " <>
-      Enum.map_join(kvs, ", ", fn {k, v} ->
-        "`#{k}` = `#{inspect_short(v)}`"
-      end)
+    Enum.map_join(kvs, "  \n", fn {k, v} ->
+      "&nbsp;&nbsp;`#{k}` = `#{inspect_short(v)}`"
+    end)
   end
 
   defp inspect_short(v) do
-    s = inspect(v, limit: 5, printable_limit: 50)
-    if String.length(s) > 70, do: String.slice(s, 0, 67) <> "…", else: s
+    s = inspect(v, limit: 3, printable_limit: 30, structs: false)
+    if String.length(s) > 50, do: String.slice(s, 0, 47) <> "…", else: s
   end
 
   defp state_label(markings) do

--- a/examples/pi_agent.livemd
+++ b/examples/pi_agent.livemd
@@ -1,0 +1,876 @@
+<!-- livebook:{"app_settings":{"access_type":"public","output_type":"rich","show_source":true,"slug":"pi-agent"}} -->
+
+# Pi Agent — Coding Agent as a Coloured Petri Net
+
+```elixir
+Mix.install(
+  [
+    {:coloured_flow, github: "Byzanteam/coloured_flow"},
+    {:kino, "~> 0.14.1"}
+  ],
+  config: [
+    coloured_flow: [
+      {ColouredFlow.Runner.Storage, [storage: ColouredFlow.Runner.Storage.InMemory]}
+    ]
+  ]
+)
+```
+
+## What we're building
+
+[pi.dev](https://pi.dev) ships a terminal coding agent — a model that reasons,
+calls tools (`read`, `grep`, `bash`, …), and keeps a session tree you can
+branch from. The execution loop has well-known shapes:
+
+- **think → tool → observe → repeat** — the ReAct cycle.
+- **safe vs. risky tool calls** — `read` runs unattended; `bash` waits on a
+  human approval.
+- **multi-provider race** — the same prompt fans out to several vendors;
+  fastest answer wins.
+- **steering** — the user injects a follow-up while the agent is mid-flight.
+
+Coloured Petri Nets express *exactly* these shapes natively: places hold
+state, transitions consume/produce tokens with guards, workitems sit in
+`:enabled` until a driver (a model, a human, a scheduler) starts them. The
+runner snapshots after every firing, so a crashed agent resumes from the
+last token state instead of re-running tool calls.
+
+We'll model Pi's loop in three passes:
+
+| | Adds | CPN feature |
+|---|---|---|
+| **A** | minimal ReAct cycle | deferred choice, free output bindings, self-driving via `action` |
+| **B** | risky-tool human gate | union colour set, workitem held in `:enabled` until human fires |
+| **C** | provider race + steering injection | concurrent enabled workitems, external-fed input place |
+
+## Mock LLM, mock tools, dialog renderer
+
+These are the only impure pieces — everything CPN-shaped lives in the
+workflow modules below. The mock LLM is a deterministic function of dialog
+length so the demo is reproducible. The dialog renderer is a pure markdown
+function passed into each enactment via `lifecycle_hooks` options.
+
+```elixir
+defmodule PiAgent.MockLLM do
+  @moduledoc false
+
+  # next_step/2: deterministic policy keyed off how many tool turns have run.
+  # Returns {:tool, {tool_name, args}} | {:answer, binary}.
+  def next_step(dialog, vendor \\ :anthropic) do
+    tools = Enum.count(dialog, fn {role, _} -> role == :tool end)
+
+    case {vendor, tools} do
+      {_, 0} -> {:tool, {:ls, "lib/"}}
+      {_, 1} -> {:tool, {:read, "lib/coloured_flow.ex"}}
+      {_, 2} -> {:tool, {:bash, "mix compile"}}
+      {v, _} -> {:answer, "[#{v}] lib/ has the ColouredFlow umbrella; compiles clean."}
+    end
+  end
+
+  # Provider-specific latency. Used by Section C to demo races.
+  def latency_ms(:anthropic), do: 80
+  def latency_ms(:openai), do: 130
+  def latency_ms(:google), do: 200
+end
+
+defmodule PiAgent.MockTool do
+  @moduledoc false
+
+  def run({:ls, args}), do: "ls(#{args}): coloured_flow.ex, dsl.ex, runner/, definition/, …"
+  def run({:read, args}), do: "<contents of #{args}>"
+  def run({:grep, args}), do: "<grep results for #{args}>"
+  def run({:write, args}), do: "wrote: #{args}"
+  def run({:edit, args}), do: "edited: #{args}"
+  def run({:bash, args}), do: "$ #{args}\n<simulated output>"
+
+  def risky?({tool, _}) when tool in [:write, :edit, :bash], do: true
+  def risky?(_), do: false
+end
+
+defmodule PiAgent.UI do
+  @moduledoc false
+  alias ColouredFlow.MultiSet
+
+  def render(nil, _markings), do: :ok
+
+  def render(frame, markings) do
+    Kino.Frame.render(frame, Kino.Markdown.new(format(markings)))
+  end
+
+  def read_dialog(markings) do
+    case Map.get(markings, "dialog") do
+      nil -> []
+      ms -> ms |> MultiSet.to_list() |> List.first() || []
+    end
+  end
+
+  defp format(markings) do
+    state = state_label(markings)
+    body = markings |> read_dialog() |> Enum.map_join("\n\n", &format_msg/1)
+    "**state**: #{state}\n\n---\n\n#{body}"
+  end
+
+  defp state_label(markings) do
+    cond do
+      Map.has_key?(markings, "answer") -> "✅ done"
+      has_token?(markings, "pending_call_risky") -> "⏸ waiting for human approval"
+      has_token?(markings, "pending_call") -> "⚙ tool running"
+      has_token?(markings, "steering_queue") -> "📣 steering pending"
+      true -> "💭 thinking"
+    end
+  end
+
+  defp has_token?(markings, place) do
+    case Map.get(markings, place) do
+      nil -> false
+      ms -> MultiSet.size(ms) > 0
+    end
+  end
+
+  defp format_msg({:user, c}), do: "**user** › #{c}"
+  defp format_msg({:assistant, c}), do: "**assistant** › #{c}"
+  defp format_msg({:tool, c}), do: "```\n#{c}\n```"
+end
+```
+
+## Shared runtime: storage + supervisor
+
+Started once for the whole notebook. All three enactments share this.
+
+```elixir
+storage_pid = Kino.start_child!(ColouredFlow.Runner.Storage.InMemory)
+runner_pid = Kino.start_child!(ColouredFlow.Runner.Supervisor)
+
+defmodule PiAgent.Sup do
+  use Supervisor
+
+  def start_link(_ \\ []) do
+    Process.whereis(__MODULE__) && Supervisor.stop(__MODULE__)
+    Supervisor.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  @impl Supervisor
+  def init(_) do
+    Supervisor.init(
+      [{Task.Supervisor, name: PiAgent.TaskSup}],
+      strategy: :one_for_one
+    )
+  end
+end
+
+Kino.start_child!(PiAgent.Sup)
+"runtime ready (#{inspect(runner_pid)})"
+```
+
+## A. Simple ReAct cycle
+
+Five places, four transitions, one `on_markings` termination on `:answer`.
+
+```
+[ready]──┬──> :think_tool ─{tc}──> [pending_call] ──> :run_tool ─{tr}──> [tool_result]
+[dialog]─┤                                                                     │
+         │                                                                     v
+         └──> :think_answer ─{ans}──> [answer]      [dialog] ──> :merge_result ──> [ready],[dialog]
+```
+
+Three transitions emit free output bindings (`tc`, `tr`, `ans`) — the
+runner leaves them open and the driver fills them when calling
+`complete_workitem/2`. That is how the LLM's decision (which tool? which
+answer text?) crosses from impure Elixir into the pure CPN state.
+
+`:think_tool` and `:think_answer` share an input pattern — classic
+**deferred choice**: both are enabled simultaneously, whichever the driver
+fires first wins. The driver here calls `MockLLM.next_step/1` and routes
+to one or the other.
+
+```elixir
+defmodule PiAgent.A do
+  use ColouredFlow.DSL, task_supervisor: PiAgent.TaskSup
+
+  alias ColouredFlow.MultiSet
+  alias ColouredFlow.Runner.Enactment.WorkitemTransition
+  alias ColouredFlow.Runner.Storage
+
+  name "Pi Agent A — Simple ReAct"
+
+  colset role() :: :user | :assistant | :tool
+  colset msg() :: {role(), binary()}
+  colset dialog() :: list(msg())
+  colset tool_name() :: :read | :grep | :ls | :write | :edit | :bash
+  colset tool_call() :: {tool_name(), binary()}
+  colset tool_result() :: binary()
+  colset answer() :: binary()
+  colset signal() :: {}
+
+  var d :: dialog()
+  var tc :: tool_call()
+  var tr :: tool_result()
+  var ans :: answer()
+  var s :: signal()
+
+  place :dialog, :dialog
+  place :ready, :signal
+  place :pending_call, :tool_call
+  place :tool_result, :tool_result
+  place :answer, :answer
+
+  initial_marking :dialog,
+    ColouredFlow.MultiSet.new([[{:user, "What's in lib/?"}]])
+
+  initial_marking :ready, ~MS[{}]
+
+  transition :think_tool do
+    input :ready, bind({1, s})
+    input :dialog, bind({1, d})
+
+    output :dialog, {1, d ++ [{:assistant, "calling tool"}]}
+    output :pending_call, {1, tc}
+
+    action do
+      tc = Keyword.fetch!(event.occurrence.free_binding, :tc)
+      PiAgent.A.run_tool(event.enactment_id, tc)
+    end
+  end
+
+  transition :think_answer do
+    input :ready, bind({1, s})
+    input :dialog, bind({1, d})
+
+    output :answer, {1, ans}
+  end
+
+  transition :run_tool do
+    input :pending_call, bind({1, tc})
+
+    output :tool_result, {1, tr}
+
+    action do
+      PiAgent.A.merge(event.enactment_id)
+    end
+  end
+
+  transition :merge_result do
+    input :dialog, bind({1, d})
+    input :tool_result, bind({1, tr})
+
+    output :dialog, {1, d ++ [{:tool, tr}]}
+    output :ready, {1, {}}
+
+    action do
+      PiAgent.UI.render(options[:frame], event.markings)
+      PiAgent.A.think(event.enactment_id, event.markings)
+    end
+  end
+
+  termination do
+    on_markings do
+      match?(%{"answer" => _}, markings)
+    end
+  end
+
+  on_enactment_start do
+    PiAgent.UI.render(options[:frame], event.markings)
+    PiAgent.A.think(event.enactment_id, event.markings)
+  end
+
+  on_enactment_terminate do
+    PiAgent.UI.render(options[:frame], event.markings)
+  end
+
+  ## Driver — turns mock-LLM/mock-tool decisions into workitem firings.
+
+  def think(enactment_id, markings) do
+    dialog = PiAgent.UI.read_dialog(markings)
+
+    case PiAgent.MockLLM.next_step(dialog) do
+      {:tool, tc} -> drive(enactment_id, "think_tool", tc: tc)
+      {:answer, ans} -> drive(enactment_id, "think_answer", ans: ans)
+    end
+  end
+
+  def run_tool(enactment_id, tc) do
+    Process.sleep(100)
+    drive(enactment_id, "run_tool", tr: PiAgent.MockTool.run(tc))
+  end
+
+  def merge(enactment_id), do: drive(enactment_id, "merge_result", [])
+
+  def to_mermaid do
+    cpnet()
+    |> ColouredFlow.Definition.Presentation.to_mermaid()
+    |> Kino.Mermaid.new()
+  end
+
+  defp drive(enactment_id, name, free_binding) do
+    enactment_id
+    |> Storage.list_live_workitems()
+    |> Enum.find(&(&1.state == :enabled and &1.binding_element.transition == name))
+    |> case do
+      nil ->
+        :ok
+
+      %{id: wid} ->
+        {:ok, _} = WorkitemTransition.start_workitem(enactment_id, wid)
+        {:ok, _} = WorkitemTransition.complete_workitem(enactment_id, {wid, free_binding})
+        :ok
+    end
+  end
+end
+
+PiAgent.A.to_mermaid()
+```
+
+```elixir
+import ColouredFlow.Runner.Storage.InMemory, only: :macros
+alias ColouredFlow.Runner.Storage.InMemory
+
+flow_a = InMemory.insert_flow!(PiAgent.A.cpnet())
+{:ok, e_a} = PiAgent.A.insert_enactment(flow(flow_a, :id))
+enactment_a = enactment(e_a, :id)
+
+frame_a = Kino.Frame.new()
+
+{:ok, _} =
+  PiAgent.A.start_enactment(enactment_a,
+    lifecycle_hooks: {PiAgent.A, [frame: frame_a]}
+  )
+
+frame_a
+```
+
+## B. Risky-tool human gate
+
+Same loop — but the model now sometimes asks for a `:bash` call. We do
+*not* trust a model with a shell unattended. The fix is one extra hop: the
+`:think_tool` output flows into a **union-typed** `:pending_call` place,
+tagged `{:safe, op}` or `{:risky, op}`. Two consumers compete for it:
+
+- `:run_safe` matches `{:safe, op}` — driver auto-fires it.
+- `:run_risky` matches `{:risky, op}` — workitem stays in `:enabled` until
+  a human clicks an approve button. The runner is happy to wait days.
+
+The crucial CPN trick is that **pattern-matching on a token's shape is
+how guards work** — no extra `guard` clause needed; `bind({1, {:safe, op}})`
+itself is the discriminator.
+
+```elixir
+defmodule PiAgent.B do
+  use ColouredFlow.DSL, task_supervisor: PiAgent.TaskSup
+
+  alias ColouredFlow.MultiSet
+  alias ColouredFlow.Runner.Enactment.WorkitemTransition
+  alias ColouredFlow.Runner.Storage
+
+  name "Pi Agent B — Permission Gate"
+
+  colset role() :: :user | :assistant | :tool
+  colset msg() :: {role(), binary()}
+  colset dialog() :: list(msg())
+  colset tool_name() :: :read | :grep | :ls | :write | :edit | :bash
+  colset tool_op() :: {tool_name(), binary()}
+  colset tool_call() :: {:safe, tool_op()} | {:risky, tool_op()}
+  colset tool_result() :: binary()
+  colset answer() :: binary()
+  colset signal() :: {}
+
+  var d :: dialog()
+  var tc :: tool_call()
+  var op :: tool_op()
+  var tr :: tool_result()
+  var ans :: answer()
+  var s :: signal()
+
+  place :dialog, :dialog
+  place :ready, :signal
+  place :pending_call, :tool_call
+  place :tool_result, :tool_result
+  place :answer, :answer
+
+  initial_marking :dialog,
+    ColouredFlow.MultiSet.new([[{:user, "Update lib/foo.ex via bash."}]])
+
+  initial_marking :ready, ~MS[{}]
+
+  transition :think_tool do
+    input :ready, bind({1, s})
+    input :dialog, bind({1, d})
+
+    output :dialog, {1, d ++ [{:assistant, "calling tool"}]}
+    output :pending_call, {1, tc}
+
+    action do
+      tc = Keyword.fetch!(event.occurrence.free_binding, :tc)
+      PiAgent.B.dispatch_call(event.enactment_id, tc)
+    end
+  end
+
+  transition :think_answer do
+    input :ready, bind({1, s})
+    input :dialog, bind({1, d})
+
+    output :answer, {1, ans}
+  end
+
+  transition :run_safe do
+    input :pending_call, bind({1, {:safe, op}})
+
+    output :tool_result, {1, tr}
+
+    action do
+      PiAgent.B.merge(event.enactment_id)
+    end
+  end
+
+  transition :run_risky do
+    input :pending_call, bind({1, {:risky, op}})
+
+    output :tool_result, {1, tr}
+
+    action do
+      PiAgent.B.merge(event.enactment_id)
+    end
+  end
+
+  transition :merge_result do
+    input :dialog, bind({1, d})
+    input :tool_result, bind({1, tr})
+
+    output :dialog, {1, d ++ [{:tool, tr}]}
+    output :ready, {1, {}}
+
+    action do
+      PiAgent.UI.render(options[:frame], event.markings)
+      PiAgent.B.think(event.enactment_id, event.markings)
+    end
+  end
+
+  termination do
+    on_markings do
+      match?(%{"answer" => _}, markings)
+    end
+  end
+
+  on_enactment_start do
+    PiAgent.UI.render(options[:frame], event.markings)
+    PiAgent.B.think(event.enactment_id, event.markings)
+  end
+
+  on_enactment_terminate do
+    PiAgent.UI.render(options[:frame], event.markings)
+  end
+
+  ## Driver
+
+  def think(enactment_id, markings) do
+    dialog = PiAgent.UI.read_dialog(markings)
+
+    case PiAgent.MockLLM.next_step(dialog) do
+      {:tool, op} ->
+        tagged = if PiAgent.MockTool.risky?(op), do: {:risky, op}, else: {:safe, op}
+        drive(enactment_id, "think_tool", tc: tagged)
+
+      {:answer, ans} ->
+        drive(enactment_id, "think_answer", ans: ans)
+    end
+  end
+
+  # After :think_tool fires, route based on the tag — auto-run safe,
+  # leave risky workitem dangling for human approval.
+  def dispatch_call(enactment_id, {:safe, op}) do
+    Process.sleep(100)
+    drive(enactment_id, "run_safe", tr: PiAgent.MockTool.run(op))
+  end
+
+  def dispatch_call(_enactment_id, {:risky, _op}), do: :ok
+
+  def approve(enactment_id) do
+    case find_risky(enactment_id) do
+      nil ->
+        :no_pending
+
+      %{id: wid, binding_element: %{binding: binding}} ->
+        {:risky, op} = Keyword.fetch!(binding, :tc)
+        Process.sleep(100)
+        {:ok, _} = WorkitemTransition.start_workitem(enactment_id, wid)
+
+        {:ok, _} =
+          WorkitemTransition.complete_workitem(
+            enactment_id,
+            {wid, [tr: PiAgent.MockTool.run(op)]}
+          )
+
+        :ok
+    end
+  end
+
+  def deny(enactment_id) do
+    case find_risky(enactment_id) do
+      nil ->
+        :no_pending
+
+      %{id: wid} ->
+        {:ok, _} = WorkitemTransition.withdraw_workitem(enactment_id, wid)
+        :denied
+    end
+  end
+
+  def merge(enactment_id), do: drive(enactment_id, "merge_result", [])
+
+  def to_mermaid do
+    cpnet()
+    |> ColouredFlow.Definition.Presentation.to_mermaid()
+    |> Kino.Mermaid.new()
+  end
+
+  defp find_risky(enactment_id) do
+    enactment_id
+    |> Storage.list_live_workitems()
+    |> Enum.find(&(&1.state == :enabled and &1.binding_element.transition == "run_risky"))
+  end
+
+  defp drive(enactment_id, name, free_binding) do
+    enactment_id
+    |> Storage.list_live_workitems()
+    |> Enum.find(&(&1.state == :enabled and &1.binding_element.transition == name))
+    |> case do
+      nil ->
+        :ok
+
+      %{id: wid} ->
+        {:ok, _} = WorkitemTransition.start_workitem(enactment_id, wid)
+        {:ok, _} = WorkitemTransition.complete_workitem(enactment_id, {wid, free_binding})
+        :ok
+    end
+  end
+end
+
+PiAgent.B.to_mermaid()
+```
+
+```elixir
+flow_b = InMemory.insert_flow!(PiAgent.B.cpnet())
+{:ok, e_b} = PiAgent.B.insert_enactment(flow(flow_b, :id))
+enactment_b = enactment(e_b, :id)
+
+frame_b = Kino.Frame.new()
+approve_btn = Kino.Control.button("Approve risky tool")
+deny_btn = Kino.Control.button("Deny")
+
+Kino.listen(approve_btn, fn _ -> PiAgent.B.approve(enactment_b) end)
+Kino.listen(deny_btn, fn _ -> PiAgent.B.deny(enactment_b) end)
+
+{:ok, _} =
+  PiAgent.B.start_enactment(enactment_b,
+    lifecycle_hooks: {PiAgent.B, [frame: frame_b]}
+  )
+
+Kino.Layout.grid([frame_b, Kino.Layout.grid([approve_btn, deny_btn], columns: 2)],
+  boxed: true
+)
+```
+
+The agent will run `:ls` and `:read` automatically (both safe), then stop
+on a `bash` call. The dialog renders `⏸ waiting for human approval` until
+you click **Approve** — the workitem fires, the result merges, the loop
+resumes.
+
+## C. Multi-provider race + steering
+
+Two upgrades, neither requires changing the existing places:
+
+1. **Provider race.** `:think_tool` and `:think_answer` are both eligible
+   the moment `(:ready, :dialog)` align. Three independent driver tasks
+   call Anthropic / OpenAI / Google mocks in parallel; the first to finish
+   wins the workitem completion (CPN consumes the input tokens, the rest
+   no-op when their drive call finds an empty workitem list).
+2. **Steering queue.** A new `:steering_queue` place plus an
+   `:append_steering` transition lets the user push a follow-up message
+   while the agent is mid-flight. `:inject_steering` drains the queue
+   into `:dialog` *before* the next `think_*` round (it competes with
+   them for `(:ready, :dialog)` — driver picks it preferentially).
+
+`append_steering` consumes a `:steering_capacity` token (a counting
+semaphore — bounds how many follow-ups the user may push) and produces
+a `msg()` token in the queue. This is the canonical CPN pattern for
+**externally-fed input**: there is no "inject token" runner API; you
+declare a transition whose only job is to accept a value via a free
+binding.
+
+```elixir
+defmodule PiAgent.C do
+  use ColouredFlow.DSL, task_supervisor: PiAgent.TaskSup
+
+  alias ColouredFlow.MultiSet
+  alias ColouredFlow.Runner.Enactment.WorkitemTransition
+  alias ColouredFlow.Runner.Storage
+
+  name "Pi Agent C — Race & Steering"
+
+  colset role() :: :user | :assistant | :tool
+  colset msg() :: {role(), binary()}
+  colset dialog() :: list(msg())
+  colset tool_name() :: :read | :grep | :ls | :write | :edit | :bash
+  colset tool_op() :: {tool_name(), binary()}
+  colset tool_call() :: {:safe, tool_op()} | {:risky, tool_op()}
+  colset tool_result() :: binary()
+  colset answer() :: binary()
+  colset signal() :: {}
+
+  var d :: dialog()
+  var tc :: tool_call()
+  var op :: tool_op()
+  var tr :: tool_result()
+  var ans :: answer()
+  var s :: signal()
+  var m :: msg()
+
+  place :dialog, :dialog
+  place :ready, :signal
+  place :pending_call, :tool_call
+  place :tool_result, :tool_result
+  place :answer, :answer
+  place :steering_queue, :msg
+  place :steering_capacity, :signal
+
+  initial_marking :dialog,
+    ColouredFlow.MultiSet.new([[{:user, "What's in lib/?"}]])
+
+  initial_marking :ready, ~MS[{}]
+  # 5 user-steering slots: each :append_steering consumes one.
+  initial_marking :steering_capacity, ~MS[5**{}]
+
+  transition :think_tool do
+    input :ready, bind({1, s})
+    input :dialog, bind({1, d})
+
+    output :dialog, {1, d ++ [{:assistant, "calling tool"}]}
+    output :pending_call, {1, tc}
+
+    action do
+      tc = Keyword.fetch!(event.occurrence.free_binding, :tc)
+      PiAgent.C.dispatch_call(event.enactment_id, tc)
+    end
+  end
+
+  transition :think_answer do
+    input :ready, bind({1, s})
+    input :dialog, bind({1, d})
+
+    output :answer, {1, ans}
+  end
+
+  transition :run_safe do
+    input :pending_call, bind({1, {:safe, op}})
+
+    output :tool_result, {1, tr}
+
+    action do
+      PiAgent.C.merge(event.enactment_id)
+    end
+  end
+
+  transition :run_risky do
+    input :pending_call, bind({1, {:risky, op}})
+
+    output :tool_result, {1, tr}
+
+    action do
+      PiAgent.C.merge(event.enactment_id)
+    end
+  end
+
+  transition :merge_result do
+    input :dialog, bind({1, d})
+    input :tool_result, bind({1, tr})
+
+    output :dialog, {1, d ++ [{:tool, tr}]}
+    output :ready, {1, {}}
+
+    action do
+      PiAgent.UI.render(options[:frame], event.markings)
+      PiAgent.C.think(event.enactment_id, event.markings)
+    end
+  end
+
+  transition :append_steering do
+    input :steering_capacity, bind({1, s})
+
+    output :steering_queue, {1, m}
+  end
+
+  transition :inject_steering do
+    input :ready, bind({1, s})
+    input :dialog, bind({1, d})
+    input :steering_queue, bind({1, m})
+
+    output :dialog, {1, d ++ [m]}
+    output :ready, {1, s}
+
+    action do
+      PiAgent.UI.render(options[:frame], event.markings)
+      PiAgent.C.think(event.enactment_id, event.markings)
+    end
+  end
+
+  termination do
+    on_markings do
+      match?(%{"answer" => _}, markings)
+    end
+  end
+
+  on_enactment_start do
+    PiAgent.UI.render(options[:frame], event.markings)
+    PiAgent.C.think(event.enactment_id, event.markings)
+  end
+
+  on_enactment_terminate do
+    PiAgent.UI.render(options[:frame], event.markings)
+  end
+
+  ## Driver
+
+  def think(enactment_id, markings) do
+    # Steering takes precedence — drain the queue first.
+    if drain_steering(enactment_id) == :drained do
+      :ok
+    else
+      race_providers(enactment_id, markings)
+    end
+  end
+
+  def race_providers(enactment_id, markings) do
+    dialog = PiAgent.UI.read_dialog(markings)
+
+    Enum.each([:anthropic, :openai, :google], fn vendor ->
+      Task.Supervisor.start_child(PiAgent.TaskSup, fn ->
+        Process.sleep(PiAgent.MockLLM.latency_ms(vendor))
+
+        case PiAgent.MockLLM.next_step(dialog, vendor) do
+          {:tool, op} ->
+            tagged = if PiAgent.MockTool.risky?(op), do: {:risky, op}, else: {:safe, op}
+            drive(enactment_id, "think_tool", tc: tagged)
+
+          {:answer, ans} ->
+            drive(enactment_id, "think_answer", ans: ans)
+        end
+      end)
+    end)
+  end
+
+  def dispatch_call(enactment_id, {:safe, op}) do
+    Process.sleep(100)
+    drive(enactment_id, "run_safe", tr: PiAgent.MockTool.run(op))
+  end
+
+  def dispatch_call(_enactment_id, {:risky, _op}), do: :ok
+
+  def approve(enactment_id) do
+    case find_workitem(enactment_id, "run_risky") do
+      nil ->
+        :no_pending
+
+      %{id: wid, binding_element: %{binding: binding}} ->
+        {:risky, op} = Keyword.fetch!(binding, :tc)
+        Process.sleep(100)
+        {:ok, _} = WorkitemTransition.start_workitem(enactment_id, wid)
+
+        {:ok, _} =
+          WorkitemTransition.complete_workitem(
+            enactment_id,
+            {wid, [tr: PiAgent.MockTool.run(op)]}
+          )
+
+        :ok
+    end
+  end
+
+  def steer(enactment_id, content) when is_binary(content) do
+    drive(enactment_id, "append_steering", m: {:user, content})
+  end
+
+  def merge(enactment_id), do: drive(enactment_id, "merge_result", [])
+
+  def to_mermaid do
+    cpnet()
+    |> ColouredFlow.Definition.Presentation.to_mermaid()
+    |> Kino.Mermaid.new()
+  end
+
+  defp drain_steering(enactment_id) do
+    case find_workitem(enactment_id, "inject_steering") do
+      nil ->
+        :empty
+
+      %{id: wid} ->
+        {:ok, _} = WorkitemTransition.start_workitem(enactment_id, wid)
+        {:ok, _} = WorkitemTransition.complete_workitem(enactment_id, {wid, []})
+        :drained
+    end
+  end
+
+  defp find_workitem(enactment_id, transition_name) do
+    enactment_id
+    |> Storage.list_live_workitems()
+    |> Enum.find(&(&1.state == :enabled and &1.binding_element.transition == transition_name))
+  end
+
+  defp drive(enactment_id, name, free_binding) do
+    case find_workitem(enactment_id, name) do
+      nil ->
+        :ok
+
+      %{id: wid} ->
+        {:ok, _} = WorkitemTransition.start_workitem(enactment_id, wid)
+        {:ok, _} = WorkitemTransition.complete_workitem(enactment_id, {wid, free_binding})
+        :ok
+    end
+  end
+end
+
+PiAgent.C.to_mermaid()
+```
+
+```elixir
+flow_c = InMemory.insert_flow!(PiAgent.C.cpnet())
+{:ok, e_c} = PiAgent.C.insert_enactment(flow(flow_c, :id))
+enactment_c = enactment(e_c, :id)
+
+frame_c = Kino.Frame.new()
+steer_input = Kino.Control.form([msg: Kino.Input.text("Steering")], submit: "Send")
+approve_btn_c = Kino.Control.button("Approve risky tool")
+
+Kino.listen(steer_input, fn %{data: %{msg: text}} ->
+  if text != "", do: PiAgent.C.steer(enactment_c, text)
+end)
+
+Kino.listen(approve_btn_c, fn _ -> PiAgent.C.approve(enactment_c) end)
+
+{:ok, _} =
+  PiAgent.C.start_enactment(enactment_c,
+    lifecycle_hooks: {PiAgent.C, [frame: frame_c]}
+  )
+
+Kino.Layout.grid([frame_c, steer_input, approve_btn_c], boxed: true)
+```
+
+## What this buys you
+
+The same module is also:
+
+- **Crash-safe.** Kill the runner mid-`bash` and restart — the runner
+  replays `Occurrence`s from the latest snapshot, the workitem state
+  comes back exactly where it was, no duplicate tool calls.
+- **Time-travelable.** Every firing is a stored event; an audit UI gets
+  the agent's full reasoning trace for free.
+- **Branchable.** Insert a fresh enactment from a snapshot of an existing
+  one and you have a session fork — the same primitive Pi exposes via
+  `/fork` and `/clone`, but earned automatically by the event-source
+  runner.
+- **Provider-agnostic.** The CPN cares about token shapes, not vendors.
+  Add a new provider in Section C by adding one line to
+  `race_providers/2`; the structure of the net does not change.
+
+The 200 lines of `PiAgent.C` give you a saga-style coding agent with
+human-in-loop, race semantics, mid-flight steering, and durable replay —
+properties that take thousands of lines to retrofit onto a hand-written
+ReAct loop.

--- a/examples/pi_agent.livemd
+++ b/examples/pi_agent.livemd
@@ -681,13 +681,16 @@ Kino.listen(deny_btn, fn _ -> PiAgent.B.deny(enactment_b) end)
     lifecycle_hooks: {PiAgent.B, [dialog_frame: dialog_b, events_frame: events_b]}
   )
 
-Kino.Layout.grid(
-  [
-    Kino.Layout.grid([dialog_b, events_b], columns: 2),
-    Kino.Layout.grid([approve_btn, deny_btn], columns: 2)
-  ],
-  boxed: true
-)
+left_b =
+  Kino.Layout.grid(
+    [
+      dialog_b,
+      Kino.Layout.grid([approve_btn, deny_btn], columns: 2)
+    ],
+    columns: 1
+  )
+
+Kino.Layout.grid([left_b, events_b], columns: 2, boxed: true)
 ```
 
 The agent will run `:ls` and `:read` automatically (both safe), then stop
@@ -1050,15 +1053,18 @@ Kino.listen(reject_plan_btn, fn _ -> PiAgent.C.reject(enactment_c) end)
     lifecycle_hooks: {PiAgent.C, [dialog_frame: dialog_c, events_frame: events_c]}
   )
 
-Kino.Layout.grid(
-  [
-    Kino.Layout.grid([dialog_c, events_c], columns: 2),
-    Kino.Layout.grid([approve_plan_btn, reject_plan_btn], columns: 2),
-    manual_input,
-    steer_input
-  ],
-  boxed: true
-)
+left_c =
+  Kino.Layout.grid(
+    [
+      dialog_c,
+      Kino.Layout.grid([approve_plan_btn, reject_plan_btn], columns: 2),
+      manual_input,
+      steer_input
+    ],
+    columns: 1
+  )
+
+Kino.Layout.grid([left_c, events_c], columns: 2, boxed: true)
 ```
 
 ### How to test the section

--- a/lib/coloured_flow/definition/presentation/presentation.ex
+++ b/lib/coloured_flow/definition/presentation/presentation.ex
@@ -77,7 +77,7 @@ defmodule ColouredFlow.Definition.Presentation do
          orientation: :p_to_t,
          expression: expression
        }) do
-    "#{place} --#{label || expression.code}--> #{transition}"
+    "#{place} -->|#{escape_arc_label(label || expression.code)}| #{transition}"
   end
 
   defp to_mermaid_arc(%Arc{
@@ -87,7 +87,15 @@ defmodule ColouredFlow.Definition.Presentation do
          orientation: :t_to_p,
          expression: expression
        }) do
-    "#{transition} --#{label || expression.code}--> #{place}"
+    "#{transition} -->|#{escape_arc_label(label || expression.code)}| #{place}"
+  end
+
+  # Mermaid's `-->|label|` edge form rejects unbalanced/special chars.
+  # The dash form (`--label-->`) is even pickier — `[`, `]`, `{`, `"` all
+  # break the parser. Quote the whole label so mermaid treats it as a
+  # string literal, and escape embedded quotes.
+  defp escape_arc_label(label) do
+    "\"" <> String.replace(label, "\"", "#quot;") <> "\""
   end
 
   @spec compose_call(atom()) :: String.t()

--- a/test/coloured_flow/definition/presentation_test.exs
+++ b/test/coloured_flow/definition/presentation_test.exs
@@ -27,8 +27,8 @@ defmodule ColouredFlow.Definition.PresentationTest do
           pass_through[pass_through]
 
           %% arcs
-          input --in--> pass_through
-          pass_through --out--> output
+          input -->|"in"| pass_through
+          pass_through -->|"out"| output
         """
       )
     end
@@ -63,24 +63,24 @@ defmodule ColouredFlow.Definition.PresentationTest do
           transmit_packet[transmit_packet]
 
           %% arcs
-          a --bind {1, {n, d}}--> transmit_packet
-          send_packet --{1, {n, d}}--> a
-          b --bind {1, {n, d}}--> receive_packet
-          transmit_packet --if success, do: {1, {n, d}}, else: {0, {n, d}}--> b
-          c --bind {1, n}--> transmit_ack
-          receive_packet --if n == k, do: {1, k + 1}, else: {1, k}--> c
-          d --bind {1, n}--> receive_ack
-          transmit_ack --if success, do: {1, n}, else: {0, n}--> d
-          data_recevied --bind {1, data}--> receive_packet
-          receive_packet --if n == k, do: {1, data <> d}, else: {1, data}--> data_recevied
-          next_rec --bind {1, k}--> receive_packet
-          receive_packet --if n == k, do: {1, k + 1}, else: {1, k}--> next_rec
-          next_send --bind {1, k}--> receive_ack
-          next_send --bind {1, {1, n}}--> send_packet
-          receive_ack --{1, n}--> next_send
-          send_packet --{1, {1, n}}--> next_send
-          packets_to_send --bind {1, {n, d}}--> send_packet
-          send_packet --{1, {n, d}}--> packets_to_send
+          a -->|"bind {1, {n, d}}"| transmit_packet
+          send_packet -->|"{1, {n, d}}"| a
+          b -->|"bind {1, {n, d}}"| receive_packet
+          transmit_packet -->|"if success, do: {1, {n, d}}, else: {0, {n, d}}"| b
+          c -->|"bind {1, n}"| transmit_ack
+          receive_packet -->|"if n == k, do: {1, k + 1}, else: {1, k}"| c
+          d -->|"bind {1, n}"| receive_ack
+          transmit_ack -->|"if success, do: {1, n}, else: {0, n}"| d
+          data_recevied -->|"bind {1, data}"| receive_packet
+          receive_packet -->|"if n == k, do: {1, data <> d}, else: {1, data}"| data_recevied
+          next_rec -->|"bind {1, k}"| receive_packet
+          receive_packet -->|"if n == k, do: {1, k + 1}, else: {1, k}"| next_rec
+          next_send -->|"bind {1, k}"| receive_ack
+          next_send -->|"bind {1, {1, n}}"| send_packet
+          receive_ack -->|"{1, n}"| next_send
+          send_packet -->|"{1, {1, n}}"| next_send
+          packets_to_send -->|"bind {1, {n, d}}"| send_packet
+          send_packet -->|"{1, {n, d}}"| packets_to_send
         """
       )
     end
@@ -151,7 +151,7 @@ defmodule ColouredFlow.Definition.PresentationTest do
         pass_through[pass_through]
 
         %% arcs
-        input --in--> pass_through
+        input -->|"in"| pass_through
       """)
     end
   end


### PR DESCRIPTION
## Summary

Adds `examples/pi_agent.livemd` modeling a [pi.dev](https://pi.dev)-style coding agent as a Coloured Petri Net, in three progressive sections that share state, runtime, and a left/right Kino UI.

| | Adds | CPN feature |
|---|---|---|
| **A** | minimal ReAct cycle | deferred choice, free output bindings, self-driving via `action` |
| **B** | risky-tool human gate | union colour set, workitem held in `:enabled` until human fires |
| **C** | provider race + steering + plan-then-act gate | concurrent enabled workitems, externally-fed input place, three-way human review |

Section C plan gate exposes three exits — Approve / Reject / Manual override — each landing a `{:user, _}` line in the dialog so the next planning round (`MockLLM.proposal_text/2`) quotes the human's note back into the proposal.

The right column shows the runner's `Occurrence` history live (via `Storage.occurrences_stream/2`); controls only appear when their target gate is open and clear when the enactment terminates.

Drive-by lib fix: `ColouredFlow.Definition.Presentation.to_mermaid/1` switched from the dash arc form (`A --label--> B`) to the pipe form with quoted labels (`A -->|"label"| B`) so labels containing `[`, `{`, `"`, etc. — common in CPN inscriptions like `{1, d ++ [tool: tr]}` — render in mermaid without parser errors. Existing presentation tests updated to match.

## Test plan

- [x] `mix test test/coloured_flow/definition/presentation_test.exs` (3 tests, 0 failures)
- [x] `mix compile --warnings-as-errors` clean
- [x] Smoke run via `mix run`: A terminates with answer; C runs 13-event sequence covering propose → manual_input → reject → approve → run → merge → answer
- [x] End-to-end via Livebook: open `examples/pi_agent.livemd`, all 3 sections render dialog (left top), controls (left bottom, only when actionable), event history (right); ✅ done footer + cleared controls on termination
- [x] Mermaid arc labels with brackets / quotes / `<>` render without "Syntax error in text" iframe